### PR TITLE
feat(391): add "archive" and "planned" to the context menu of cards

### DIFF
--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
@@ -1,5 +1,7 @@
 import {
+  Archive,
   Calendar as CalendarIcon,
+  Clock,
   Copy,
   Flag,
   FlipHorizontal2,
@@ -352,6 +354,20 @@ export default function TaskCardContextMenuContent({
             </ContextMenuSubContent>
           )}
         </ContextMenuSub>
+        <ContextMenuItem
+          onClick={() => handleChange("status", "archived")}
+          className="flex items-center transition-all duration-200 gap-2  cursor-pointer"
+        >
+          <Archive className="w-3.5 h-3.5 text-indigo-500 dark:text-indigo-400" />
+          Archive Task
+        </ContextMenuItem>
+        <ContextMenuItem
+          onClick={() => handleChange("status", "planned")}
+          className="flex items-center transition-all duration-200 gap-2  cursor-pointer"
+        >
+          <Clock className="w-3.5 h-3.5 text-indigo-500 dark:text-indigo-400" />
+          Set as planned
+        </ContextMenuItem>
 
         <ContextMenuItem
           onClick={() => setIsDeleteTaskModalOpen(true)}


### PR DESCRIPTION
## Description
- This will add "Archive Task" and "Set as planned" to the context menu of task cards
- works in the kanban board and also in the backlog
- An idea for future improvement: Do not display Archive or Planned if it is in the corresponding views.

## Related Issue(s)
https://github.com/usekaneo/kaneo/issues/391


## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

<img width="524" height="710" alt="Bildschirmfoto 2025-08-06 um 19 03 22" src="https://github.com/user-attachments/assets/23f1b5f6-ba4b-47c3-8fd1-cd7540ad0e58" />
<img width="559" height="582" alt="Bildschirmfoto 2025-08-06 um 19 03 09" src="https://github.com/user-attachments/assets/325349ed-f4f9-46ed-984e-40ec571f7997" />


## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any other context about the PR here -->