### PR TITLE
fix: file upload with umlauts

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -50,6 +50,25 @@ type ApiKey = {
   enabled: boolean;
 };
 
+function buildContentDisposition(filename: string) {
+  const normalized = filename.normalize("NFC").replace(/[\r\n"]/g, "").trim();
+  const safeFilename = normalized || "file";
+  const asciiFallback =
+    safeFilename
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/[\\\/]/g, "-")
+      .replace(/[^\x20-\x7E]+/g, "_")
+      .replace(/\s+/g, " ")
+      .trim() || "file";
+  const encodedFilename = encodeURIComponent(safeFilename).replace(
+    /['()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+
+  return `inline; filename="${asciiFallback}"; filename*=UTF-8''${encodedFilename}`;
+}
+
 const app = new Hono<{
   Variables: {
     user: User | null;
@@ -150,7 +169,7 @@ api.get("/asset/:id", async (c) => {
         "Cache-Control": asset.isPublic
           ? "public, max-age=300"
           : "private, max-age=120",
-        "Content-Disposition": `inline; filename="${asset.filename.replace(/"/g, "")}"`,
+        "Content-Disposition": buildContentDisposition(asset.filename),
         "Content-Length": object.contentLength?.toString() || "",
         "Content-Type": object.contentType || asset.mimeType,
         ETag: object.etag || "",


### PR DESCRIPTION
## Description
Fixes an asset delivery bug where uploaded files with umlauts or other Unicode characters in the filename could cause `GET /api/asset/:id` to return a `500 Internal Server Error`.

The PR updates the asset response header generation to use a safe ASCII fallback for `Content-Disposition` while also including a proper UTF-8 `filename*` value. This prevents header encoding errors and allows images like `test uöh` to load correctly.

## Related Issue(s)
Fixes #

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Other (please describe): Verified the API build succeeds and confirmed valid `Content-Disposition` headers are generated for both standard and Unicode filenames, including decomposed `ö` forms.

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
This issue was caused by the API inserting the original filename directly into the `Content-Disposition` header. Certain Unicode filename forms, especially decomposed characters commonly produced by macOS input, are invalid in HTTP header content and caused the response to fail before the asset could be streamed.

The fix is limited to response header generation and does not change how files are uploaded to or stored in S3.