### PR TITLE
[REF]: update_task: optimize event publishing in updateTask function

### DIFF
--- a/apps/api/src/task/controllers/update-task.ts
+++ b/apps/api/src/task/controllers/update-task.ts
@@ -46,33 +46,42 @@ async function updateTask(
     });
   }
 
-  if (existingTask.status !== status) {
-    await publishEvent("task.status_changed", {
-      taskId: updatedTask.id,
-      userId: updatedTask.userId,
-      oldStatus: existingTask.status,
-      newStatus: status,
-      title: updatedTask.title,
-    });
-  }
 
-  if (existingTask.priority !== priority) {
-    await publishEvent("task.priority_changed", {
-      taskId: updatedTask.id,
-      userId: updatedTask.userId,
-      oldPriority: existingTask.priority,
-      newPriority: priority,
-      title: updatedTask.title,
-    });
-  }
-
-  if (existingTask.userId !== userId) {
-    await publishEvent("task.assignee_changed", {
-      taskId: updatedTask.id,
-      newAssignee: userId,
-      title: updatedTask.title,
-    });
-  }
+    const eventPromises = [];
+    if (existingTask.status !== status) {
+      eventPromises.push(
+        publishEvent("task.status_changed", {
+          taskId: updatedTask.id,
+          userId: updatedTask.userId,
+          oldStatus: existingTask.status,
+          newStatus: status,
+          title: updatedTask.title,
+        })
+      );
+    }
+    if (existingTask.priority !== priority) {
+      eventPromises.push(
+        publishEvent("task.priority_changed", {
+          taskId: updatedTask.id,
+          userId: updatedTask.userId,
+          oldPriority: existingTask.priority,
+          newPriority: priority,
+          title: updatedTask.title,
+        })
+      );
+    }
+    if (existingTask.userId !== userId) {
+      eventPromises.push(
+        publishEvent("task.assignee_changed", {
+          taskId: updatedTask.id,
+          newAssignee: userId,
+          title: updatedTask.title,
+        })
+      );
+    }
+    if (eventPromises.length > 0) {
+      await Promise.all(eventPromises);
+    }
 
   return updatedTask;
 }


### PR DESCRIPTION
The event publishing for status, priority, and assignee changes in update-task.ts is now parallelized using Promise.all.

Other controllers like create-task.ts, import-tasks.ts, create-notification.ts, and create-time-entry.ts publish a single event per operation, so parallelization is not needed there. If you want to optimize batch operations (e.g., importing multiple tasks), you could collect all event promises and use Promise.all for those as well.