### PR TITLE
fix: mark optional Organization fields as nullable in OpenAPI spec

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -42,6 +42,7 @@ import { migrateWorkspaceUserEmail } from "./utils/migrate-workspace-user-email"
 import {
   dedupeOperationIds,
   ensureOperationSummaries,
+  markOptionalSchemaFieldsNullable,
   mergeOpenApiSpecs,
   normalizeApiServerUrl,
   normalizeEmptyRequiredArrays,
@@ -304,9 +305,11 @@ api.get("/openapi", async (c) => {
   return c.json(
     ensureOperationSummaries(
       dedupeOperationIds(
-        normalizeNullableSchemasForOpenApi30(
-          normalizeEmptyRequiredArrays(
-            mergeOpenApiSpecs(honoSpec, normalizedAuthSpec),
+        markOptionalSchemaFieldsNullable(
+          normalizeNullableSchemasForOpenApi30(
+            normalizeEmptyRequiredArrays(
+              mergeOpenApiSpecs(honoSpec, normalizedAuthSpec),
+            ),
           ),
         ),
       ),

--- a/apps/api/src/utils/openapi-spec.ts
+++ b/apps/api/src/utils/openapi-spec.ts
@@ -410,6 +410,33 @@ export const normalizeEmptyRequiredArrays = (spec: Record<string, unknown>) => {
   return spec;
 };
 
+export const markOptionalSchemaFieldsNullable = (
+  spec: Record<string, unknown>,
+) => {
+  const schemas = ((spec as { components?: { schemas?: unknown } }).components
+    ?.schemas || {}) as Record<string, unknown>;
+
+  for (const schema of Object.values(schemas)) {
+    if (!isPlainObject(schema)) continue;
+
+    const properties = schema.properties as Record<string, unknown> | undefined;
+    if (!isPlainObject(properties)) continue;
+
+    const required = Array.isArray(schema.required) ? schema.required : [];
+
+    for (const [name, prop] of Object.entries(properties)) {
+      if (required.includes(name)) continue;
+      if (!isPlainObject(prop)) continue;
+      if (prop.nullable === true) continue;
+      if (typeof prop.type !== "string") continue;
+
+      prop.nullable = true;
+    }
+  }
+
+  return spec;
+};
+
 export const ensureOperationSummaries = (spec: Record<string, unknown>) => {
   const paths = ((spec as { paths?: unknown }).paths || {}) as Record<
     string,


### PR DESCRIPTION
## Summary

The OpenAPI spec declares `logo`, `metadata`, and `description` as non-nullable strings in the Organization (Workspace) schema, but the API actually returns `null` for these fields when they are not set. This breaks OpenAPI client generators that validate responses against the spec.

The root cause is Better Auth's OpenAPI generator — `getFieldSchema()` does not emit `nullable: true` for fields with `required: false`. Since we can't patch the dependency directly, this adds a `markOptionalSchemaFieldsNullable` post-processor to the existing OpenAPI spec pipeline that marks non-required properties as `nullable: true` in component schemas.

## Test plan

- [x] Check `/api/openapi` — verify `Organization`/`Workspace` schema has `nullable: true` on `logo`, `metadata`, `description`
- [x] Verify required fields (like `id`, `name`, `createdAt`) are NOT marked nullable
- [x] Run an OpenAPI client generator against the spec — should validate without errors
- [x] Full monorepo build passes (`pnpm build`)

Closes #1087