### PR TITLE
helm chart add support for Gateway API

### DIFF
--- a/charts/kaneo/README.md
+++ b/charts/kaneo/README.md
@@ -4,7 +4,7 @@ This Helm chart deploys [Kaneo](https://kaneo.app) - open source project managem
 
 ## Introduction
 
-This chart bootstraps a Kaneo deployment on a Kubernetes cluster using the Helm package manager. It deploys both the API backend and Web frontend components, along with a PostgreSQL database, with optional ingress resources.
+This chart bootstraps a Kaneo deployment on a Kubernetes cluster using the Helm package manager. It deploys both the API backend and Web frontend components, along with a PostgreSQL database, with optional ingress or Gateway API resources.
 
 ## Prerequisites
 
@@ -43,6 +43,21 @@ helm install kaneo ./charts/kaneo \
   --set ingress.enabled=true \
   --set ingress.className=nginx \
   --set "ingress.hosts[0].host=pm.yourcompany.com"
+```
+
+### Production Setup with Gateway API
+
+If your cluster already has Gateway API CRDs and a `Gateway` configured, you can expose Kaneo with an `HTTPRoute`:
+
+```bash
+helm install kaneo ./charts/kaneo \
+  --namespace kaneo \
+  --create-namespace \
+  --set gateway.enabled=true \
+  --set "gateway.parentRefs[0].name=main-gateway" \
+  --set "gateway.parentRefs[0].namespace=gateway-system" \
+  --set "gateway.parentRefs[0].sectionName=https" \
+  --set "gateway.hostnames[0]=pm.yourcompany.com"
 ```
 
 ## Installing the Chart
@@ -148,6 +163,17 @@ helm uninstall my-kaneo
 | `ingress.annotations`               | Ingress annotations                                                                                                | `{}`                            |
 | `ingress.hosts`                     | Ingress hosts configuration                                                                                        | See `values.yaml`               |
 | `ingress.tls`                       | Ingress TLS configuration                                                                                          | `[]`                            |
+
+### Gateway API parameters
+
+| Name                                | Description                                                                                                        | Value                           |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------- |
+| `gateway.enabled`                   | Enable Gateway API `HTTPRoute` creation                                                                            | `false`                         |
+| `gateway.annotations`               | Annotations added to the `HTTPRoute`                                                                               | `{}`                            |
+| `gateway.labels`                    | Extra labels added to the `HTTPRoute`                                                                              | `{}`                            |
+| `gateway.parentRefs`                | Parent Gateway listener references for attaching the `HTTPRoute`                                                   | `[]`                            |
+| `gateway.hostnames`                 | Hostnames exposed by the `HTTPRoute`                                                                               | `[]`                            |
+| `gateway.rules`                     | Gateway API routing rules mapping paths to the chart services                                                      | See `values.yaml`               |
 
 ## Configuration Examples
 
@@ -379,52 +405,26 @@ ingress:
 
 ## Using Gateway API
 
-As an alternative to Ingress, you can use the Kubernetes Gateway API for more advanced routing capabilities:
+As an alternative to Ingress, the chart can create an `HTTPRoute` for the Kubernetes Gateway API:
 
 ```yaml
-# kaneo-gateway.yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: HTTPRoute
-metadata:
-  name: kaneo
-  namespace: kaneo
-spec:
+# values.yaml
+gateway:
+  enabled: true
   parentRefs:
-  - name: main-gateway  # Your gateway name
-    namespace: gateway-system  # Your gateway namespace
-    sectionName: https
+    - name: main-gateway
+      namespace: gateway-system
+      sectionName: https
   hostnames:
-  - "kaneo.example.com"
-  rules:
-  # Frontend route (root path)
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /
-    backendRefs:
-    - name: kaneo-web
-      port: 80
-  # API route (api path prefix)
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /api
-    backendRefs:
-    - name: kaneo-api
-      port: 1337
-    filters:
-    - type: URLRewrite
-      urlRewrite:
-        path:
-          type: ReplacePrefixMatch
-          replacePrefixMatch: /
+    - kaneo.example.com
 ```
 
-Apply the Gateway configuration:
+By default the chart creates two Gateway API rules:
 
-```bash
-kubectl apply -f kaneo-gateway.yaml
-```
+1. `/api` goes to the API service and rewrites the prefix to `/`
+2. `/` goes to the web service
+
+If you need custom matching or multiple backend references, override `gateway.rules` directly. Each `backendRefs` entry follows the same pattern as ingress and uses the chart-specific `service` field (`api` or `web`), which is expanded to the release-specific Service name.
 
 ## Security
 

--- a/charts/kaneo/templates/NOTES.txt
+++ b/charts/kaneo/templates/NOTES.txt
@@ -18,6 +18,19 @@ Note: This chart uses path patterns with regex capture groups for nginx:
   - /api/?(.*)  -> for API requests
 Make sure your ingress controller supports the configured annotations:
   nginx.ingress.kubernetes.io/rewrite-target: /$1
+{{- else if .Values.gateway.enabled }}
+
+An HTTPRoute has been created for Gateway API.
+{{- if .Values.gateway.hostnames }}
+Configured hostnames:
+{{- range .Values.gateway.hostnames }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+No hostnames were set on the HTTPRoute. Configure .Values.gateway.hostnames if your Gateway requires them.
+{{- end }}
+
+Attach the route by setting .Values.gateway.parentRefs to your Gateway listener references.
 {{- else }}
 
 To access the application, you need to set up port forwarding to both services:
@@ -29,6 +42,7 @@ Then access the application at http://localhost:5173
 The web frontend will communicate with the API at http://localhost:1337
 
 Alternatively, you can expose the services using an Ingress by setting .Values.ingress.enabled=true
+or Gateway API by setting .Values.gateway.enabled=true
 {{- end }}
 
 NOTES:

--- a/charts/kaneo/templates/httproute.yaml
+++ b/charts/kaneo/templates/httproute.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "kaneo.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "kaneo.labels" . | nindent 4 }}
+    {{- with .Values.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.gateway.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        {{- range .backendRefs }}
+        - name: {{ printf "%s-%s" $fullName .service }}
+          port: {{ .port }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kaneo/values.yaml
+++ b/charts/kaneo/values.yaml
@@ -188,3 +188,32 @@ ingress:
           service: api
           port: 1337
   tls: []
+
+# Gateway API configuration
+gateway:
+  enabled: false
+  annotations: {}
+  labels: {}
+  parentRefs: []
+  hostnames: []
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - service: api
+          port: 1337
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - service: web
+          port: 80


### PR DESCRIPTION
## Description
Add Gateway API support to the Helm chart by introducing an optional HTTPRoute template and corresponding values. This keeps the existing Ingress behavior unchanged while allowing Gateway-based routing for the web and API services through chart-managed configuration.

## Related Issue(s)
None

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [X] Manual testing
- [ ] Other (please describe):

## Checklist
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published