### PR TITLE
Update query conditions to use ilike for case-insensitive matching

### DIFF
--- a/apps/api/src/github-integration/controllers/get-github-integration-by-repository-id.ts
+++ b/apps/api/src/github-integration/controllers/get-github-integration-by-repository-id.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, ilike } from "drizzle-orm";
 import db from "../../database";
 import { githubIntegrationTable } from "../../database/schema";
 
@@ -8,8 +8,8 @@ async function getGithubIntegrationByRepositoryId(
 ) {
   const integration = await db.query.githubIntegrationTable.findFirst({
     where: and(
-      eq(githubIntegrationTable.repositoryOwner, repositoryOwner),
-      eq(githubIntegrationTable.repositoryName, repositoryName),
+      ilike(githubIntegrationTable.repositoryOwner, repositoryOwner),
+      ilike(githubIntegrationTable.repositoryName, repositoryName),
     ),
   });
 


### PR DESCRIPTION
## Description
Aims to fix . Use ilike instead of eq to ignore case-sensitivity

## Related Issue(s)
Fixes #603

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any other context about the PR here -->