### PR TITLE
fix: fix public project access after getTasks response shape change

### DIFF
--- a/apps/api/src/project/controllers/get-public-project.ts
+++ b/apps/api/src/project/controllers/get-public-project.ts
@@ -2,19 +2,19 @@ import { HTTPException } from "hono/http-exception";
 import getTasks from "../../task/controllers/get-tasks";
 
 export async function getPublicProject(id: string) {
-  const project = await getTasks(id);
+  const result = await getTasks(id);
 
-  if (!project) {
+  if (!result.data) {
     throw new HTTPException(404, {
       message: "Project not found",
     });
   }
 
-  if (!project.isPublic) {
+  if (!result.data.isPublic) {
     throw new HTTPException(403, {
       message: "Project is not public",
     });
   }
 
-  return project;
+  return result.data;
 }


### PR DESCRIPTION
## Summary

- `getPublicProject` accesses `result.isPublic` directly, but `getTasks` now returns `{ data: {..., isPublic}, pagination: {...} }`, so `result.isPublic` is always `undefined` — causing **all public projects to return 403 Forbidden**
- Fix: access `result.data.isPublic` and return `result.data` instead of the full response wrapper

## Test plan

- [x] Mark a project as public — verify it loads correctly (no 403)
- [x] Verify public project board renders with all columns and tasks
- [x] Full monorepo build passes (`pnpm build`)