### PR TITLE
Fix: modify NOTES.txt from .Values.api to .Values.postgresql for .persistence object

### DIFF
--- a/charts/kaneo/templates/NOTES.txt
+++ b/charts/kaneo/templates/NOTES.txt
@@ -33,17 +33,17 @@ Alternatively, you can expose the services using an Ingress by setting .Values.i
 
 NOTES:
 1. Kaneo is configured with SQLite database for persistence.
-   {{- if .Values.api.persistence.enabled }}
+   {{- if .Values.postgresql.persistence.enabled }}
    A PersistentVolumeClaim is used to store the SQLite database file.
    {{- else }}
    WARNING: Persistence is disabled. Your data will be lost when the pod is terminated.
-   To enable persistence, set .Values.api.persistence.enabled=true
+   To enable persistence, set .Values.postgresql.persistence.enabled=true
    {{- end }}
 
 2. Important environment variables:
    - API:
      - JWT_ACCESS: Secret key for generating JWT tokens (currently set to: {{ .Values.api.env.jwtAccess }})
-     - DB_PATH: Path to the SQLite database file (set to: "{{ .Values.api.persistence.mountPath }}/{{ .Values.api.persistence.dbFilename }}")
+     - DB_PATH: Path to the SQLite database file (set to: "{{ .Values.postgresql.persistence.mountPath }}/{{ .Values.postgresql.persistence.dbFilename }}")
 
    - Web:
      - KANEO_API_URL: URL of the API service (set to: "{{- if .Values.web.env.apiUrl -}}


### PR DESCRIPTION
I've got error while running helm chart caused by misdefinition on NOTES.txt (`.persistence` object should be at `.Values.postgresql`), and this patch will fix the issue.

Helm version: v3.15.1
Kubernetes version: v1.34.0

<img width="1353" height="147" alt="image" src="https://github.com/user-attachments/assets/9267fc16-f75c-4b77-b065-573e0d1f4bb8" />