### PR TITLE
feat: add rich text editor for comments

### DIFF
--- a/apps/web/src/components/task/task-activities.tsx
+++ b/apps/web/src/components/task/task-activities.tsx
@@ -1,4 +1,5 @@
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { MarkdownRenderer } from "@/components/common/markdown-renderer";
 import useDeleteComment from "@/hooks/mutations/comment/use-delete-comment";
 import useGetActivitiesByTaskId from "@/hooks/queries/activity/use-get-activities-by-task-id";
 import { cn } from "@/lib/cn";
@@ -76,9 +77,9 @@ function TaskActivities() {
                       onSubmit={() => setEditingCommentId(null)}
                     />
                   ) : (
-                    <span className="text-zinc-600 dark:text-zinc-100">
-                      {activity.content}
-                    </span>
+                    <div className="text-zinc-600 dark:text-zinc-100">
+                      <MarkdownRenderer content={activity.content || ""} />
+                    </div>
                   ))}
               </div>
               {activity.type === "comment" && editingCommentId === null && (

--- a/apps/web/src/components/task/task-comment.tsx
+++ b/apps/web/src/components/task/task-comment.tsx
@@ -1,4 +1,5 @@
 import useAuth from "@/components/providers/auth-provider/hooks/use-auth";
+import { Editor } from "@/components/common/editor";
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem } from "@/components/ui/form";
 import useCreateComment from "@/hooks/mutations/comment/use-create-comment";
@@ -100,12 +101,13 @@ function TaskComment({
                 <FormItem>
                   <div className="flex flex-col gap-4">
                     <FormControl>
-                      <textarea
-                        placeholder="Add a comment..."
-                        {...field}
-                        value={field.value}
-                        className="w-full rounded-xl border border-zinc-200/50 dark:border-zinc-800/50 bg-white dark:bg-zinc-900 shadow-sm px-4 py-3 text-sm text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-500 dark:placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 min-h-[100px]"
-                      />
+                      <div className="bg-white dark:bg-zinc-900 rounded-xl border border-zinc-200/50 dark:border-zinc-800/50 shadow-sm overflow-hidden min-h-[100px]">
+                        <Editor
+                          value={field.value || ""}
+                          onChange={field.onChange}
+                          placeholder="Add a comment..."
+                        />
+                      </div>
                     </FormControl>
                   </div>
                 </FormItem>


### PR DESCRIPTION
## Description
- Replace textarea with TipTap editor in comment input
- Add MarkdownRenderer for formatted comment display
- Support line breaks, bold, italic, lists, and links
- Maintain backward compatibility with existing comments
- Use same editor as task descriptions for consistency

Fixes issue where line breaks were removed from comments.

## Related Issue(s)
<!-- Link to the related issue(s) this PR addresses -->
Fixes 
- https://github.com/usekaneo/kaneo/issues/383
- https://github.com/usekaneo/kaneo/issues/237

Austin-tanksley is assigned to the last one. I hope it's still okay for me to make this contribution.
## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)
<img width="2560" height="971" alt="Bildschirmfoto 2025-08-05 um 23 35 24" src="https://github.com/user-attachments/assets/06b708a0-75ff-42c6-80f8-1dac5d4a8756" />
<img width="2542" height="1104" alt="Bildschirmfoto 2025-08-05 um 23 35 37" src="https://github.com/user-attachments/assets/a47e5ee8-cdb7-44a4-a086-bd2e5e4628c3" />
<img width="2557" height="1052" alt="Bildschirmfoto 2025-08-05 um 23 35 50" src="https://github.com/user-attachments/assets/ed0398c3-88e5-45e0-a6be-31f4b5436b9d" />


## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
(Question: Should I also update the changelog.md? )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
Nope, because these parts are tested in other locations...At least, that's what I think.
- [ ] New and existing unit tests pass locally with my changes
Didn't run, but it should. How I can run these tests?
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any other context about the PR here -->