### PR TITLE
feat: delete a task option #122

### DIFF
--- a/apps/api/src/task/controllers/delete-task.ts
+++ b/apps/api/src/task/controllers/delete-task.ts
@@ -1,0 +1,22 @@
+import { eq } from "drizzle-orm";
+import { HTTPException } from "hono/http-exception";
+import db from "../../database";
+import { taskTable } from "../../database/schema";
+
+async function deleteTask(taskId: string) {
+  const task = await db
+    .delete(taskTable)
+    .where(eq(taskTable.id, taskId))
+    .returning()
+    .execute();
+
+  if (!task) {
+    throw new HTTPException(404, {
+      message: "Task not found",
+    });
+  }
+
+  return task;
+}
+
+export default deleteTask;

--- a/apps/api/src/task/index.ts
+++ b/apps/api/src/task/index.ts
@@ -2,6 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
 import createTask from "./controllers/create-task";
+import deleteTask from "./controllers/delete-task";
 import exportTasks from "./controllers/export-tasks";
 import getTask from "./controllers/get-task";
 import getTasks from "./controllers/get-tasks";
@@ -143,6 +144,16 @@ const task = new Hono<{
 
       return c.json(result);
     },
-  );
+  )
+  .delete(
+    "/:id",
+    zValidator("param", z.object({ id: z.string() })),
+    async (c) => {
+      const { id } = c.req.valid("param");
 
+      const task = await deleteTask(id);
+
+      return c.json(task);
+    },
+  );
 export default task;

--- a/apps/web/src/components/task/task-info.tsx
+++ b/apps/web/src/components/task/task-info.tsx
@@ -66,6 +66,19 @@ function TaskInfo({
     }
   };
 
+  const handleDeleteTask = async () => {
+    if (!task) return;
+
+    try {
+      await deleteTask(task.id);
+      toast.success("Task deleted successfully");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to delete task",
+      );
+    }
+  };
+
   useEffect(() => {
     return () => {
       form.reset();
@@ -184,6 +197,7 @@ function TaskInfo({
         <TaskLabels taskId={task.id} setIsSaving={setIsSaving} />
       </Form>
       <Button
+        onClick={handleDeleteTask}
         className="bg-red-600 text-white hover:bg-red-500 dark:bg-red-500 dark:hover:bg-red-400"
       >
         {isDeleting ? "Deleting..." : "Delete Task"}

--- a/apps/web/src/components/task/task-info.tsx
+++ b/apps/web/src/components/task/task-info.tsx
@@ -5,6 +5,7 @@ import useUpdateTask from "@/hooks/mutations/task/use-update-task";
 import useGetActiveWorkspaceUsers from "@/hooks/queries/workspace-users/use-active-workspace-users";
 import useProjectStore from "@/store/project";
 import type Task from "@/types/task";
+import { useQueryClient } from "@tanstack/react-query";
 import { Flag } from "lucide-react";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -27,6 +28,7 @@ function TaskInfo({
   task: Task;
   setIsSaving: (isSaving: boolean) => void;
 }) {
+  const queryClient = useQueryClient();
   const { project } = useProjectStore();
   const { data: workspaceUsers } = useGetActiveWorkspaceUsers({
     workspaceId: project?.workspaceId ?? "",
@@ -71,6 +73,9 @@ function TaskInfo({
 
     try {
       await deleteTask(task.id);
+      queryClient.invalidateQueries({
+        queryKey: ["tasks", project?.id ?? ""],
+      });
       toast.success("Task deleted successfully");
     } catch (error) {
       toast.error(

--- a/apps/web/src/components/task/task-info.tsx
+++ b/apps/web/src/components/task/task-info.tsx
@@ -1,5 +1,6 @@
 import { Form, FormField, FormItem, FormLabel } from "@/components/ui/form";
 import { Select } from "@/components/ui/select";
+import useDeleteTask from "@/hooks/mutations/task/use-delete-task";
 import useUpdateTask from "@/hooks/mutations/task/use-update-task";
 import useGetActiveWorkspaceUsers from "@/hooks/queries/workspace-users/use-active-workspace-users";
 import useProjectStore from "@/store/project";
@@ -31,6 +32,7 @@ function TaskInfo({
     workspaceId: project?.workspaceId ?? "",
   });
   const { mutateAsync: updateTask } = useUpdateTask();
+  const { mutateAsync: deleteTask, isPending: isDeleting } = useDeleteTask();
 
   const form = useForm<z.infer<typeof taskInfoSchema>>({
     defaultValues: {
@@ -181,6 +183,11 @@ function TaskInfo({
         />
         <TaskLabels taskId={task.id} setIsSaving={setIsSaving} />
       </Form>
+      <Button
+        className="bg-red-600 text-white hover:bg-red-500 dark:bg-red-500 dark:hover:bg-red-400"
+      >
+        {isDeleting ? "Deleting..." : "Delete Task"}
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/components/task/task-info.tsx
+++ b/apps/web/src/components/task/task-info.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import { Form, FormField, FormItem, FormLabel } from "@/components/ui/form";
 import { Select } from "@/components/ui/select";
 import useDeleteTask from "@/hooks/mutations/task/use-delete-task";
@@ -6,6 +7,7 @@ import useGetActiveWorkspaceUsers from "@/hooks/queries/workspace-users/use-acti
 import useProjectStore from "@/store/project";
 import type Task from "@/types/task";
 import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import { Flag } from "lucide-react";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -28,6 +30,7 @@ function TaskInfo({
   task: Task;
   setIsSaving: (isSaving: boolean) => void;
 }) {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { project } = useProjectStore();
   const { data: workspaceUsers } = useGetActiveWorkspaceUsers({
@@ -77,6 +80,13 @@ function TaskInfo({
         queryKey: ["tasks", project?.id ?? ""],
       });
       toast.success("Task deleted successfully");
+      navigate({
+        to: "/dashboard/workspace/$workspaceId/project/$projectId/board",
+        params: {
+          workspaceId: project?.workspaceId ?? "",
+          projectId: project?.id ?? "",
+        },
+      });
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to delete task",

--- a/apps/web/src/fetchers/task/delete-task.ts
+++ b/apps/web/src/fetchers/task/delete-task.ts
@@ -1,0 +1,16 @@
+import { client } from "@kaneo/libs";
+import type { InferRequestType } from "hono/client";
+
+export type DeleteTaskRequest = InferRequestType<
+  (typeof client)["task"][":id"]["$delete"]
+>["param"];
+
+async function deleteTask(taskId: string) {
+  const response = await client.task[":id"].$delete({ param: { id: taskId } });
+
+  const data = await response.json();
+
+  return data;
+}
+
+export default deleteTask;

--- a/apps/web/src/hooks/mutations/task/use-delete-task.ts
+++ b/apps/web/src/hooks/mutations/task/use-delete-task.ts
@@ -1,0 +1,10 @@
+import deleteTask from "@/fetchers/task/delete-task";
+import { useMutation } from "@tanstack/react-query";
+
+function useDeleteTask() {
+  return useMutation({
+    mutationFn: deleteTask,
+  });
+}
+
+export default useDeleteTask;


### PR DESCRIPTION
# Delete task buttton
This PR adds a button that allows users to delete a task, addressing issue #122 . 

## Summary

- Implemented a backend API endpoint to handle task deletion.
- Integrated the deletion logic with the frontend.
- Added a "Delete Task" button in the UI.
- After deletion, users are redirected to the board page.

## Image
![image](https://github.com/user-attachments/assets/e37ee123-1741-4034-9f8c-0ddbd15ff019)

## Caution
This feature enables task deletion. Since the project currently lacks a role or permission system, any user who can view a task is also able to delete it. This may need to be addressed in future iterations.