### PR TITLE
feat(web): add sorting controls to board, backlog, and list views

### DIFF
--- a/apps/api/src/task/controllers/create-task.ts
+++ b/apps/api/src/task/controllers/create-task.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, max } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import db from "../../database";
 import { columnTable, taskTable, userTable } from "../../database/schema";
@@ -36,6 +36,20 @@ async function createTask({
     ),
   });
 
+  const [maxPositionResult] = await db
+    .select({ maxPosition: max(taskTable.position) })
+    .from(taskTable)
+    .where(
+      and(
+        eq(taskTable.projectId, projectId),
+        column?.id
+          ? eq(taskTable.columnId, column.id)
+          : eq(taskTable.status, status || "to-do"),
+      ),
+    );
+
+  const nextPosition = (maxPositionResult?.maxPosition ?? 0) + 1;
+
   const [createdTask] = await db
     .insert(taskTable)
     .values({
@@ -48,6 +62,7 @@ async function createTask({
       description: description || "",
       priority: priority || "",
       number: nextTaskNumber + 1,
+      position: nextPosition,
     })
     .returning();
 

--- a/apps/api/src/task/controllers/get-next-task-number.ts
+++ b/apps/api/src/task/controllers/get-next-task-number.ts
@@ -1,14 +1,14 @@
-import { count, eq } from "drizzle-orm";
+import { eq, max } from "drizzle-orm";
 import db from "../../database";
 import { taskTable } from "../../database/schema";
 
 async function getNextTaskNumber(projectId: string) {
-  const [task] = await db
-    .select({ count: count() })
+  const [result] = await db
+    .select({ maxNumber: max(taskTable.number) })
     .from(taskTable)
     .where(eq(taskTable.projectId, projectId));
 
-  return task ? task.count : 0;
+  return result?.maxNumber ?? 0;
 }
 
 export default getNextTaskNumber;

--- a/apps/web/src/components/backlog-list-view/index.tsx
+++ b/apps/web/src/components/backlog-list-view/index.tsx
@@ -36,9 +36,13 @@ import BacklogTaskRow from "./backlog-task-row";
 
 type BacklogListViewProps = {
   project?: ProjectWithTasks;
+  disableDragDrop?: boolean;
 };
 
-function BacklogListView({ project }: BacklogListViewProps) {
+function BacklogListView({
+  project,
+  disableDragDrop = false,
+}: BacklogListViewProps) {
   const { mutate: updateTask } = useUpdateTask();
   const { setProject } = useProjectStore();
   const {
@@ -114,11 +118,11 @@ function BacklogListView({ project }: BacklogListViewProps) {
 
   const sensors = useSensors(
     useSensor(MouseSensor, {
-      activationConstraint: { distance: 8 },
+      activationConstraint: { distance: disableDragDrop ? 999999 : 8 },
     }),
     useSensor(TouchSensor, {
       activationConstraint: {
-        delay: 200,
+        delay: disableDragDrop ? 999999 : 200,
         tolerance: 8,
       },
     }),
@@ -232,7 +236,7 @@ function BacklogListView({ project }: BacklogListViewProps) {
         finalTasks.forEach((t, index) => {
           updateTask({
             ...t,
-            position: index + 1,
+            position: index,
           });
         });
       } else {
@@ -253,7 +257,19 @@ function BacklogListView({ project }: BacklogListViewProps) {
           updateTask({
             ...t,
             status: targetSection,
-            position: index + 1,
+            position: index,
+          });
+        });
+
+        const sourceTasks =
+          activeTask.status === "planned"
+            ? draft.plannedTasks || []
+            : draft.archivedTasks || [];
+
+        sourceTasks.forEach((t, index) => {
+          updateTask({
+            ...t,
+            position: index,
           });
         });
       }

--- a/apps/web/src/components/board/board-toolbar.tsx
+++ b/apps/web/src/components/board/board-toolbar.tsx
@@ -1,5 +1,6 @@
 import { Filter, PanelsTopLeft, Rows3, X } from "lucide-react";
 import type { ReactNode } from "react";
+import SortControl from "@/components/common/sort-control";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -17,6 +18,7 @@ import labelColors from "@/constants/label-colors";
 import type { BoardFilters } from "@/hooks/use-task-filters";
 import { getColumnIcon } from "@/lib/column";
 import { getPriorityIcon } from "@/lib/priority";
+import type { SortConfig } from "@/lib/sort-tasks";
 import type { ProjectWithTasks } from "@/types/project";
 
 type WorkspaceLabel = {
@@ -49,6 +51,8 @@ type BoardToolbarProps = {
   workspaceLabels: WorkspaceLabel[];
   viewMode: "board" | "list";
   setViewMode: (mode: "board" | "list") => void;
+  sort: SortConfig;
+  onSortChange: (sort: SortConfig) => void;
 };
 
 function CheckSlot({ checked }: { checked: boolean }) {
@@ -131,6 +135,8 @@ export default function BoardToolbar({
   workspaceLabels,
   viewMode,
   setViewMode,
+  sort,
+  onSortChange,
 }: BoardToolbarProps) {
   const selectedStatusIds = filters.status ?? [];
   const selectedPriorityIds = filters.priority ?? [];
@@ -502,6 +508,8 @@ export default function BoardToolbar({
                 )}
               </DropdownMenuContent>
             </DropdownMenu>
+
+            <SortControl sort={sort} onSortChange={onSortChange} />
 
             {selectedStatusIds.length > 0 && (
               <ActiveFilterChip

--- a/apps/web/src/components/common/sort-control.tsx
+++ b/apps/web/src/components/common/sort-control.tsx
@@ -1,0 +1,145 @@
+import { ArrowDownAZ, ArrowUpAZ } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/menu";
+import type { SortConfig, SortDirection, SortField } from "@/lib/sort-tasks";
+
+type SortControlProps = {
+  sort: SortConfig;
+  onSortChange: (sort: SortConfig) => void;
+};
+
+const sortFields: { field: SortField; label: string }[] = [
+  { field: "position", label: "Manual (position)" },
+  { field: "createdAt", label: "Created date" },
+  { field: "priority", label: "Priority" },
+  { field: "dueDate", label: "Due date" },
+  { field: "title", label: "Title" },
+  { field: "number", label: "Task number" },
+];
+
+function CheckSlot({ checked }: { checked: boolean }) {
+  return (
+    <span
+      className={`inline-flex size-4 shrink-0 items-center justify-center rounded-[4px] border ${
+        checked
+          ? "border-primary bg-primary text-primary-foreground"
+          : "border-input bg-background"
+      }`}
+    >
+      {checked ? "\u2713" : null}
+    </span>
+  );
+}
+
+export default function SortControl({ sort, onSortChange }: SortControlProps) {
+  const isActive = sort.field !== "position";
+  const activeLabel = sortFields.find((f) => f.field === sort.field)?.label;
+
+  const handleFieldChange = (field: SortField) => {
+    if (field === "position" || field === sort.field) {
+      onSortChange({ field: "position", direction: "asc" });
+    } else {
+      const defaultDirection: SortDirection =
+        field === "priority" ? "desc" : "asc";
+      onSortChange({ field, direction: defaultDirection });
+    }
+  };
+
+  const toggleDirection = () => {
+    onSortChange({
+      ...sort,
+      direction: sort.direction === "asc" ? "desc" : "asc",
+    });
+  };
+
+  return (
+    <div className="inline-flex items-center gap-1">
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <button
+              type="button"
+              className={`inline-flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium outline-none ring-0 ${
+                isActive
+                  ? "border-primary/30 bg-primary/10 text-primary hover:bg-primary/15"
+                  : "border-border bg-background text-foreground hover:bg-accent/60"
+              }`}
+            />
+          }
+        >
+          {sort.direction === "asc" ? (
+            <ArrowUpAZ className="h-3 w-3" />
+          ) : (
+            <ArrowDownAZ className="h-3 w-3" />
+          )}
+          {isActive ? activeLabel : "Sort"}
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-48" align="start">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel className="text-[11px] uppercase tracking-wide">
+              Sort By
+            </DropdownMenuLabel>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          {sortFields.map(({ field, label }) => (
+            <DropdownMenuItem
+              key={field}
+              onClick={() => handleFieldChange(field)}
+              className="h-8 rounded-md text-sm"
+            >
+              <CheckSlot checked={sort.field === field} />
+              {label}
+            </DropdownMenuItem>
+          ))}
+
+          {isActive && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuGroup>
+                <DropdownMenuLabel className="text-[11px] uppercase tracking-wide">
+                  Direction
+                </DropdownMenuLabel>
+              </DropdownMenuGroup>
+              <DropdownMenuItem
+                onClick={() => onSortChange({ ...sort, direction: "asc" })}
+                className="h-8 rounded-md text-sm"
+              >
+                <CheckSlot checked={sort.direction === "asc"} />
+                Ascending
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => onSortChange({ ...sort, direction: "desc" })}
+                className="h-8 rounded-md text-sm"
+              >
+                <CheckSlot checked={sort.direction === "desc"} />
+                Descending
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {isActive && (
+        <button
+          type="button"
+          onClick={toggleDirection}
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background text-foreground hover:bg-accent/60"
+          title={sort.direction === "asc" ? "Ascending" : "Descending"}
+        >
+          {sort.direction === "asc" ? (
+            <ArrowUpAZ className="h-3 w-3" />
+          ) : (
+            <ArrowDownAZ className="h-3 w-3" />
+          )}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/kanban-board/index.tsx
+++ b/apps/web/src/components/kanban-board/index.tsx
@@ -28,9 +28,10 @@ import TaskCard from "./task-card";
 
 type KanbanBoardProps = {
   project: ProjectWithTasks;
+  disableDragDrop?: boolean;
 };
 
-function KanbanBoard({ project }: KanbanBoardProps) {
+function KanbanBoard({ project, disableDragDrop = false }: KanbanBoardProps) {
   const queryClient = useQueryClient();
   const { setProject } = useProjectStore();
   const {
@@ -90,11 +91,11 @@ function KanbanBoard({ project }: KanbanBoardProps) {
 
   const sensors = useSensors(
     useSensor(MouseSensor, {
-      activationConstraint: { distance: 8 },
+      activationConstraint: { distance: disableDragDrop ? 999999 : 8 },
     }),
     useSensor(TouchSensor, {
       activationConstraint: {
-        delay: 250,
+        delay: disableDragDrop ? 999999 : 250,
         tolerance: 10,
       },
     }),
@@ -154,23 +155,27 @@ function KanbanBoard({ project }: KanbanBoardProps) {
         destinationColumn.tasks.splice(destinationIndex, 0, task);
 
         destinationColumn.tasks.forEach((t, index) => {
-          updateTask({ ...t, position: index + 1 });
+          updateTask({ ...t, position: index });
         });
 
         queryClient.invalidateQueries({
           queryKey: ["projects", project.workspaceId],
         });
       } else {
-        const updatedTask = { ...task, status: destinationColumn.id };
+        task.status = destinationColumn.id;
         const destinationIndex =
           overId === destinationColumn.id
             ? destinationColumn.tasks.length
-            : destinationColumn.tasks.findIndex((t) => t.id === overId);
+            : destinationColumn.tasks.findIndex((t) => t.id === overId) + 1;
 
-        destinationColumn.tasks.splice(destinationIndex + 1, 0, updatedTask);
+        destinationColumn.tasks.splice(destinationIndex, 0, task);
 
         destinationColumn.tasks.forEach((t, index) => {
-          updateTask({ ...t, position: index + 1 });
+          updateTask({ ...t, status: destinationColumn.id, position: index });
+        });
+
+        sourceColumn.tasks.forEach((t, index) => {
+          updateTask({ ...t, position: index });
         });
       }
     });

--- a/apps/web/src/components/list-view/index.tsx
+++ b/apps/web/src/components/list-view/index.tsx
@@ -37,9 +37,10 @@ import TaskRow from "./task-row";
 
 type ListViewProps = {
   project: ProjectWithTasks;
+  disableDragDrop?: boolean;
 };
 
-function ListView({ project }: ListViewProps) {
+function ListView({ project, disableDragDrop = false }: ListViewProps) {
   const { setProject } = useProjectStore();
   const {
     setAvailableTasks,
@@ -112,11 +113,11 @@ function ListView({ project }: ListViewProps) {
 
   const sensors = useSensors(
     useSensor(MouseSensor, {
-      activationConstraint: { distance: 8 },
+      activationConstraint: { distance: disableDragDrop ? 999999 : 8 },
     }),
     useSensor(TouchSensor, {
       activationConstraint: {
-        delay: 200,
+        delay: disableDragDrop ? 999999 : 200,
         tolerance: 8,
       },
     }),
@@ -194,18 +195,30 @@ function ListView({ project }: ListViewProps) {
           updateTask({
             ...t,
             status: destinationColumn.id,
-            position: index + 1,
+            position: index,
           });
         });
       } else {
         task.status = destinationColumn.id;
-        destinationColumn.tasks.push(task);
+        const destinationIndex =
+          overId === destinationColumn.id
+            ? destinationColumn.tasks.length
+            : destinationColumn.tasks.findIndex((t) => t.id === overId) + 1;
+
+        destinationColumn.tasks.splice(destinationIndex, 0, task);
 
         destinationColumn.tasks.forEach((t, index) => {
           updateTask({
             ...t,
             status: destinationColumn.id,
-            position: index + 1,
+            position: index,
+          });
+        });
+
+        sourceColumn.tasks.forEach((t, index) => {
+          updateTask({
+            ...t,
+            position: index,
           });
         });
       }

--- a/apps/web/src/hooks/queries/task/use-get-tasks.ts
+++ b/apps/web/src/hooks/queries/task/use-get-tasks.ts
@@ -5,7 +5,7 @@ export function useGetTasks(projectId: string) {
   return useQuery({
     queryKey: ["tasks", projectId],
     queryFn: () => getTasks(projectId),
-    refetchInterval: 5000,
+    refetchInterval: 30000,
     enabled: !!projectId,
   });
 }

--- a/apps/web/src/lib/sort-tasks.ts
+++ b/apps/web/src/lib/sort-tasks.ts
@@ -1,0 +1,72 @@
+import type Task from "@/types/task";
+
+export type SortField =
+  | "position"
+  | "createdAt"
+  | "priority"
+  | "dueDate"
+  | "title"
+  | "number";
+
+export type SortDirection = "asc" | "desc";
+
+export type SortConfig = {
+  field: SortField;
+  direction: SortDirection;
+};
+
+const priorityOrder: Record<string, number> = {
+  urgent: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+function getPriorityValue(priority: string | null): number {
+  if (!priority) return 0;
+  return priorityOrder[priority] ?? 0;
+}
+
+export function sortTasks(tasks: Task[], config: SortConfig): Task[] {
+  if (config.field === "position") {
+    return tasks;
+  }
+
+  const sorted = [...tasks].sort((a, b) => {
+    let comparison = 0;
+
+    switch (config.field) {
+      case "priority": {
+        comparison =
+          getPriorityValue(a.priority) - getPriorityValue(b.priority);
+        break;
+      }
+      case "dueDate": {
+        const aDate = a.dueDate ? new Date(a.dueDate).getTime() : 0;
+        const bDate = b.dueDate ? new Date(b.dueDate).getTime() : 0;
+        if (!a.dueDate && !b.dueDate) comparison = 0;
+        else if (!a.dueDate) comparison = 1;
+        else if (!b.dueDate) comparison = -1;
+        else comparison = aDate - bDate;
+        break;
+      }
+      case "createdAt": {
+        comparison =
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+        break;
+      }
+      case "title": {
+        comparison = a.title.localeCompare(b.title);
+        break;
+      }
+      case "number": {
+        comparison = (a.number ?? 0) - (b.number ?? 0);
+        break;
+      }
+    }
+
+    return config.direction === "asc" ? comparison : -comparison;
+  });
+
+  return sorted;
+}

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, Calendar, Filter, Plus, User, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import BacklogListView from "@/components/backlog-list-view";
 import ProjectLayout from "@/components/common/project-layout";
+import SortControl from "@/components/common/sort-control";
 import PageTitle from "@/components/page-title";
 import CreateTaskModal from "@/components/shared/modals/create-task-modal";
 import TaskDetailsSheet from "@/components/task/task-details-sheet";
@@ -28,6 +29,8 @@ import { useGetTasks } from "@/hooks/queries/task/use-get-tasks";
 import { useGetActiveWorkspaceUsers } from "@/hooks/queries/workspace-users/use-get-active-workspace-users";
 import { useRegisterShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { getPriorityIcon } from "@/lib/priority";
+import type { SortConfig } from "@/lib/sort-tasks";
+import { sortTasks } from "@/lib/sort-tasks";
 import { toast } from "@/lib/toast";
 import useProjectStore from "@/store/project";
 import { useUserPreferencesStore } from "@/store/user-preferences";
@@ -54,6 +57,10 @@ function RouteComponent() {
   const { project, setProject } = useProjectStore();
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
   const { mutate: updateTask } = useUpdateTask();
+  const [sort, setSort] = useState<SortConfig>({
+    field: "position",
+    direction: "asc",
+  });
 
   const { data: users } = useGetActiveWorkspaceUsers(workspaceId);
   const { data: workspaceLabels = [] } = useGetLabelsByWorkspace(workspaceId);
@@ -278,6 +285,15 @@ function RouteComponent() {
     }
   };
 
+  const sortedProject = useMemo(() => {
+    if (!filteredProject || sort.field === "position") return filteredProject;
+    return {
+      ...filteredProject,
+      plannedTasks: sortTasks(filteredProject.plannedTasks || [], sort),
+      archivedTasks: sortTasks(filteredProject.archivedTasks || [], sort),
+    };
+  }, [filteredProject, sort]);
+
   const handleMoveAllPlannedToTodo = () => {
     if (!project) return;
 
@@ -464,6 +480,8 @@ function RouteComponent() {
                       </Button>
                     ))}
 
+                <SortControl sort={sort} onSortChange={setSort} />
+
                 <DropdownMenu>
                   <DropdownMenuTrigger
                     render={
@@ -615,8 +633,11 @@ function RouteComponent() {
         </div>
 
         <div className="flex-1 overflow-hidden bg-card h-full">
-          {filteredProject ? (
-            <BacklogListView project={filteredProject} />
+          {sortedProject ? (
+            <BacklogListView
+              project={sortedProject}
+              disableDragDrop={sort.field !== "position"}
+            />
           ) : (
             <div className="flex h-full items-center justify-center">
               <div className="text-center space-y-4">

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Search } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import BoardToolbar from "@/components/board/board-toolbar";
 import ProjectLayout from "@/components/common/project-layout";
 import KanbanBoard from "@/components/kanban-board";
@@ -15,6 +15,8 @@ import { useGetTasks } from "@/hooks/queries/task/use-get-tasks";
 import { useGetActiveWorkspaceUsers } from "@/hooks/queries/workspace-users/use-get-active-workspace-users";
 import { useRegisterShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { useTaskFiltersWithLabelsSupport } from "@/hooks/use-task-filters-with-labels-support";
+import type { SortConfig } from "@/lib/sort-tasks";
+import { sortTasks } from "@/lib/sort-tasks";
 import useProjectStore from "@/store/project";
 import { useUserPreferencesStore } from "@/store/user-preferences";
 
@@ -44,6 +46,10 @@ function RouteComponent() {
   const [isBoardSearchVisible, setIsBoardSearchVisible] = useState(false);
   const [boardSearchInput, setBoardSearchInput] =
     useState<HTMLInputElement | null>(null);
+  const [sort, setSort] = useState<SortConfig>({
+    field: "position",
+    direction: "asc",
+  });
 
   const { data: users } = useGetActiveWorkspaceUsers(workspaceId);
   const { data: workspaceLabels = [] } = useGetLabelsByWorkspace(workspaceId);
@@ -115,6 +121,17 @@ function RouteComponent() {
     clearFilters,
   } = useTaskFiltersWithLabelsSupport(project, projectId, boardSearchQuery);
 
+  const sortedProject = useMemo(() => {
+    if (!filteredProject || sort.field === "position") return filteredProject;
+    return {
+      ...filteredProject,
+      columns: filteredProject.columns.map((column) => ({
+        ...column,
+        tasks: sortTasks(column.tasks, sort),
+      })),
+    };
+  }, [filteredProject, sort]);
+
   const boardHeaderSearch = isBoardSearchMounted ? (
     <div
       className={`relative w-[240px] origin-top transition-all duration-180 ease-out ${
@@ -167,14 +184,22 @@ function RouteComponent() {
           workspaceLabels={workspaceLabels}
           viewMode={viewMode}
           setViewMode={setViewMode}
+          sort={sort}
+          onSortChange={setSort}
         />
 
         <div className="flex h-full flex-1 overflow-hidden bg-background">
-          {filteredProject ? (
+          {sortedProject ? (
             viewMode === "board" ? (
-              <KanbanBoard project={filteredProject} />
+              <KanbanBoard
+                project={sortedProject}
+                disableDragDrop={sort.field !== "position"}
+              />
             ) : (
-              <ListView project={filteredProject} />
+              <ListView
+                project={sortedProject}
+                disableDragDrop={sort.field !== "position"}
+              />
             )
           ) : (
             <div className="flex h-full items-center justify-center">


### PR DESCRIPTION
## Summary
- New reusable `SortControl` dropdown component using Radix DropdownMenu
- New `sortTasks` utility supporting all sort fields with priority numeric mapping
- Sorting integrated in board, backlog, and list views via toolbar
- Drag-and-drop automatically disabled when sorting is active (sensor distance set to prevent accidental drags)

## Test plan
- [ ] Open board view — verify Sort dropdown appears in toolbar
- [ ] Sort by priority (desc) — verify urgent tasks appear first in each column
- [ ] Sort by due date — verify tasks without dates go to the end
- [ ] Try to drag a card while sorting is active — verify it's disabled
- [ ] Click active sort field again — verify it resets to manual order