### PR TITLE
fix(ui): make subtasks appear after creation without refresh

### DIFF
--- a/apps/web/src/hooks/mutations/task/use-create-task.ts
+++ b/apps/web/src/hooks/mutations/task/use-create-task.ts
@@ -1,9 +1,11 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import createTask, {
   type CreateTaskRequest,
 } from "@/fetchers/task/create-task";
 
 function useCreateTask() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: ({
       title,
@@ -23,6 +25,11 @@ function useCreateTask() {
         dueDate ? new Date(dueDate) : undefined,
         priority,
       ),
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: ["tasks", variables.projectId],
+      });
+    },
   });
 }
 


### PR DESCRIPTION
## Description

Subtasks are created with `useCreateTask` plus a task relation, but the board/list project data comes from the `["tasks", projectId]` query synced into Zustand. Unlike the create-task modal (which updates the store via `syncTaskIntoProject`), subtask creation never invalidated that query, so new subtask cards stayed missing until a full reload or the existing 30s refetch on `useGetTasks`.

This PR adds `onSuccess` to `useCreateTask` to invalidate `["tasks", variables.projectId]` after a successful create, so the board refetches and updates as soon as any task is created—including subtasks.

## Related Issue(s)

Fixes #1081

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Other (please describe):

- `pnpm --filter @kaneo/web exec tsc --noEmit`
- `pnpm biome check` on the changed file
- `pnpm --filter @kaneo/web build`

Manual: open project board → open a task → add subtasks → close task sheet; subtask cards should appear in columns without refresh (after tasks query refetch).

## Screenshots (if applicable)

https://github.com/user-attachments/assets/eeddf5b2-0a0c-4d03-b40e-9632203f6936


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

`useCreateTask` is only used by the create-task modal and task subtasks; invalidating on create aligns with other task mutations (e.g. update/delete) that already invalidate `["tasks", projectId]`. The create modal still uses `syncTaskIntoProject`; the refetch from invalidation keeps client state consistent with the server.