### PR TITLE
fix: clear input fields when closing create task dialog

### DIFF
--- a/apps/web/src/components/task/create-task-modal.tsx
+++ b/apps/web/src/components/task/create-task-modal.tsx
@@ -59,6 +59,11 @@ export function CreateTaskModal({
   });
   const { mutateAsync } = useCreateTask();
 
+  const handleClose = () => {
+    form.reset();
+    onClose();
+  };
+
   const onSubmit = async (data: TaskFormValues) => {
     if (!project?.id || !workspace?.id) return;
 
@@ -92,7 +97,7 @@ export function CreateTaskModal({
       toast.success("Task created successfully");
 
       form.reset();
-      onClose();
+      handleClose();
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to create task",
@@ -101,7 +106,7 @@ export function CreateTaskModal({
   };
 
   return (
-    <Dialog.Root open={open} onOpenChange={onClose}>
+    <Dialog.Root open={open} onOpenChange={handleClose}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40" />
         <Dialog.Content className="fixed z-50 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-lg">


### PR DESCRIPTION
**Description:**
When creating a new task, if a user filled in the fields but closed the dialog without submitting, the form data would remain populated the next time the dialog was opened.

This PR fixes the issue by clearing the input fields when the create task dialog is closed.

Now, when you reopen the dialog, all fields are reset to their default empty state.

**Before:** Form retains old values when reopening the dialog.
![image](https://github.com/user-attachments/assets/c5df4637-4427-4650-bf9d-d665d1dc846c)

**After:** Form is cleared when reopening the dialog.
![image](https://github.com/user-attachments/assets/1a3d05ca-4991-474e-b4e6-031053f81bc1)