### PR TITLE
Refresh label caches after creating a label

### DIFF
--- a/apps/web/src/hooks/mutations/label/use-create-label.ts
+++ b/apps/web/src/hooks/mutations/label/use-create-label.ts
@@ -1,9 +1,55 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import createLabel from "@/fetchers/label/create-label";
+import type { CreateLabelRequest } from "@/fetchers/label/create-label";
 
 function useCreateLabel() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: createLabel,
+    onSuccess: (createdLabel, variables: CreateLabelRequest) => {
+      queryClient.setQueryData(
+        ["labels", variables.workspaceId],
+        (existingLabels: Array<typeof createdLabel> | undefined) => {
+          if (!existingLabels) return [createdLabel];
+
+          const alreadyExists = existingLabels.some(
+            (label) => label.id === createdLabel.id,
+          );
+
+          return alreadyExists
+            ? existingLabels
+            : [...existingLabels, createdLabel];
+        },
+      );
+
+      if (createdLabel.taskId) {
+        queryClient.setQueryData(
+          ["labels", createdLabel.taskId],
+          (existingLabels: Array<typeof createdLabel> | undefined) => {
+            if (!existingLabels) return [createdLabel];
+
+            const alreadyExists = existingLabels.some(
+              (label) => label.id === createdLabel.id,
+            );
+
+            return alreadyExists
+              ? existingLabels
+              : [...existingLabels, createdLabel];
+          },
+        );
+      }
+
+      void queryClient.invalidateQueries({
+        queryKey: ["labels", variables.workspaceId],
+      });
+
+      if (createdLabel.taskId) {
+        void queryClient.invalidateQueries({
+          queryKey: ["labels", createdLabel.taskId],
+        });
+      }
+    },
   });
 }
 


### PR DESCRIPTION
## Description
Updates the shared label creation mutation so newly created labels appear immediately across issue/task label pickers without requiring a hard refresh. The mutation now seeds the workspace and task label query caches with the created label, then invalidates both queries to keep client state aligned with server data.

## Related Issue(s)
Fixes #1066

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Other (please describe): Reviewed the query flow and verified the fix path for both workspace-label and task-label caches.

## Screenshots (if applicable)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published