### PR TITLE
feat(auth): allow OIDC-only user registration

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -26,6 +26,10 @@ import { generateDemoName } from "./utils/generate-demo-name";
 
 config();
 
+const isRegistrationDisabled = process.env.DISABLE_REGISTRATION === "true";
+const isPasswordRegistrationDisabled =
+  process.env.DISABLE_PASSWORD_REGISTRATION === "true";
+
 const apiUrl = process.env.KANEO_API_URL || "http://localhost:1337";
 const clientUrl = process.env.KANEO_CLIENT_URL || "http://localhost:5173";
 const isHttps = apiUrl.startsWith("https://");
@@ -281,8 +285,15 @@ export const auth = betterAuth({
         return;
       }
 
-      const isRegistrationDisabled =
-        process.env.DISABLE_REGISTRATION === "true";
+      if (ctx.path === "/sign-up/email") {
+        if (isPasswordRegistrationDisabled) {
+          throw new APIError("FORBIDDEN", {
+            message:
+              "Password registration is currently disabled. Please use a configured social or OIDC sign-in method.",
+          });
+        }
+      }
+
       if (!isRegistrationDisabled) {
         return;
       }

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -123,6 +123,7 @@ export const commentSchema = v.object({
 
 export const configSchema = v.object({
   disableRegistration: v.nullable(v.boolean()),
+  disablePasswordRegistration: v.nullable(v.boolean()),
   isDemoMode: v.boolean(),
   hasSmtp: v.boolean(),
   hasGithubSignIn: v.nullable(v.boolean()),

--- a/apps/api/src/utils/get-settings.ts
+++ b/apps/api/src/utils/get-settings.ts
@@ -5,6 +5,8 @@ config();
 function getSettings() {
   return {
     disableRegistration: process.env.DISABLE_REGISTRATION === "true",
+    disablePasswordRegistration:
+      process.env.DISABLE_PASSWORD_REGISTRATION === "true",
     isDemoMode: process.env.DEMO_MODE === "true",
     hasSmtp:
       Boolean(process.env.SMTP_HOST) &&

--- a/apps/docs/core/installation/environment-variables.mdx
+++ b/apps/docs/core/installation/environment-variables.mdx
@@ -78,6 +78,7 @@ Name | Description | Default |
 --- | --- | --- |
 | `DISABLE_GUEST_ACCESS` | Disable anonymous/guest sign-in. When set to `true`, the guest access button will not be shown on sign-in and sign-up pages. | `false` |
 | `DISABLE_REGISTRATION` | Disable public user registration. When set to `true`, the sign-up option will not be shown on the sign-in page and new user creation is blocked (including via SSO). **Note:** Users with valid workspace invitations can still register even when this is enabled. | `false` | 
+| `DISABLE_PASSWORD_REGISTRATION` | Disable password-based account creation. When set to `true`, email/password sign-up is blocked, but social/OIDC registration remains available unless `DISABLE_REGISTRATION=true`. | `false` |
 
 ### GitHub SSO & Integration
 

--- a/apps/web/src/components/auth/toggle.tsx
+++ b/apps/web/src/components/auth/toggle.tsx
@@ -10,7 +10,7 @@ type AuthToggleProps = {
 export function AuthToggle({ message, linkText, linkTo }: AuthToggleProps) {
   const { data: config } = useGetConfig();
 
-  if (config?.disableRegistration) {
+  if (config?.disableRegistration || config?.disablePasswordRegistration) {
     return null;
   }
 

--- a/apps/web/src/routes/auth/sign-in.tsx
+++ b/apps/web/src/routes/auth/sign-in.tsx
@@ -355,16 +355,13 @@ function SignIn() {
               onSuccess={handleSignInSuccess}
             />
           )}
-          {config?.disableRegistration ? (
+          {config?.disableRegistration ||
+          config?.disablePasswordRegistration ? (
             <div className="text-center pt-4">
               <p className="text-sm text-muted-foreground">
-                Don't have an account?{" "}
-                <a
-                  href="/auth/sign-up"
-                  className="text-primary hover:underline font-medium"
-                >
-                  Sign up with invitation
-                </a>
+                {config?.disableRegistration
+                  ? "Public registration is disabled. Use an invitation to create an account."
+                  : "Password registration is disabled. Use a configured social or OIDC sign-in method to create an account."}
               </p>
             </div>
           ) : (

--- a/apps/web/src/routes/auth/sign-up.tsx
+++ b/apps/web/src/routes/auth/sign-up.tsx
@@ -63,7 +63,9 @@ function SignUp() {
             ? "Create an account to accept your invitation"
             : config?.disableRegistration
               ? "Registration requires an invitation"
-              : "Get started with your workspace"
+              : config?.disablePasswordRegistration
+                ? "Use social or OIDC sign-in to create an account"
+                : "Get started with your workspace"
         }
       >
         <div className="space-y-4 mt-6">
@@ -84,27 +86,42 @@ function SignUp() {
               </AlertDescription>
             </Alert>
           )}
-
-          {config?.hasGuestAccess && !invitationId && (
-            <>
-              <Button
-                variant="outline"
-                onClick={handleGuestAccess}
-                disabled={isGuestLoading}
-                className="w-full mb-0"
-                size="sm"
-              >
-                <UserCheck className="w-4 h-4 mr-2" />
-                {isGuestLoading ? "Signing in..." : "Continue as guest"}
-              </Button>
-              <div className="flex items-center gap-4 my-4">
-                <div className="flex-1 h-px bg-border" />
-                <span className="text-sm text-muted-foreground">or</span>
-                <div className="flex-1 h-px bg-border" />
-              </div>
-            </>
+          {config?.disablePasswordRegistration && (
+            <Alert>
+              <AlertDescription>
+                Password-based account creation is disabled. Use a configured
+                social or OIDC sign-in method from the sign-in page.
+              </AlertDescription>
+            </Alert>
           )}
-          <SignUpForm invitationId={invitationId} defaultEmail={prefillEmail} />
+
+          {config?.hasGuestAccess &&
+            !invitationId &&
+            !config?.disablePasswordRegistration && (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={handleGuestAccess}
+                  disabled={isGuestLoading}
+                  className="w-full mb-0"
+                  size="sm"
+                >
+                  <UserCheck className="w-4 h-4 mr-2" />
+                  {isGuestLoading ? "Signing in..." : "Continue as guest"}
+                </Button>
+                <div className="flex items-center gap-4 my-4">
+                  <div className="flex-1 h-px bg-border" />
+                  <span className="text-sm text-muted-foreground">or</span>
+                  <div className="flex-1 h-px bg-border" />
+                </div>
+              </>
+            )}
+          {!config?.disablePasswordRegistration && (
+            <SignUpForm
+              invitationId={invitationId}
+              defaultEmail={prefillEmail}
+            />
+          )}
           <AuthToggle
             message="Already have an account?"
             linkText="Sign in"

--- a/charts/kaneo/README.md
+++ b/charts/kaneo/README.md
@@ -133,6 +133,7 @@ helm uninstall my-kaneo
 | `api.env.existingSecret.name`       | Name of the existing secret containing the JWT access token                                                       | `""`                            |
 | `api.env.existingSecret.key`        | Key in the existing secret that contains the JWT access token                                                     | `jwt-access`                    |
 | `api.env.disableRegistration`       | Disable new user registration                                                                                      | `false`                         |
+| `api.env.disablePasswordRegistration` | Disable password-based account creation while keeping social/OIDC registration available                        | `false`                         |
 | `api.env.database.external.enabled` | Use external PostgreSQL database (set postgresql.enabled to false)                                               | `false`                         |
 | `api.env.database.external.host`    | External PostgreSQL host                                                                                          | `""`                            |
 | `api.env.database.external.port`    | External PostgreSQL port                                                                                          | `5432`                          |

--- a/charts/kaneo/templates/deployment.yaml
+++ b/charts/kaneo/templates/deployment.yaml
@@ -88,6 +88,8 @@ spec:
               {{- end }}
             - name: DISABLE_REGISTRATION
               value: {{ .Values.api.env.disableRegistration | quote }}
+            - name: DISABLE_PASSWORD_REGISTRATION
+              value: {{ .Values.api.env.disablePasswordRegistration | quote }}
           livenessProbe:
             {{- toYaml .Values.api.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/kaneo/values.yaml
+++ b/charts/kaneo/values.yaml
@@ -87,6 +87,7 @@ api:
       name: ""
       key: auth-secret
     disableRegistration: false
+    disablePasswordRegistration: false
     # Database configuration
     database:
       # Use external PostgreSQL (set postgresql.enabled to false)


### PR DESCRIPTION
## Description
Adds support for OIDC-only user registration by introducing `DISABLE_PASSWORD_REGISTRATION`.

With this change:
- `DISABLE_REGISTRATION=true` keeps the existing behavior and blocks all new public registrations, including SSO/OIDC, unless the user has a valid invitation.
- `DISABLE_PASSWORD_REGISTRATION=true` blocks only email/password sign-up while still allowing new users to register through configured social/OIDC providers.

The PR also updates the auth UI and deployment/docs surfaces so the new behavior is configurable and visible to users.

## Related Issue(s)
Adds/Fixes #1042

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Other (please describe): API build verification and web typecheck attempted

Manual/API verification performed:
- Verified API auth middleware blocks `/sign-up/email` when `DISABLE_PASSWORD_REGISTRATION=true`
- Verified `DISABLE_REGISTRATION` behavior remains unchanged for full registration disablement
- Verified config surface now exposes `disablePasswordRegistration`
- Verified docs and Helm chart values/templates include the new environment variable
- Verified `pnpm --filter @kaneo/api build` passes

Note:
- `pnpm --filter @kaneo/web typecheck` currently fails due to pre-existing unrelated type errors in the web app
- Commit hooks also report a pre-existing formatting issue in `scripts/setup-env.mjs`

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
New environment variable:
- `DISABLE_PASSWORD_REGISTRATION=true`

Recommended manual verification:
1. Set `DISABLE_REGISTRATION=false` and `DISABLE_PASSWORD_REGISTRATION=true`
2. Confirm `/auth/sign-up` no longer allows password-based account creation
3. Confirm configured OIDC/social sign-in buttons still appear on `/auth/sign-in`
4. Sign in with a new OIDC user and verify the account is created successfully
5. Confirm setting `DISABLE_REGISTRATION=true` still blocks all new public registrations as before