### PR TITLE
feat: add access control to API endpoints

### DIFF
--- a/apps/api/src/activity/index.ts
+++ b/apps/api/src/activity/index.ts
@@ -3,6 +3,7 @@ import { describeRoute, resolver, validator } from "hono-openapi";
 import * as v from "valibot";
 import { subscribeToEvent } from "../events";
 import { activitySchema } from "../schemas";
+import { workspaceAccess } from "../utils/workspace-access-middleware";
 import createActivity from "./controllers/create-activity";
 import createComment from "./controllers/create-comment";
 import deleteComment from "./controllers/delete-comment";
@@ -30,6 +31,7 @@ const activity = new Hono<{
       },
     }),
     validator("param", v.object({ taskId: v.string() })),
+    workspaceAccess.fromTaskId(),
     async (c) => {
       const { taskId } = c.req.valid("param");
       const activities = await getActivities(taskId);
@@ -60,6 +62,7 @@ const activity = new Hono<{
         type: v.string(),
       }),
     ),
+    workspaceAccess.fromTaskId(),
     async (c) => {
       const { taskId, userId, message, type } = c.req.valid("json");
       const activity = await createActivity(taskId, type, userId, message);
@@ -88,6 +91,7 @@ const activity = new Hono<{
         comment: v.string(),
       }),
     ),
+    workspaceAccess.fromTaskId(),
     async (c) => {
       const { taskId, comment } = c.req.valid("json");
       const userId = c.get("userId");
@@ -117,6 +121,7 @@ const activity = new Hono<{
         comment: v.string(),
       }),
     ),
+    workspaceAccess.fromActivity("activityId"),
     async (c) => {
       const { activityId, comment } = c.req.valid("json");
       const userId = c.get("userId");
@@ -145,6 +150,7 @@ const activity = new Hono<{
         activityId: v.string(),
       }),
     ),
+    workspaceAccess.fromActivity("activityId"),
     async (c) => {
       const { activityId } = c.req.valid("json");
       const userId = c.get("userId");

--- a/apps/api/src/label/index.ts
+++ b/apps/api/src/label/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import * as v from "valibot";
 import { labelSchema } from "../schemas";
+import { workspaceAccess } from "../utils/workspace-access-middleware";
 import createLabel from "./controllers/create-label";
 import deleteLabel from "./controllers/delete-label";
 import getLabel from "./controllers/get-label";
@@ -26,6 +27,7 @@ const label = new Hono()
       },
     }),
     validator("param", v.object({ taskId: v.string() })),
+    workspaceAccess.fromTaskId(),
     async (c) => {
       const { taskId } = c.req.valid("param");
       const labels = await getLabelsByTaskId(taskId);
@@ -48,6 +50,7 @@ const label = new Hono()
       },
     }),
     validator("param", v.object({ workspaceId: v.string() })),
+    workspaceAccess.fromParam(),
     async (c) => {
       const { workspaceId } = c.req.valid("param");
       const labels = await getLabelsByWorkspaceId(workspaceId);
@@ -78,6 +81,7 @@ const label = new Hono()
         taskId: v.optional(v.string()),
       }),
     ),
+    workspaceAccess.fromBody(),
     async (c) => {
       const { name, color, workspaceId, taskId } = c.req.valid("json");
       const label = await createLabel(name, color, taskId, workspaceId);
@@ -100,6 +104,7 @@ const label = new Hono()
       },
     }),
     validator("param", v.object({ id: v.string() })),
+    workspaceAccess.fromLabel(),
     async (c) => {
       const { id } = c.req.valid("param");
       const label = await getLabel(id);
@@ -129,6 +134,7 @@ const label = new Hono()
         color: v.string(),
       }),
     ),
+    workspaceAccess.fromLabel(),
     async (c) => {
       const { id } = c.req.valid("param");
       const { name, color } = c.req.valid("json");
@@ -152,6 +158,7 @@ const label = new Hono()
       },
     }),
     validator("param", v.object({ id: v.string() })),
+    workspaceAccess.fromLabel(),
     async (c) => {
       const { id } = c.req.valid("param");
       const label = await deleteLabel(id);

--- a/apps/api/src/search/index.ts
+++ b/apps/api/src/search/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import * as v from "valibot";
 import { activitySchema, projectSchema, taskSchema } from "../schemas";
+import { workspaceAccess } from "../utils/workspace-access-middleware";
 import globalSearch from "./controllers/global-search";
 
 const workspaceSchema = v.object({
@@ -74,6 +75,7 @@ const search = new Hono<{
       userEmail: v.optional(v.pipe(v.string(), v.email())),
     }),
   ),
+  workspaceAccess.fromQuery(),
   async (c) => {
     const { q, type, workspaceId, projectId, limit, userEmail } =
       c.req.valid("query");

--- a/apps/api/src/task/index.ts
+++ b/apps/api/src/task/index.ts
@@ -4,6 +4,7 @@ import * as v from "valibot";
 import { auth } from "../auth";
 import { publishEvent } from "../events";
 import { taskSchema } from "../schemas";
+import { workspaceAccess } from "../utils/workspace-access-middleware";
 import createTask from "./controllers/create-task";
 import deleteTask from "./controllers/delete-task";
 import exportTasks from "./controllers/export-tasks";
@@ -39,6 +40,7 @@ const task = new Hono<{
       },
     }),
     validator("param", v.object({ projectId: v.string() })),
+    workspaceAccess.fromProject("projectId"),
     async (c) => {
       const { projectId } = c.req.valid("param");
 
@@ -73,6 +75,7 @@ const task = new Hono<{
         userId: v.optional(v.string()),
       }),
     ),
+    workspaceAccess.fromProject("projectId"),
     async (c) => {
       const { projectId } = c.req.param();
       const { title, description, dueDate, priority, status, userId } =
@@ -107,6 +110,7 @@ const task = new Hono<{
       },
     }),
     validator("param", v.object({ id: v.string() })),
+    workspaceAccess.fromTask(),
     async (c) => {
       const { id } = c.req.valid("param");
 
@@ -144,6 +148,7 @@ const task = new Hono<{
         userId: v.optional(v.string()),
       }),
     ),
+    workspaceAccess.fromTask(),
     async (c) => {
       const { id } = c.req.valid("param");
       const {
@@ -201,6 +206,7 @@ const task = new Hono<{
       },
     }),
     validator("param", v.object({ projectId: v.string() })),
+    workspaceAccess.fromProject("projectId"),
     async (c) => {
       const { projectId } = c.req.valid("param");
 
@@ -240,6 +246,7 @@ const task = new Hono<{
         ),
       }),
     ),
+    workspaceAccess.fromProject("projectId"),
     async (c) => {
       const { projectId } = c.req.valid("param");
       const { tasks } = c.req.valid("json");
@@ -265,6 +272,7 @@ const task = new Hono<{
       },
     }),
     validator("param", v.object({ id: v.string() })),
+    workspaceAccess.fromTask(),
     async (c) => {
       const { id } = c.req.valid("param");
 
@@ -290,6 +298,7 @@ const task = new Hono<{
     }),
     validator("param", v.object({ id: v.string() })),
     validator("json", v.object({ status: v.string() })),
+    workspaceAccess.fromTask(),
     async (c) => {
       const { id } = c.req.valid("param");
       const { status } = c.req.valid("json");
@@ -327,6 +336,7 @@ const task = new Hono<{
     }),
     validator("param", v.object({ id: v.string() })),
     validator("json", v.object({ priority: v.string() })),
+    workspaceAccess.fromTask(),
     async (c) => {
       const { id } = c.req.valid("param");
       const { priority } = c.req.valid("json");
@@ -363,6 +373,7 @@ const task = new Hono<{
     }),
     validator("param", v.object({ id: v.string() })),
     validator("json", v.object({ userId: v.string() })),
+    workspaceAccess.fromTask(),
     async (c) => {
       const { id } = c.req.valid("param");
       const { userId } = c.req.valid("json");
@@ -418,6 +429,7 @@ const task = new Hono<{
     }),
     validator("param", v.object({ id: v.string() })),
     validator("json", v.object({ dueDate: v.string() })),
+    workspaceAccess.fromTask(),
     async (c) => {
       const { id } = c.req.valid("param");
       const { dueDate } = c.req.valid("json");
@@ -455,6 +467,7 @@ const task = new Hono<{
     }),
     validator("param", v.object({ id: v.string() })),
     validator("json", v.object({ title: v.string() })),
+    workspaceAccess.fromTask(),
     async (c) => {
       const { id } = c.req.valid("param");
       const { title } = c.req.valid("json");
@@ -492,6 +505,7 @@ const task = new Hono<{
     }),
     validator("param", v.object({ id: v.string() })),
     validator("json", v.object({ description: v.string() })),
+    workspaceAccess.fromTask(),
     async (c) => {
       const { id } = c.req.valid("param");
       const { description } = c.req.valid("json");

--- a/apps/api/src/time-entry/index.ts
+++ b/apps/api/src/time-entry/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import * as v from "valibot";
 import { timeEntrySchema } from "../schemas";
+import { workspaceAccess } from "../utils/workspace-access-middleware";
 import createTimeEntry from "./controllers/create-time-entry";
 import getTimeEntriesByTaskId from "./controllers/get-time-entries";
 import getTimeEntry from "./controllers/get-time-entry";
@@ -28,6 +29,7 @@ const timeEntry = new Hono<{
       },
     }),
     validator("param", v.object({ taskId: v.string() })),
+    workspaceAccess.fromTaskId(),
     async (c) => {
       const { taskId } = c.req.valid("param");
       const timeEntries = await getTimeEntriesByTaskId(taskId);
@@ -50,6 +52,7 @@ const timeEntry = new Hono<{
       },
     }),
     validator("param", v.object({ id: v.string() })),
+    workspaceAccess.fromTimeEntry(),
     async (c) => {
       const { id } = c.req.valid("param");
       const timeEntry = await getTimeEntry(id);
@@ -80,6 +83,7 @@ const timeEntry = new Hono<{
         description: v.optional(v.string()),
       }),
     ),
+    workspaceAccess.fromTaskId(),
     async (c) => {
       const { taskId, startTime, endTime, description } = c.req.valid("json");
       const userId = c.get("userId");
@@ -117,6 +121,7 @@ const timeEntry = new Hono<{
         description: v.optional(v.string()),
       }),
     ),
+    workspaceAccess.fromTimeEntry(),
     async (c) => {
       const { id } = c.req.valid("param");
       const { startTime, endTime, description } = c.req.valid("json");


### PR DESCRIPTION
## Description
This PR adds access control checks to most API endpoints, ensuring only members of a workspace can access its resources (projects, tasks, labels, ...).

This is implemented using the `workspaceAccess` utility (only extending it a little bit).

Note: protecting the githubIntegration API endpoints requires refactoring the code since the client API key is **not** validated currently. I believe this does not have to significant security implications, nonetheless this should also be fixed in the future (tracked in #722).

## Related Issue(s)
Fixes #521

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [x] Other (please describe): security vulnerability fix

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist
Note: I only marked relevant checkboxes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
