### PR TITLE
feat: right click card/row context menu

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
 		"@hookform/resolvers": "^5.0.1",
 		"@radix-ui/react-accordion": "^1.2.2",
 		"@radix-ui/react-avatar": "^1.1.6",
+		"@radix-ui/react-context-menu": "^2.2.12",
 		"@radix-ui/react-dialog": "^1.1.11",
 		"@radix-ui/react-dropdown-menu": "^2.1.12",
 		"@radix-ui/react-label": "^2.1.4",

--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
@@ -123,10 +123,10 @@ export default function TaskCardContextMenuContent({
     }
   }
 
-  const handleChange = async (
+  async function handleChange(
     field: keyof z.infer<typeof taskInfoSchema>,
     value: string | Date,
-  ) => {
+  ) {
     try {
       await updateTask({
         ...task,
@@ -139,7 +139,7 @@ export default function TaskCardContextMenuContent({
     } finally {
       toast.success("Task updated successfully");
     }
-  };
+  }
 
   async function handleDeleteTask() {
     try {

--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
@@ -169,7 +169,7 @@ export default function TaskCardContextMenuContent({
 
       <ContextMenuSub>
         <ContextMenuSubTrigger className="flex items-center gap-2">
-          <Tags className="h-4 w-4 text-indigo-500 dark:text-indigo-400" />{" "}
+          <Tags className="h-3.5 w-3.5 text-indigo-500 dark:text-indigo-400" />{" "}
           Priority
         </ContextMenuSubTrigger>
         <ContextMenuSubContent>
@@ -210,7 +210,7 @@ export default function TaskCardContextMenuContent({
 
       <ContextMenuSub>
         <ContextMenuSubTrigger className="flex items-center gap-2">
-          <ListTodo className="h-4 w-4 text-indigo-500 dark:text-indigo-400" />{" "}
+          <ListTodo className="h-3.5 w-3.5 text-indigo-500 dark:text-indigo-400" />{" "}
           Status
         </ContextMenuSubTrigger>
         <ContextMenuSubContent>
@@ -229,7 +229,7 @@ export default function TaskCardContextMenuContent({
 
       <ContextMenuSub>
         <ContextMenuSubTrigger className="flex items-center gap-2">
-          <User className="h-4 w-4 text-indigo-500 dark:text-indigo-400" />{" "}
+          <User className="h-3.5 w-3.5 text-indigo-500 dark:text-indigo-400" />{" "}
           Assignee
         </ContextMenuSubTrigger>
 
@@ -260,7 +260,7 @@ export default function TaskCardContextMenuContent({
 
       <ContextMenuSub>
         <ContextMenuSubTrigger className="flex items-center gap-2">
-          <FlipHorizontal2 className="h-4 w-4 text-indigo-500 dark:text-indigo-400" />{" "}
+          <FlipHorizontal2 className="h-3.5 w-3.5 text-indigo-500 dark:text-indigo-400" />{" "}
           Mirror
         </ContextMenuSubTrigger>
 
@@ -280,8 +280,8 @@ export default function TaskCardContextMenuContent({
       </ContextMenuSub>
 
       <ContextMenuSub>
-        <ContextMenuSubTrigger className="flex items-center gap-2 mb-1">
-          <CalendarIcon className="h-4 w-4 text-indigo-500 dark:text-indigo-400" />{" "}
+        <ContextMenuSubTrigger className="flex items-center gap-2">
+          <CalendarIcon className="h-3.5 w-3.5 text-indigo-500 dark:text-indigo-400" />{" "}
           Due date
         </ContextMenuSubTrigger>
         {projectsOptions && (

--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
@@ -25,13 +25,12 @@ import {
   ContextMenuSubTrigger,
 } from "@/components/ui/context-menu";
 
-
-import Task from "@/types/task";
+import useDeleteTask from "@/hooks/mutations/task/use-delete-task";
+import { generateLink } from "@/lib/generate-link";
+import type Task from "@/types/task";
+import { useMemo } from "react";
 import { toast } from "sonner";
 import type { z } from "zod";
-import { generateLink } from "@/lib/generate-link";
-import { useMemo } from "react";
-import useDeleteTask from "@/hooks/mutations/task/use-delete-task";
 
 interface TaskCardContext {
   worskpaceId: string;
@@ -128,7 +127,6 @@ export default function TaskCardContextMenuContent({
     field: keyof z.infer<typeof taskInfoSchema>,
     value: string | Date,
   ) => {
-
     try {
       await updateTask({
         ...task,
@@ -143,7 +141,7 @@ export default function TaskCardContextMenuContent({
     }
   };
 
-  async function handleDeleteTask(){
+  async function handleDeleteTask() {
     try {
       await deleteTask(task.id);
     } catch (error) {
@@ -234,7 +232,9 @@ export default function TaskCardContextMenuContent({
               <ContextMenuCheckboxItem
                 key={user.value}
                 checked={task.userEmail === user.value}
-                onCheckedChange={() => handleChange("userEmail", user.value ?? "")}
+                onCheckedChange={() =>
+                  handleChange("userEmail", user.value ?? "")
+                }
                 className="flex items-center justify-between cursor-pointer"
               >
                 {user.label}
@@ -261,9 +261,7 @@ export default function TaskCardContextMenuContent({
             {projectsOptions.map((project) => (
               <ContextMenuItem
                 key={project.value}
-                onClick={() =>
-                  handleDuplicateTask(project.value)
-                }
+                onClick={() => handleDuplicateTask(project.value)}
                 className="flex items-center justify-between cursor-pointer hover:bg-accent"
               >
                 {project.label}

--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
@@ -88,15 +88,15 @@ export default function TaskCardContextMenuContent({
     },
   ];
 
-  function handleCopyTaskLink() {
+  const handleCopyTaskLink = () => {
     const path = `/dashboard/workspace/${taskCardContext.worskpaceId}/project/${taskCardContext.projectId}/task/${task.id}`;
     const taskLink = generateLink(path);
 
     navigator.clipboard.writeText(taskLink);
     toast.success("Task link copied!");
-  }
+  };
 
-  async function handleDuplicateTask(projectId: string) {
+  const handleDuplicateTask = async (projectId: string) => {
     const selectedProject = projectsOptions?.find(
       (project) => project.value === projectId,
     );
@@ -121,12 +121,12 @@ export default function TaskCardContextMenuContent({
     } finally {
       toast.success(`Mirrored task successfully to: ${selectedProject?.label}`);
     }
-  }
+  };
 
-  async function handleChange(
+  const handleChange = async (
     field: keyof z.infer<typeof taskInfoSchema>,
     value: string | Date,
-  ) {
+  ) => {
     try {
       await updateTask({
         ...task,
@@ -139,9 +139,9 @@ export default function TaskCardContextMenuContent({
     } finally {
       toast.success("Task updated successfully");
     }
-  }
+  };
 
-  async function handleDeleteTask() {
+  const handleDeleteTask = async () => {
     try {
       await deleteTask(task.id);
     } catch (error) {
@@ -151,7 +151,7 @@ export default function TaskCardContextMenuContent({
     } finally {
       toast.success("Task deleted successfully");
     }
-  }
+  };
 
   return (
     <ContextMenuContent>

--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
@@ -27,6 +27,7 @@ import {
 
 import useDeleteTask from "@/hooks/mutations/task/use-delete-task";
 import { generateLink } from "@/lib/generate-link";
+import queryClient from "@/query-client";
 import type Task from "@/types/task";
 import { useMemo } from "react";
 import { toast } from "sonner";
@@ -144,6 +145,9 @@ export default function TaskCardContextMenuContent({
   const handleDeleteTask = async () => {
     try {
       await deleteTask(task.id);
+      queryClient.invalidateQueries({
+        queryKey: ["tasks", taskCardContext.projectId],
+      });
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to delete task",

--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
@@ -163,13 +163,14 @@ export default function TaskCardContextMenuContent({
         onClick={handleCopyTaskLink}
         className="flex items-center gap-2 cursor-pointer"
       >
-        <Copy className="w-4 h-4 text-indigo-400 " />
+        <Copy className="w-3.5 h-3.5 text-indigo-500 dark:text-indigo-400 " />
         Copy Link
       </ContextMenuItem>
 
       <ContextMenuSub>
         <ContextMenuSubTrigger className="flex items-center gap-2">
-          <Tags className="h-4 w-4 text-indigo-400" /> Priority
+          <Tags className="h-4 w-4 text-indigo-500 dark:text-indigo-400" />{" "}
+          Priority
         </ContextMenuSubTrigger>
         <ContextMenuSubContent>
           <ContextMenuCheckboxItem
@@ -177,7 +178,7 @@ export default function TaskCardContextMenuContent({
             className="flex items-center gap-2 cursor-pointer"
             checked={task.priority === "low"}
           >
-            <Flag className="w-4 h-4 text-blue-400" />
+            <Flag className="w-3.5 h-3.5 text-blue-400" />
             Low
           </ContextMenuCheckboxItem>
           <ContextMenuCheckboxItem
@@ -185,7 +186,7 @@ export default function TaskCardContextMenuContent({
             className="flex items-center gap-2 cursor-pointer"
             checked={task.priority === "medium"}
           >
-            <Flag className="w-4 h-4 text-yellow-400" />
+            <Flag className="w-3.5 h-3.5 text-yellow-400" />
             Medium
           </ContextMenuCheckboxItem>
           <ContextMenuCheckboxItem
@@ -193,7 +194,7 @@ export default function TaskCardContextMenuContent({
             className="flex items-center gap-2 cursor-pointer"
             checked={task.priority === "high"}
           >
-            <Flag className="w-4 h-4 text-red-400" />
+            <Flag className="w-3.5 h-3.5 text-red-400" />
             High
           </ContextMenuCheckboxItem>
           <ContextMenuCheckboxItem
@@ -201,7 +202,7 @@ export default function TaskCardContextMenuContent({
             className="flex items-center gap-2 cursor-pointer"
             checked={task.priority === "urgent"}
           >
-            <Flag className="w-4 h-4 text-red-400" />
+            <Flag className="w-3.5 h-3.5 text-red-400" />
             Urgent
           </ContextMenuCheckboxItem>
         </ContextMenuSubContent>
@@ -209,7 +210,8 @@ export default function TaskCardContextMenuContent({
 
       <ContextMenuSub>
         <ContextMenuSubTrigger className="flex items-center gap-2">
-          <ListTodo className="h-4 w-4 text-indigo-400" /> Status
+          <ListTodo className="h-4 w-4 text-indigo-500 dark:text-indigo-400" />{" "}
+          Status
         </ContextMenuSubTrigger>
         <ContextMenuSubContent>
           {statusOptions.map((status) => (
@@ -227,7 +229,8 @@ export default function TaskCardContextMenuContent({
 
       <ContextMenuSub>
         <ContextMenuSubTrigger className="flex items-center gap-2">
-          <User className="h-4 w-4 text-indigo-400" /> Assignee
+          <User className="h-4 w-4 text-indigo-500 dark:text-indigo-400" />{" "}
+          Assignee
         </ContextMenuSubTrigger>
 
         {usersOptions && (
@@ -257,7 +260,8 @@ export default function TaskCardContextMenuContent({
 
       <ContextMenuSub>
         <ContextMenuSubTrigger className="flex items-center gap-2">
-          <FlipHorizontal2 className="h-4 w-4 text-indigo-400" /> Mirror
+          <FlipHorizontal2 className="h-4 w-4 text-indigo-500 dark:text-indigo-400" />{" "}
+          Mirror
         </ContextMenuSubTrigger>
 
         {projectsOptions && (
@@ -277,7 +281,8 @@ export default function TaskCardContextMenuContent({
 
       <ContextMenuSub>
         <ContextMenuSubTrigger className="flex items-center gap-2 mb-1">
-          <CalendarIcon className="h-4 w-4 text-indigo-400" /> Due date
+          <CalendarIcon className="h-4 w-4 text-indigo-500 dark:text-indigo-400" />{" "}
+          Due date
         </ContextMenuSubTrigger>
         {projectsOptions && (
           <ContextMenuSubContent>
@@ -296,7 +301,7 @@ export default function TaskCardContextMenuContent({
         onClick={handleDeleteTask}
         className="flex items-center transition-all duration-200 gap-2  cursor-pointer"
       >
-        <Trash className="w-4 h-4 text-red-400" />
+        <Trash className="w-3.5 h-3.5 text-red-400" />
         Delete Task
       </ContextMenuItem>
     </ContextMenuContent>

--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
@@ -161,7 +161,7 @@ export default function TaskCardContextMenuContent({
     <ContextMenuContent>
       <ContextMenuItem
         onClick={handleCopyTaskLink}
-        className="flex items-center gap-2 cursor-pointer hover:bg-accent "
+        className="flex items-center gap-2 cursor-pointer"
       >
         <Copy className="w-4 h-4 text-indigo-400 " />
         Copy Link
@@ -174,7 +174,7 @@ export default function TaskCardContextMenuContent({
         <ContextMenuSubContent>
           <ContextMenuCheckboxItem
             onClick={() => handleChange("priority", "low")}
-            className="flex items-center gap-2 cursor-pointer hover:bg-accent"
+            className="flex items-center gap-2 cursor-pointer"
             checked={task.priority === "low"}
           >
             <Flag className="w-4 h-4 text-blue-400" />
@@ -182,7 +182,7 @@ export default function TaskCardContextMenuContent({
           </ContextMenuCheckboxItem>
           <ContextMenuCheckboxItem
             onClick={() => handleChange("priority", "medium")}
-            className="flex items-center gap-2 cursor-pointer hover:bg-accent"
+            className="flex items-center gap-2 cursor-pointer"
             checked={task.priority === "medium"}
           >
             <Flag className="w-4 h-4 text-yellow-400" />
@@ -190,7 +190,7 @@ export default function TaskCardContextMenuContent({
           </ContextMenuCheckboxItem>
           <ContextMenuCheckboxItem
             onClick={() => handleChange("priority", "high")}
-            className="flex items-center gap-2 cursor-pointer hover:bg-accent"
+            className="flex items-center gap-2 cursor-pointer"
             checked={task.priority === "high"}
           >
             <Flag className="w-4 h-4 text-red-400" />
@@ -198,7 +198,7 @@ export default function TaskCardContextMenuContent({
           </ContextMenuCheckboxItem>
           <ContextMenuCheckboxItem
             onClick={() => handleChange("priority", "urgent")}
-            className="flex items-center gap-2 cursor-pointer hover:bg-accent"
+            className="flex items-center gap-2 cursor-pointer"
             checked={task.priority === "urgent"}
           >
             <Flag className="w-4 h-4 text-red-400" />
@@ -227,7 +227,7 @@ export default function TaskCardContextMenuContent({
 
       <ContextMenuSub>
         <ContextMenuSubTrigger className="flex items-center gap-2">
-          <User className="h-4 w-4 text-indigo-400" /> Assign to
+          <User className="h-4 w-4 text-indigo-400" /> Assignee
         </ContextMenuSubTrigger>
 
         {usersOptions && (
@@ -257,7 +257,7 @@ export default function TaskCardContextMenuContent({
 
       <ContextMenuSub>
         <ContextMenuSubTrigger className="flex items-center gap-2">
-          <FlipHorizontal2 className="h-4 w-4 text-indigo-400" /> Mirror to
+          <FlipHorizontal2 className="h-4 w-4 text-indigo-400" /> Mirror
         </ContextMenuSubTrigger>
 
         {projectsOptions && (
@@ -266,7 +266,7 @@ export default function TaskCardContextMenuContent({
               <ContextMenuItem
                 key={project.value}
                 onClick={() => handleDuplicateTask(project.value)}
-                className="flex items-center justify-between cursor-pointer hover:bg-accent"
+                className="flex items-center justify-between cursor-pointer"
               >
                 {project.label}
               </ContextMenuItem>
@@ -291,12 +291,12 @@ export default function TaskCardContextMenuContent({
           </ContextMenuSubContent>
         )}
       </ContextMenuSub>
-      <hr className="border-t border-gray-200 dark:border-gray-700" />
+
       <ContextMenuItem
         onClick={handleDeleteTask}
-        className="flex items-center transition-all duration-200 gap-2 mt-1 cursor-pointer text-red-600 dark:text-red-400 dark:hover:text-white hover:bg-red-500 hover:text-white"
+        className="flex items-center transition-all duration-200 gap-2  cursor-pointer"
       >
-        <Trash className="w-4 h-4 " />
+        <Trash className="w-4 h-4 text-red-400" />
         Delete Task
       </ContextMenuItem>
     </ContextMenuContent>

--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
@@ -1,0 +1,302 @@
+import {
+  Calendar as CalendarIcon,
+  Copy,
+  Flag,
+  FlipHorizontal2,
+  ListTodo,
+  Tags,
+  Trash,
+  User,
+} from "lucide-react";
+
+import useCreateTask from "@/hooks/mutations/task/use-create-task";
+import useUpdateTask from "@/hooks/mutations/task/use-update-task";
+import useGetProjects from "@/hooks/queries/project/use-get-projects";
+import useGetActiveWorkspaceUsers from "@/hooks/queries/workspace-users/use-active-workspace-users";
+
+import type { taskInfoSchema } from "@/components/task/task-info";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  ContextMenuCheckboxItem,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+} from "@/components/ui/context-menu";
+
+
+import Task from "@/types/task";
+import { toast } from "sonner";
+import type { z } from "zod";
+import { generateLink } from "@/lib/generate-link";
+import { useMemo } from "react";
+import useDeleteTask from "@/hooks/mutations/task/use-delete-task";
+
+interface TaskCardContext {
+  worskpaceId: string;
+  projectId: string;
+}
+
+interface TaskCardContextMenuContentProps {
+  task: Task;
+  taskCardContext: TaskCardContext;
+}
+
+export default function TaskCardContextMenuContent({
+  task,
+  taskCardContext,
+}: TaskCardContextMenuContentProps) {
+  const { data: projects } = useGetProjects({
+    workspaceId: taskCardContext.worskpaceId,
+  });
+  const { data: workspaceUsers } = useGetActiveWorkspaceUsers({
+    workspaceId: taskCardContext.worskpaceId,
+  });
+  const { mutateAsync: updateTask } = useUpdateTask();
+  const { mutateAsync: createTask } = useCreateTask();
+  const { mutateAsync: deleteTask } = useDeleteTask();
+
+  const projectsOptions = useMemo(() => {
+    return projects?.map((project) => {
+      return { label: project.name, value: project.id };
+    });
+  }, [projects]);
+
+  const usersOptions = useMemo(() => {
+    return workspaceUsers?.map((user) => ({
+      label: user.userName ?? user.userEmail,
+      value: user.userEmail,
+    }));
+  }, [workspaceUsers]);
+
+  const statusOptions = [
+    {
+      label: "To Do",
+      value: "to-do",
+    },
+    {
+      label: "In Progress",
+      value: "in-progress",
+    },
+    {
+      label: "In Review",
+      value: "in-review",
+    },
+    {
+      label: "Done",
+      value: "done",
+    },
+  ];
+
+  function handleCopyTaskLink() {
+    const path = `/dashboard/workspace/${taskCardContext.worskpaceId}/project/${taskCardContext.projectId}/task/${task.id}`;
+    const taskLink = generateLink(path);
+
+    navigator.clipboard.writeText(taskLink);
+    toast.success("Task link copied!");
+  }
+
+  async function handleDuplicateTask(projectId: string) {
+    const selectedProject = projectsOptions?.find(
+      (project) => project.value === projectId,
+    );
+
+    const newTask = {
+      description: task.description ?? "",
+      dueDate: task.dueDate ?? "",
+      position: 0,
+      priority: task.priority as "low" | "medium" | "high" | "urgent",
+      status: task.status,
+      title: task.title,
+      userEmail: task.userEmail ?? "",
+      projectId,
+    };
+
+    try {
+      await createTask(newTask);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to update task",
+      );
+    } finally {
+      toast.success(`Mirrored task successfully to: ${selectedProject?.label}`);
+    }
+  }
+
+  const handleChange = async (
+    field: keyof z.infer<typeof taskInfoSchema>,
+    value: string | Date,
+  ) => {
+
+    try {
+      await updateTask({
+        ...task,
+        [field]: value,
+      });
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to update task",
+      );
+    } finally {
+      toast.success("Task updated successfully");
+    }
+  };
+
+  async function handleDeleteTask(){
+    try {
+      await deleteTask(task.id);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to delete task",
+      );
+    } finally {
+      toast.success("Task deleted successfully");
+    }
+  }
+
+  return (
+    <ContextMenuContent>
+      <ContextMenuItem
+        onClick={handleCopyTaskLink}
+        className="flex items-center gap-2 cursor-pointer hover:bg-accent "
+      >
+        <Copy className="w-4 h-4 text-indigo-400 " />
+        Copy Link
+      </ContextMenuItem>
+
+      <ContextMenuSub>
+        <ContextMenuSubTrigger className="flex items-center gap-2">
+          <Tags className="h-4 w-4 text-indigo-400" /> Priority
+        </ContextMenuSubTrigger>
+        <ContextMenuSubContent>
+          <ContextMenuCheckboxItem
+            onClick={() => handleChange("priority", "low")}
+            className="flex items-center gap-2 cursor-pointer hover:bg-accent"
+            checked={task.priority === "low"}
+          >
+            <Flag className="w-4 h-4 text-blue-400" />
+            Low
+          </ContextMenuCheckboxItem>
+          <ContextMenuCheckboxItem
+            onClick={() => handleChange("priority", "medium")}
+            className="flex items-center gap-2 cursor-pointer hover:bg-accent"
+            checked={task.priority === "medium"}
+          >
+            <Flag className="w-4 h-4 text-yellow-400" />
+            Medium
+          </ContextMenuCheckboxItem>
+          <ContextMenuCheckboxItem
+            onClick={() => handleChange("priority", "high")}
+            className="flex items-center gap-2 cursor-pointer hover:bg-accent"
+            checked={task.priority === "high"}
+          >
+            <Flag className="w-4 h-4 text-red-400" />
+            High
+          </ContextMenuCheckboxItem>
+          <ContextMenuCheckboxItem
+            onClick={() => handleChange("priority", "urgent")}
+            className="flex items-center gap-2 cursor-pointer hover:bg-accent"
+            checked={task.priority === "urgent"}
+          >
+            <Flag className="w-4 h-4 text-red-400" />
+            Urgent
+          </ContextMenuCheckboxItem>
+        </ContextMenuSubContent>
+      </ContextMenuSub>
+
+      <ContextMenuSub>
+        <ContextMenuSubTrigger className="flex items-center gap-2">
+          <ListTodo className="h-4 w-4 text-indigo-400" /> Status
+        </ContextMenuSubTrigger>
+        <ContextMenuSubContent>
+          {statusOptions.map((status) => (
+            <ContextMenuCheckboxItem
+              key={status.value}
+              checked={task.status === status.value}
+              onCheckedChange={() => handleChange("status", status.value)}
+              className="flex items-center justify-between cursor-pointer"
+            >
+              {status.label}
+            </ContextMenuCheckboxItem>
+          ))}
+        </ContextMenuSubContent>
+      </ContextMenuSub>
+
+      <ContextMenuSub>
+        <ContextMenuSubTrigger className="flex items-center gap-2">
+          <User className="h-4 w-4 text-indigo-400" /> Assign to
+        </ContextMenuSubTrigger>
+
+        {usersOptions && (
+          <ContextMenuSubContent>
+            {usersOptions.map((user) => (
+              <ContextMenuCheckboxItem
+                key={user.value}
+                checked={task.userEmail === user.value}
+                onCheckedChange={() => handleChange("userEmail", user.value ?? "")}
+                className="flex items-center justify-between cursor-pointer"
+              >
+                {user.label}
+              </ContextMenuCheckboxItem>
+            ))}
+            <ContextMenuCheckboxItem
+              checked={!task.userEmail}
+              onCheckedChange={() => handleChange("userEmail", "")}
+              className="flex items-center justify-between cursor-pointer"
+            >
+              Unassigned
+            </ContextMenuCheckboxItem>
+          </ContextMenuSubContent>
+        )}
+      </ContextMenuSub>
+
+      <ContextMenuSub>
+        <ContextMenuSubTrigger className="flex items-center gap-2">
+          <FlipHorizontal2 className="h-4 w-4 text-indigo-400" /> Mirror to
+        </ContextMenuSubTrigger>
+
+        {projectsOptions && (
+          <ContextMenuSubContent>
+            {projectsOptions.map((project) => (
+              <ContextMenuItem
+                key={project.value}
+                onClick={() =>
+                  handleDuplicateTask(project.value)
+                }
+                className="flex items-center justify-between cursor-pointer hover:bg-accent"
+              >
+                {project.label}
+              </ContextMenuItem>
+            ))}
+          </ContextMenuSubContent>
+        )}
+      </ContextMenuSub>
+
+      <ContextMenuSub>
+        <ContextMenuSubTrigger className="flex items-center gap-2 mb-1">
+          <CalendarIcon className="h-4 w-4 text-indigo-400" /> Due date
+        </ContextMenuSubTrigger>
+        {projectsOptions && (
+          <ContextMenuSubContent>
+            <Calendar
+              mode="single"
+              selected={task.dueDate ? new Date(task.dueDate) : undefined}
+              onSelect={(value) => handleChange("dueDate", String(value))}
+              className="w-auto border-none"
+              initialFocus
+            />
+          </ContextMenuSubContent>
+        )}
+      </ContextMenuSub>
+      <hr />
+      <ContextMenuItem
+        onClick={handleDeleteTask}
+        className="flex items-center transition-all duration-200 gap-2 mt-1 cursor-pointer text-red-600 hover:bg-red-500 hover:text-white dark:bg-red-500 dark:hover:bg-red-400"
+      >
+        <Trash className="w-4 h-4 " />
+        Delete Task
+      </ContextMenuItem>
+    </ContextMenuContent>
+  );
+}

--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
@@ -287,10 +287,10 @@ export default function TaskCardContextMenuContent({
           </ContextMenuSubContent>
         )}
       </ContextMenuSub>
-      <hr />
+      <hr className="border-t border-gray-200 dark:border-gray-700" />
       <ContextMenuItem
         onClick={handleDeleteTask}
-        className="flex items-center transition-all duration-200 gap-2 mt-1 cursor-pointer text-red-600 hover:bg-red-500 hover:text-white dark:bg-red-500 dark:hover:bg-red-400"
+        className="flex items-center transition-all duration-200 gap-2 mt-1 cursor-pointer text-red-600 dark:text-red-400 dark:hover:text-white hover:bg-red-500 hover:text-white"
       >
         <Trash className="w-4 h-4 " />
         Delete Task

--- a/apps/web/src/components/kanban-board/task-card.tsx
+++ b/apps/web/src/components/kanban-board/task-card.tsx
@@ -9,6 +9,8 @@ import { format } from "date-fns";
 import { Calendar, Flag, UserIcon } from "lucide-react";
 import type { CSSProperties } from "react";
 import TaskCardLabels from "./task-labels";
+import { ContextMenu, ContextMenuTrigger } from "../ui/context-menu";
+import TaskCardContextMenuContent from "./task-card-context-menu/task-card-context-menu-content";
 
 interface TaskCardProps {
   task: Task;
@@ -53,9 +55,16 @@ function TaskCard({ task }: TaskCardProps) {
       style={style}
       {...attributes}
       {...listeners}
-      onClick={handleTaskCardClick}
-      className="group bg-white dark:bg-zinc-800/50 backdrop-blur-sm rounded-lg border border-zinc-200 dark:border-zinc-700/50 p-3 cursor-move hover:border-zinc-300 dark:hover:border-zinc-700 transition-colors shadow-sm"
     >
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div
+            onClick={handleTaskCardClick}
+            className="group bg-white dark:bg-zinc-800/50 backdrop-blur-sm rounded-lg border border-zinc-200 dark:border-zinc-700/50 p-3 cursor-move hover:border-zinc-300 dark:hover:border-zinc-700 transition-colors shadow-sm"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleTaskCardClick();
+            }}
+          >
       <div className="flex items-center gap-2 text-xs font-mono text-zinc-500 dark:text-zinc-400 mb-2">
         {project?.slug}-{task.number}
       </div>
@@ -107,6 +116,20 @@ function TaskCard({ task }: TaskCardProps) {
           </span>
         </div>
       </div>
+      </div>
+      </ContextMenuTrigger>
+       
+        {project && workspace && (
+          <TaskCardContextMenuContent
+            task={task}
+            taskCardContext={{
+              projectId: project.id,
+              worskpaceId: workspace.id,
+            }}
+          />
+        )}
+       
+      </ContextMenu>
     </div>
   );
 }

--- a/apps/web/src/components/kanban-board/task-card.tsx
+++ b/apps/web/src/components/kanban-board/task-card.tsx
@@ -8,9 +8,9 @@ import { useNavigate } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { Calendar, Flag, UserIcon } from "lucide-react";
 import type { CSSProperties } from "react";
-import TaskCardLabels from "./task-labels";
 import { ContextMenu, ContextMenuTrigger } from "../ui/context-menu";
 import TaskCardContextMenuContent from "./task-card-context-menu/task-card-context-menu-content";
+import TaskCardLabels from "./task-labels";
 
 interface TaskCardProps {
   task: Task;
@@ -50,12 +50,7 @@ function TaskCard({ task }: TaskCardProps) {
   }
 
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      {...attributes}
-      {...listeners}
-    >
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
       <ContextMenu>
         <ContextMenuTrigger asChild>
           <div
@@ -65,60 +60,60 @@ function TaskCard({ task }: TaskCardProps) {
               if (e.key === "Enter") handleTaskCardClick();
             }}
           >
-      <div className="flex items-center gap-2 text-xs font-mono text-zinc-500 dark:text-zinc-400 mb-2">
-        {project?.slug}-{task.number}
-      </div>
+            <div className="flex items-center gap-2 text-xs font-mono text-zinc-500 dark:text-zinc-400 mb-2">
+              {project?.slug}-{task.number}
+            </div>
 
-      <div className="flex flex-col gap-2 mb-2">
-        <h3 className="font-medium text-zinc-900 dark:text-zinc-100 max-w-4/5 truncate">
-          {task.title}
-        </h3>
-        <TaskCardLabels taskId={task.id} />
-      </div>
+            <div className="flex flex-col gap-2 mb-2">
+              <h3 className="font-medium text-zinc-900 dark:text-zinc-100 max-w-4/5 truncate">
+                {task.title}
+              </h3>
+              <TaskCardLabels taskId={task.id} />
+            </div>
 
-      <div className="flex flex-wrap items-center gap-2 mt-auto">
-        {task.userEmail ? (
-          <div
-            className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-zinc-100/50 dark:bg-zinc-800/50 group-hover:bg-zinc-100 dark:group-hover:bg-zinc-800/80 transition-colors"
-            title={task.userEmail}
-          >
-            <span className="text-xs text-zinc-600 dark:text-zinc-400 truncate max-w-[100px]">
-              {task.userEmail}
-            </span>
+            <div className="flex flex-wrap items-center gap-2 mt-auto">
+              {task.userEmail ? (
+                <div
+                  className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-zinc-100/50 dark:bg-zinc-800/50 group-hover:bg-zinc-100 dark:group-hover:bg-zinc-800/80 transition-colors"
+                  title={task.userEmail}
+                >
+                  <span className="text-xs text-zinc-600 dark:text-zinc-400 truncate max-w-[100px]">
+                    {task.userEmail}
+                  </span>
+                </div>
+              ) : (
+                <div
+                  className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-zinc-100/50 dark:bg-zinc-800/50 group-hover:bg-zinc-100 dark:group-hover:bg-zinc-800/80 transition-colors"
+                  title="Unassigned"
+                >
+                  <UserIcon className="h-3 w-3 text-zinc-400 dark:text-zinc-500" />
+                  <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                    Unassigned
+                  </span>
+                </div>
+              )}
+
+              {task.dueDate && (
+                <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-zinc-100/50 dark:bg-zinc-800/50 group-hover:bg-zinc-100 dark:group-hover:bg-zinc-800/80 transition-colors">
+                  <Calendar className="w-3 h-3 text-zinc-400 dark:text-zinc-500" />
+                  <span className="text-xs text-zinc-600 dark:text-zinc-400">
+                    {format(new Date(task.dueDate), "MMM d, yyyy")}
+                  </span>
+                </div>
+              )}
+
+              <div className="flex-shrink-0">
+                <span
+                  className={`text-xs px-2 py-1 rounded-full ${priorityColorsTaskCard[task.priority as keyof typeof priorityColorsTaskCard]}`}
+                >
+                  <Flag className="w-3 h-3 inline-block mr-1" />
+                  {task.priority}
+                </span>
+              </div>
+            </div>
           </div>
-        ) : (
-          <div
-            className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-zinc-100/50 dark:bg-zinc-800/50 group-hover:bg-zinc-100 dark:group-hover:bg-zinc-800/80 transition-colors"
-            title="Unassigned"
-          >
-            <UserIcon className="h-3 w-3 text-zinc-400 dark:text-zinc-500" />
-            <span className="text-xs text-zinc-500 dark:text-zinc-400">
-              Unassigned
-            </span>
-          </div>
-        )}
+        </ContextMenuTrigger>
 
-        {task.dueDate && (
-          <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-zinc-100/50 dark:bg-zinc-800/50 group-hover:bg-zinc-100 dark:group-hover:bg-zinc-800/80 transition-colors">
-            <Calendar className="w-3 h-3 text-zinc-400 dark:text-zinc-500" />
-            <span className="text-xs text-zinc-600 dark:text-zinc-400">
-              {format(new Date(task.dueDate), "MMM d, yyyy")}
-            </span>
-          </div>
-        )}
-
-        <div className="flex-shrink-0">
-          <span
-            className={`text-xs px-2 py-1 rounded-full ${priorityColorsTaskCard[task.priority as keyof typeof priorityColorsTaskCard]}`}
-          >
-            <Flag className="w-3 h-3 inline-block mr-1" />
-            {task.priority}
-          </span>
-        </div>
-      </div>
-      </div>
-      </ContextMenuTrigger>
-       
         {project && workspace && (
           <TaskCardContextMenuContent
             task={task}
@@ -128,7 +123,6 @@ function TaskCard({ task }: TaskCardProps) {
             }}
           />
         )}
-       
       </ContextMenu>
     </div>
   );

--- a/apps/web/src/components/list-view/task-row.tsx
+++ b/apps/web/src/components/list-view/task-row.tsx
@@ -8,8 +8,8 @@ import { CSS } from "@dnd-kit/utilities";
 import { useNavigate } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { Flag, GripVertical } from "lucide-react";
-import { ContextMenu, ContextMenuTrigger } from "../ui/context-menu";
 import TaskCardContextMenuContent from "../kanban-board/task-card-context-menu/task-card-context-menu-content";
+import { ContextMenu, ContextMenuTrigger } from "../ui/context-menu";
 
 interface TaskRowProps {
   task: Task;
@@ -48,7 +48,7 @@ function TaskRow({ task, projectSlug }: TaskRowProps) {
     });
   };
 
-    return (
+  return (
     <div ref={setNodeRef} style={style}>
       <ContextMenu>
         <ContextMenuTrigger asChild>
@@ -125,17 +125,15 @@ function TaskRow({ task, projectSlug }: TaskRowProps) {
           </div>
         </ContextMenuTrigger>
 
-      
-          {project && (
-            <TaskCardContextMenuContent
-              task={task}
-              taskCardContext={{
-                projectId: project.id,
-                worskpaceId: project.workspaceId,
-              }}
-            />
-          )}
-       
+        {project && (
+          <TaskCardContextMenuContent
+            task={task}
+            taskCardContext={{
+              projectId: project.id,
+              worskpaceId: project.workspaceId,
+            }}
+          />
+        )}
       </ContextMenu>
     </div>
   );

--- a/apps/web/src/components/list-view/task-row.tsx
+++ b/apps/web/src/components/list-view/task-row.tsx
@@ -8,6 +8,8 @@ import { CSS } from "@dnd-kit/utilities";
 import { useNavigate } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { Flag, GripVertical } from "lucide-react";
+import { ContextMenu, ContextMenuTrigger } from "../ui/context-menu";
+import TaskCardContextMenuContent from "../kanban-board/task-card-context-menu/task-card-context-menu-content";
 
 interface TaskRowProps {
   task: Task;
@@ -46,75 +48,95 @@ function TaskRow({ task, projectSlug }: TaskRowProps) {
     });
   };
 
-  return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      onClick={handleClick}
-      onKeyDown={(e) => e.key === "Enter" && handleClick()}
-      className={cn(
-        "group px-4 py-2 rounded-lg flex items-center gap-4 bg-white dark:bg-zinc-900",
-        "hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors cursor-pointer",
-        "border border-transparent hover:border-zinc-200 dark:hover:border-zinc-800",
-        isDragging && "opacity-25",
-      )}
-    >
-      <button
-        type="button"
-        className="p-1 -ml-2 rounded-md hover:bg-zinc-100 dark:hover:bg-zinc-800 cursor-grab active:cursor-grabbing"
-        {...attributes}
-        {...listeners}
-      >
-        <GripVertical className="w-4 h-4 text-zinc-400" />
-      </button>
-
-      <div className="flex-1 min-w-0 flex items-center gap-3">
-        <div className="text-xs font-mono text-zinc-500 dark:text-zinc-400 shrink-0">
-          {projectSlug}-{task.number}
-        </div>
-
-        <h3 className="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate">
-          {task.title}
-        </h3>
-      </div>
-
-      <div className="flex items-center gap-3">
-        {task.userEmail ? (
-          <Avatar className="h-6 w-6">
-            <AvatarFallback className="text-xs">
-              {task.userEmail.charAt(0)}
-            </AvatarFallback>
-          </Avatar>
-        ) : (
-          <Avatar className="h-6 w-6">
-            <AvatarFallback className="text-xs bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400">
-              ?
-            </AvatarFallback>
-          </Avatar>
-        )}
-
-        {task.dueDate && (
-          <div className="text-xs text-zinc-500 dark:text-zinc-400">
-            {format(new Date(task.dueDate), "MMM d")}
-          </div>
-        )}
-
-        {task.priority && (
+    return (
+    <div ref={setNodeRef} style={style}>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
           <div
+            onClick={(e) => {
+              if (e.nativeEvent.which === 1) {
+                handleClick();
+              }
+            }}
+            onKeyDown={(e) => e.key === "Enter" && handleClick()}
             className={cn(
-              "flex items-center gap-1 text-xs px-2 py-1 rounded-full",
-              priorityColorsTaskCard[
-                task.priority as keyof typeof priorityColorsTaskCard
-              ],
+              "group px-4 py-2 rounded-lg flex items-center gap-4 bg-white dark:bg-zinc-900",
+              "hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors cursor-pointer",
+              "border border-transparent hover:border-zinc-200 dark:hover:border-zinc-800",
+              isDragging && "opacity-25",
             )}
           >
-            <Flag className="w-3 h-3" />
-            <span className="capitalize hidden group-hover:inline">
-              {task.priority}
-            </span>
+            <button
+              type="button"
+              className="p-1 -ml-2 rounded-md hover:bg-zinc-100 dark:hover:bg-zinc-800 cursor-grab active:cursor-grabbing"
+              {...attributes}
+              {...listeners}
+            >
+              <GripVertical className="w-4 h-4 text-zinc-400" />
+            </button>
+
+            <div className="flex-1 min-w-0 flex items-center gap-3">
+              <div className="text-xs font-mono text-zinc-500 dark:text-zinc-400 shrink-0">
+                {projectSlug}-{task.number}
+              </div>
+
+              <h3 className="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate">
+                {task.title}
+              </h3>
+            </div>
+
+            <div className="flex items-center gap-3">
+              {task.userEmail ? (
+                <Avatar className="h-6 w-6">
+                  <AvatarFallback className="text-xs">
+                    {task.userEmail.charAt(0)}
+                  </AvatarFallback>
+                </Avatar>
+              ) : (
+                <Avatar className="h-6 w-6">
+                  <AvatarFallback className="text-xs bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400">
+                    ?
+                  </AvatarFallback>
+                </Avatar>
+              )}
+
+              {task.dueDate && (
+                <div className="text-xs text-zinc-500 dark:text-zinc-400">
+                  {format(new Date(task.dueDate), "MMM d")}
+                </div>
+              )}
+
+              {task.priority && (
+                <div
+                  className={cn(
+                    "flex items-center gap-1 text-xs px-2 py-1 rounded-full",
+                    priorityColorsTaskCard[
+                      task.priority as keyof typeof priorityColorsTaskCard
+                    ],
+                  )}
+                >
+                  <Flag className="w-3 h-3" />
+                  <span className="capitalize hidden group-hover:inline">
+                    {task.priority}
+                  </span>
+                </div>
+              )}
+            </div>
           </div>
-        )}
-      </div>
+        </ContextMenuTrigger>
+
+      
+          {project && (
+            <TaskCardContextMenuContent
+              task={task}
+              taskCardContext={{
+                projectId: project.id,
+                worskpaceId: project.workspaceId,
+              }}
+            />
+          )}
+       
+      </ContextMenu>
     </div>
   );
 }

--- a/apps/web/src/components/ui/context-menu.tsx
+++ b/apps/web/src/components/ui/context-menu.tsx
@@ -1,0 +1,197 @@
+import { cn } from "@/lib/cn";
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+import * as React from "react";
+
+const ContextMenu = ContextMenuPrimitive.Root;
+
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+
+const ContextMenuGroup = ContextMenuPrimitive.Group;
+
+const ContextMenuPortal = ContextMenuPrimitive.Portal;
+
+const ContextMenuSub = ContextMenuPrimitive.Sub;
+
+const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
+
+const ContextMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <ContextMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </ContextMenuPrimitive.SubTrigger>
+));
+ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
+
+const ContextMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
+
+const ContextMenuContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 max-h-[--radix-context-menu-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
+        className,
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+));
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+
+const ContextMenuItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none  data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+
+const ContextMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <ContextMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 ",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4 text-indigo-500" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.CheckboxItem>
+));
+ContextMenuCheckboxItem.displayName =
+  ContextMenuPrimitive.CheckboxItem.displayName;
+
+const ContextMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <ContextMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Circle className="h-4 w-4 fill-current" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.RadioItem>
+));
+ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName;
+
+const ContextMenuLabel = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold text-foreground",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName;
+
+const ContextMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
+));
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
+
+const ContextMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+ContextMenuShortcut.displayName = "ContextMenuShortcut";
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+};

--- a/apps/web/src/components/ui/context-menu.tsx
+++ b/apps/web/src/components/ui/context-menu.tsx
@@ -24,7 +24,7 @@ const ContextMenuSubTrigger = React.forwardRef<
   <ContextMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center px-2 py-1 text-sm outline-none text-zinc-600 dark:text-zinc-400 focus:bg-zinc-100 dark:focus:bg-zinc-800 data-[state=open]:bg-zinc-100 dark:data-[state=open]:bg-zinc-800",
+      "flex cursor-default select-none items-center px-2 py-1 text-sm outline-none text-zinc-600 rounded-sm dark:text-zinc-400 focus:bg-zinc-100 dark:focus:bg-zinc-800 data-[state=open]:bg-zinc-100 dark:data-[state=open]:bg-zinc-800",
       inset && "pl-8",
       className,
     )}
@@ -77,7 +77,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center focus:bg-accent px-2 py-1 text-sm outline-none text-zinc-600 dark:text-zinc-400 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center focus:bg-accent rounded-sm px-2 py-1 text-sm outline-none text-zinc-600 dark:text-zinc-400 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className,
     )}
@@ -93,7 +93,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center  py-1 px-2 text-sm outline-none text-zinc-600 dark:text-zinc-400 hover:bg-indigo-50 focus:bg-zinc-100 dark:focus:bg-zinc-800 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[state=checked]:bg-indigo-50 data-[state=checked]:text-indigo-600 dark:data-[state=checked]:bg-indigo-500/10 dark:data-[state=checked]:text-indigo-400",
+      "relative flex cursor-default select-none items-center py-1 px-2 text-sm outline-none text-zinc-600 dark:text-zinc-400 hover:bg-indigo-50 focus:bg-zinc-100 dark:focus:bg-zinc-800 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[state=checked]:bg-indigo-50 data-[state=checked]:text-indigo-600 dark:data-[state=checked]:bg-indigo-500/10 dark:data-[state=checked]:text-indigo-400",
       className,
     )}
     checked={checked}

--- a/apps/web/src/components/ui/context-menu.tsx
+++ b/apps/web/src/components/ui/context-menu.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/cn";
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
-import { Check, ChevronRight, Circle } from "lucide-react";
+import { ChevronRight, Circle } from "lucide-react";
 import * as React from "react";
 
 const ContextMenu = ContextMenuPrimitive.Root;
@@ -24,7 +24,7 @@ const ContextMenuSubTrigger = React.forwardRef<
   <ContextMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      "flex cursor-default select-none items-center px-2 py-1 text-sm outline-none text-zinc-600 dark:text-zinc-400 focus:bg-zinc-100 dark:focus:bg-zinc-800 data-[state=open]:bg-zinc-100 dark:data-[state=open]:bg-zinc-800",
       inset && "pl-8",
       className,
     )}
@@ -43,7 +43,7 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900  shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
       className,
     )}
     {...props}
@@ -59,7 +59,7 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 max-h-[--radix-context-menu-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
+        "z-50 max-h-[--radix-context-menu-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border border-zinc-200 bg-white p-1 dark:border-zinc-800 dark:bg-zinc-900 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
         className,
       )}
       {...props}
@@ -77,7 +77,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none  data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center focus:bg-accent px-2 py-1 text-sm outline-none text-zinc-600 dark:text-zinc-400 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className,
     )}
@@ -93,17 +93,12 @@ const ContextMenuCheckboxItem = React.forwardRef<
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 ",
+      "relative flex cursor-default select-none items-center  py-1 px-2 text-sm outline-none text-zinc-600 dark:text-zinc-400 hover:bg-indigo-50 focus:bg-zinc-100 dark:focus:bg-zinc-800 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[state=checked]:bg-indigo-50 data-[state=checked]:text-indigo-600 dark:data-[state=checked]:bg-indigo-500/10 dark:data-[state=checked]:text-indigo-400",
       className,
     )}
     checked={checked}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <ContextMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4 text-indigo-500" />
-      </ContextMenuPrimitive.ItemIndicator>
-    </span>
     {children}
   </ContextMenuPrimitive.CheckboxItem>
 ));
@@ -117,14 +112,14 @@ const ContextMenuRadioItem = React.forwardRef<
   <ContextMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center  py-1 pl-8 pr-2 text-sm outline-none text-zinc-600 dark:text-zinc-400 hover:bg-indigo-50 focus:bg-indigo-50 focus:text-indigo-600 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <ContextMenuPrimitive.ItemIndicator>
-        <Circle className="h-4 w-4 fill-current" />
+        <Circle className="h-4 w-4 fill-indigo-600 dark:fill-indigo-400" />
       </ContextMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -141,7 +136,7 @@ const ContextMenuLabel = React.forwardRef<
   <ContextMenuPrimitive.Label
     ref={ref}
     className={cn(
-      "px-2 py-1.5 text-sm font-semibold text-foreground",
+      "px-2 py-1 text-sm font-semibold text-zinc-500 dark:text-zinc-400",
       inset && "pl-8",
       className,
     )}
@@ -156,7 +151,7 @@ const ContextMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ContextMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    className={cn("-mx-1 my-1 h-px bg-zinc-200 dark:bg-zinc-800", className)}
     {...props}
   />
 ));
@@ -169,7 +164,7 @@ const ContextMenuShortcut = ({
   return (
     <span
       className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground",
+        "ml-auto text-sm tracking-widest text-zinc-500 dark:text-zinc-400",
         className,
       )}
       {...props}

--- a/apps/web/src/lib/generate-link.ts
+++ b/apps/web/src/lib/generate-link.ts
@@ -1,0 +1,7 @@
+export function generateLink(path = "") {
+  const baseUrl =
+    import.meta.env.VITE_APP_URL ||
+    `${window.location.protocol}//${window.location.host}`;
+
+  return `${baseUrl}${path}`;
+}


### PR DESCRIPTION
## Description
I've implemented the following functionalities to context menu when user 'right-click' the task card/task row:

- copy task link
- change priority
- change status
- change assigned user
- mirror task
- change due date
- delete task

## Related Issue(s)
[Issue #127](https://github.com/usekaneo/kaneo/issues/127)

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)
<p align="left">
  <img src="https://github.com/user-attachments/assets/a5b78c5f-1bab-47d7-b442-d2c28ef11fd8" width="300" />
  <img src="https://github.com/user-attachments/assets/da3fbb55-c829-4bd5-a09b-f59c59023332" width="300" />
</p>

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
this feature was made using [ContextMenu](https://ui.shadcn.com/docs/components/context-menu)
the functions are describing well what they are doing and I think there is no hard-to-understand areas
new dependency: "@radix-ui/react-context-menu": "^2.2.12"