### PR TITLE
feat(api,web): add global search with short-id support (DEP-23)

### DIFF
--- a/apps/api/src/search/controllers/global-search.ts
+++ b/apps/api/src/search/controllers/global-search.ts
@@ -97,7 +97,75 @@ async function globalSearch(params: SearchParams): Promise<{
     ? eq(projectTable.workspaceId, workspaceId)
     : sql`${projectTable.workspaceId} IN ${accessibleWorkspaceIds}`;
 
+  // Check if query matches short-id pattern (e.g. "DEP-23")
+  const shortIdMatch = query.match(/^([A-Za-z][\w-]*)-(\d+)$/);
+
   if (type === "all" || type === "tasks") {
+    const seenTaskIds = new Set<string>();
+
+    // If query matches short-id pattern, look up by project slug + task number first
+    if (shortIdMatch) {
+      const [, slug, numberStr] = shortIdMatch;
+      const taskNumber = Number.parseInt(numberStr, 10);
+
+      const shortIdTasks = await db
+        .select({
+          id: taskTable.id,
+          title: taskTable.title,
+          description: taskTable.description,
+          projectId: taskTable.projectId,
+          projectName: projectTable.name,
+          projectSlug: projectTable.slug,
+          workspaceId: projectTable.workspaceId,
+          workspaceName: workspaceTable.name,
+          userId: taskTable.userId,
+          userName: userTable.name,
+          createdAt: taskTable.createdAt,
+          taskNumber: taskTable.number,
+          priority: taskTable.priority,
+          status: taskTable.status,
+        })
+        .from(taskTable)
+        .leftJoin(projectTable, eq(taskTable.projectId, projectTable.id))
+        .leftJoin(
+          workspaceTable,
+          eq(projectTable.workspaceId, workspaceTable.id),
+        )
+        .leftJoin(userTable, eq(taskTable.userId, userTable.id))
+        .where(
+          and(
+            workspaceFilter,
+            projectId ? eq(taskTable.projectId, projectId) : undefined,
+            ilike(projectTable.slug, slug),
+            eq(taskTable.number, taskNumber),
+          ),
+        )
+        .limit(1);
+
+      for (const task of shortIdTasks) {
+        seenTaskIds.add(task.id);
+        results.push({
+          id: task.id,
+          type: "task",
+          title: task.title,
+          description: task.description || undefined,
+          projectId: task.projectId,
+          projectName: task.projectName || undefined,
+          projectSlug: task.projectSlug || undefined,
+          workspaceId: task.workspaceId || undefined,
+          workspaceName: task.workspaceName || undefined,
+          userId: task.userId || undefined,
+          userName: task.userName || undefined,
+          createdAt: task.createdAt,
+          relevanceScore: 10, // Highest relevance for exact short-id match
+          taskNumber: task.taskNumber || undefined,
+          priority: task.priority || undefined,
+          status: task.status,
+        });
+      }
+    }
+
+    // Also run text search for tasks
     const taskRelevanceScore = sql<number>`
       CASE
         WHEN LOWER(${taskTable.title}) LIKE ${searchPattern} THEN 3
@@ -144,6 +212,7 @@ async function globalSearch(params: SearchParams): Promise<{
     const tasks = await taskQuery;
 
     for (const task of tasks) {
+      if (seenTaskIds.has(task.id)) continue;
       results.push({
         id: task.id,
         type: "task",

--- a/apps/web/src/hooks/queries/search/use-global-search.ts
+++ b/apps/web/src/hooks/queries/search/use-global-search.ts
@@ -19,7 +19,7 @@ function useGlobalSearch(params: SearchParams) {
   return useQuery({
     queryKey: ["search", params],
     queryFn: () => globalSearch(params),
-    enabled: !!params.q && params.q.length > 2,
+    enabled: !!params.q && params.q.length >= 1,
     staleTime: 1000 * 30, // 30 seconds
   });
 }

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/search.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/search.tsx
@@ -1,10 +1,12 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowLeft, Search } from "lucide-react";
-import { useState } from "react";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { ArrowLeft, Loader2, Search } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import WorkspaceLayout from "@/components/common/workspace-layout";
 import PageTitle from "@/components/page-title";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import useGlobalSearch from "@/hooks/queries/search/use-global-search";
+import { getPriorityIcon } from "@/lib/priority";
 
 export const Route = createFileRoute(
   "/_layout/_authenticated/dashboard/workspace/$workspaceId/search",
@@ -14,17 +16,40 @@ export const Route = createFileRoute(
 
 function SearchComponent() {
   const { workspaceId } = Route.useParams();
-  const [searchQuery, setSearchQuery] = useState("");
-  const [isSearching, setIsSearching] = useState(false);
+  const navigate = useNavigate();
+  const [searchInput, setSearchInput] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleSearch = async (query: string) => {
-    if (!query.trim()) return;
+  const { data, isLoading, isFetching } = useGlobalSearch({
+    q: debouncedQuery,
+    workspaceId,
+    type: "tasks",
+  });
 
-    setIsSearching(true);
-    setTimeout(() => {
-      setIsSearching(false);
-    }, 1000);
-  };
+  const handleInputChange = useCallback((value: string) => {
+    setSearchInput(value);
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    debounceRef.current = setTimeout(() => {
+      setDebouncedQuery(value.trim());
+    }, 300);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
+
+  const results = data?.results ?? [];
+  const hasQuery = debouncedQuery.length > 0;
+  const showLoading = hasQuery && (isLoading || isFetching);
 
   return (
     <>
@@ -45,46 +70,87 @@ function SearchComponent() {
             <div className="relative">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
               <Input
-                placeholder="Search projects, tasks, comments..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    handleSearch(searchQuery);
-                  }
-                }}
+                placeholder="Search tasks by title or short ID (e.g. DEP-23)..."
+                value={searchInput}
+                onChange={(e) => handleInputChange(e.target.value)}
                 className="pl-10 h-12 text-lg"
                 autoFocus
               />
-              <Button
-                onClick={() => handleSearch(searchQuery)}
-                disabled={!searchQuery.trim() || isSearching}
-                className="absolute right-2 top-1/2 transform -translate-y-1/2"
-                size="sm"
-              >
-                {isSearching ? "Searching..." : "Search"}
-              </Button>
+              {showLoading && (
+                <Loader2 className="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 animate-spin text-muted-foreground" />
+              )}
             </div>
             <p className="text-sm text-muted-foreground mt-2">
-              Search across all projects, tasks, and comments in this workspace
+              Search across all projects in this workspace. Use short IDs like
+              DEP-23 to find specific tasks.
             </p>
           </div>
 
-          {searchQuery ? (
+          {hasQuery ? (
             <div>
-              <h2 className="text-xl font-semibold mb-4">
-                Search Results for "{searchQuery}"
-              </h2>
-
-              {isSearching ? (
+              {showLoading && results.length === 0 ? (
                 <div className="flex items-center justify-center py-12">
                   <div className="text-center space-y-4">
-                    <div className="w-16 h-16 bg-muted rounded-lg animate-pulse mx-auto" />
-                    <div className="space-y-2">
-                      <div className="w-48 h-4 bg-muted rounded animate-pulse mx-auto" />
-                      <div className="w-64 h-3 bg-muted rounded animate-pulse mx-auto" />
-                    </div>
+                    <Loader2 className="w-8 h-8 animate-spin text-muted-foreground mx-auto" />
+                    <p className="text-sm text-muted-foreground">
+                      Searching...
+                    </p>
                   </div>
+                </div>
+              ) : results.length > 0 ? (
+                <div className="space-y-1">
+                  <p className="text-xs text-muted-foreground mb-3">
+                    {data?.totalCount ?? results.length} result
+                    {(data?.totalCount ?? results.length) !== 1 ? "s" : ""}{" "}
+                    found
+                  </p>
+                  {results.map((result) => (
+                    <button
+                      key={result.id}
+                      type="button"
+                      onClick={() => {
+                        if (result.type === "task" && result.projectId) {
+                          navigate({
+                            to: "/dashboard/workspace/$workspaceId/project/$projectId/board",
+                            params: {
+                              workspaceId,
+                              projectId: result.projectId,
+                            },
+                            search: { taskId: result.id },
+                          });
+                        }
+                      }}
+                      className="w-full flex items-center gap-3 px-4 py-3 rounded-lg border border-border bg-background hover:bg-accent/60 transition-colors text-left"
+                    >
+                      <div className="flex-shrink-0 first:[&_svg]:h-4 first:[&_svg]:w-4">
+                        {getPriorityIcon(result.priority ?? "")}
+                      </div>
+
+                      {result.projectSlug && result.taskNumber && (
+                        <span className="text-xs font-mono text-muted-foreground flex-shrink-0">
+                          {result.projectSlug}-{result.taskNumber}
+                        </span>
+                      )}
+
+                      <div className="flex-1 min-w-0">
+                        <span className="text-sm text-foreground truncate block">
+                          {result.title}
+                        </span>
+                      </div>
+
+                      {result.projectName && (
+                        <span className="text-xs text-muted-foreground flex-shrink-0">
+                          {result.projectName}
+                        </span>
+                      )}
+
+                      {result.status && (
+                        <span className="text-[10px] font-medium px-2 py-0.5 rounded border border-border bg-muted/55 text-muted-foreground flex-shrink-0">
+                          {result.status}
+                        </span>
+                      )}
+                    </button>
+                  ))}
                 </div>
               ) : (
                 <div className="text-center py-12">
@@ -101,7 +167,7 @@ function SearchComponent() {
               <Search className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
               <h2 className="text-xl font-semibold mb-2">Start Searching</h2>
               <p className="text-muted-foreground mb-6">
-                Enter a search term to find projects, tasks, and comments
+                Enter a search term to find tasks across all projects
               </p>
 
               <div className="space-y-2">
@@ -121,8 +187,8 @@ function SearchComponent() {
                       variant="outline"
                       size="sm"
                       onClick={() => {
-                        setSearchQuery(suggestion);
-                        handleSearch(suggestion);
+                        setSearchInput(suggestion);
+                        setDebouncedQuery(suggestion);
                       }}
                       className="text-xs"
                     >


### PR DESCRIPTION
## Summary
- Enhanced `globalSearch` controller to detect short-ID patterns like `DEP-23`
- When matched, looks up by project slug + task number with highest relevance score
- Full search page replacing the stub: debounced input, results with priority/status badges, click to navigate
- Lowered minimum query length from 3 to 1 to support short IDs

## Test plan
- [x] Search for "DEP-23" — verify it finds the exact task
- [x] Search for a task title — verify text search results appear
- [x] Click a search result — verify navigation to the task
- [x] Type quickly — verify debounce works (no excessive API calls)