### PR TITLE
Address pull request comments

### DIFF
--- a/charts/kaneo/templates/NOTES.txt
+++ b/charts/kaneo/templates/NOTES.txt
@@ -32,9 +32,9 @@ Alternatively, you can expose the services using an Ingress by setting .Values.i
 {{- end }}
 
 NOTES:
-1. Kaneo is configured with SQLite database for persistence.
+1. Kaneo is configured with PostgreSQL database for persistence.
    {{- if .Values.postgresql.persistence.enabled }}
-   A PersistentVolumeClaim is used to store the SQLite database file.
+   A PersistentVolumeClaim is used to store the PostgreSQL data.
    {{- else }}
    WARNING: Persistence is disabled. Your data will be lost when the pod is terminated.
    To enable persistence, set .Values.postgresql.persistence.enabled=true
@@ -43,7 +43,7 @@ NOTES:
 2. Important environment variables:
    - API:
      - JWT_ACCESS: Secret key for generating JWT tokens (currently set to: {{ .Values.api.env.jwtAccess }})
-     - DB_PATH: Path to the SQLite database file (set to: "{{ .Values.postgresql.persistence.mountPath }}/{{ .Values.postgresql.persistence.dbFilename }}")
+     - Database: PostgreSQL database connection (configured via .Values.postgresql settings)
 
    - Web:
      - KANEO_API_URL: URL of the API service (set to: "{{- if .Values.web.env.apiUrl -}}


### PR DESCRIPTION
## Description
This PR addresses an inconsistency in the `charts/kaneo/templates/NOTES.txt` file. While a previous PR (#510) updated persistence references to `.Values.postgresql.persistence`, the template content still incorrectly referred to SQLite database. This change updates the `NOTES.txt` to accurately reflect that Kaneo uses PostgreSQL for persistence.

## Related Issue(s)
Fixes inconsistencies introduced by a previous PR.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?
- [x] Manual testing (visual inspection of the updated template)

## Screenshots (if applicable)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
The `NOTES.txt` template was updated to:
1. Change "Kaneo is configured with SQLite database for persistence" to "Kaneo is configured with PostgreSQL database for persistence".
2. Update "A PersistentVolumeClaim is used to store the SQLite database file" to "A PersistentVolumeClaim is used to store the PostgreSQL data".
3. Replace the incorrect `DB_PATH` reference for SQLite with a general description for PostgreSQL database connection.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d377cc3-5ae4-43eb-8645-20906a164388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4d377cc3-5ae4-43eb-8645-20906a164388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

