### PR TITLE
fix(api): mistake with regex

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -51,13 +51,16 @@ type ApiKey = {
 };
 
 function buildContentDisposition(filename: string) {
-  const normalized = filename.normalize("NFC").replace(/[\r\n"]/g, "").trim();
+  const normalized = filename
+    .normalize("NFC")
+    .replace(/[\r\n"]/g, "")
+    .trim();
   const safeFilename = normalized || "file";
   const asciiFallback =
     safeFilename
       .normalize("NFKD")
       .replace(/[\u0300-\u036f]/g, "")
-      .replace(/[\\\/]/g, "-")
+      .replace(/[\\/]/g, "-")
       .replace(/[^\x20-\x7E]+/g, "_")
       .replace(/\s+/g, " ")
       .trim() || "file";


### PR DESCRIPTION
**The code before isn't wrong, this is just accepted by biome...**

## Description
Fixes the Biome CI issues in `apps/api/src/index.ts` by:
- reformatting `buildContentDisposition()` to match Biome formatting
- removing the unnecessary escaped `/` in the regex character class

## Related Issue(s)
Fixes #

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other (please describe): `pnpm exec biome ci apps/api/src/index.ts`

## Screenshots (if applicable)

N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
This change is non-functional and only resolves Biome formatting/lint failures.
