### PR TITLE
fix: fixed the saving of the indent of the description of the task

### DIFF
--- a/apps/web/src/components/common/editor.tsx
+++ b/apps/web/src/components/common/editor.tsx
@@ -62,6 +62,9 @@ export function Editor({
         class: "h-full flex-1",
       },
     },
+    parseOptions: {
+      preserveWhitespace: "full",
+    },
     extensions: [
       StarterKit.configure({
         heading: {


### PR DESCRIPTION
I added a parseOptions to the useEditor hook parseOptions properties and added the preserveWithSpace options to be full so it can parse the new lines and the white spaces

This was this [bug](https://github.com/usekaneo/kaneo/issues/179) that was reported