### PR TITLE
fix: Subtasks default priority

### DIFF
--- a/apps/web/src/components/task/task-subtasks.tsx
+++ b/apps/web/src/components/task/task-subtasks.tsx
@@ -224,7 +224,7 @@ export default function TaskSubtasks({
         description: "",
         projectId,
         status: "to-do",
-        priority: "low",
+        priority: "no-priority",
       });
 
       await createRelation.mutateAsync({


### PR DESCRIPTION
## Description
Change the subtasks default priority to from `low` to `no priority` to match normal task creation

## Related Issue(s)
N/A

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [X] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)
N/A

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
N/A