### PR TITLE
fix: validate task status and priority inputs across all API endpoints

### DIFF
--- a/apps/api/src/column/controllers/create-column.ts
+++ b/apps/api/src/column/controllers/create-column.ts
@@ -2,6 +2,7 @@ import { eq, sql } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import db from "../../database";
 import { columnTable } from "../../database/schema";
+import { VIRTUAL_STATUSES } from "../../task/validate-task-fields";
 
 function toSlug(name: string): string {
   return name
@@ -25,6 +26,18 @@ async function createColumn({
   isFinal?: boolean;
 }) {
   const slug = toSlug(name);
+
+  if (!slug) {
+    throw new HTTPException(400, {
+      message: "Column name must contain at least one alphanumeric character",
+    });
+  }
+
+  if ((VIRTUAL_STATUSES as readonly string[]).includes(slug)) {
+    throw new HTTPException(409, {
+      message: `Column slug "${slug}" is reserved for virtual task statuses`,
+    });
+  }
 
   const existing = await db
     .select({ id: columnTable.id })

--- a/apps/api/src/task/controllers/bulk-update-tasks.ts
+++ b/apps/api/src/task/controllers/bulk-update-tasks.ts
@@ -8,6 +8,10 @@ import {
   taskTable,
   workspaceUserTable,
 } from "../../database/schema";
+import {
+  assertValidPriority,
+  assertValidTaskStatus,
+} from "../validate-task-fields";
 
 type BulkOperation =
   | "updateStatus"
@@ -89,6 +93,8 @@ async function bulkUpdateTasks({
       const projectIds = [...new Set(tasks.map((t) => t.projectId))];
 
       for (const projectId of projectIds) {
+        await assertValidTaskStatus(value, projectId);
+
         const column = await db.query.columnTable.findFirst({
           where: and(
             eq(columnTable.projectId, projectId),
@@ -114,6 +120,8 @@ async function bulkUpdateTasks({
       if (!value) {
         throw new HTTPException(400, { message: "Priority value is required" });
       }
+      assertValidPriority(value);
+
       const result = await db
         .update(taskTable)
         .set({ priority: value })
@@ -193,13 +201,29 @@ async function bulkUpdateTasks({
     }
 
     case "updateDueDate": {
+      let parsedDate: Date | null = null;
+      if (value) {
+        parsedDate = new Date(value);
+        if (Number.isNaN(parsedDate.getTime())) {
+          throw new HTTPException(400, {
+            message: `Invalid date value "${value}"`,
+          });
+        }
+      }
+
       const result = await db
         .update(taskTable)
-        .set({ dueDate: value ? new Date(value) : null })
+        .set({ dueDate: parsedDate })
         .where(inArray(taskTable.id, foundIds));
 
       updatedCount = result.rowCount ?? foundIds.length;
       break;
+    }
+
+    default: {
+      throw new HTTPException(400, {
+        message: `Unknown operation "${operation}"`,
+      });
     }
   }
 

--- a/apps/api/src/task/controllers/create-task.ts
+++ b/apps/api/src/task/controllers/create-task.ts
@@ -3,6 +3,7 @@ import { HTTPException } from "hono/http-exception";
 import db from "../../database";
 import { columnTable, taskTable, userTable } from "../../database/schema";
 import { publishEvent } from "../../events";
+import { assertValidTaskStatus } from "../validate-task-fields";
 import getNextTaskNumber from "./get-next-task-number";
 
 async function createTask({
@@ -24,6 +25,11 @@ async function createTask({
   description?: string;
   priority?: string;
 }) {
+  const resolvedStatus = status || "to-do";
+  const resolvedPriority = priority || "no-priority";
+
+  await assertValidTaskStatus(resolvedStatus, projectId);
+
   const [assignee] = await db
     .select({ name: userTable.name })
     .from(userTable)
@@ -34,7 +40,7 @@ async function createTask({
   const column = await db.query.columnTable.findFirst({
     where: and(
       eq(columnTable.projectId, projectId),
-      eq(columnTable.slug, status || "to-do"),
+      eq(columnTable.slug, resolvedStatus),
     ),
   });
 
@@ -46,7 +52,7 @@ async function createTask({
         eq(taskTable.projectId, projectId),
         column?.id
           ? eq(taskTable.columnId, column.id)
-          : eq(taskTable.status, status || "to-do"),
+          : eq(taskTable.status, resolvedStatus),
       ),
     );
 
@@ -58,12 +64,12 @@ async function createTask({
       projectId,
       userId: userId || null,
       title: title || "",
-      status: status || "",
+      status: resolvedStatus,
       columnId: column?.id ?? null,
       startDate: startDate || null,
       dueDate: dueDate || null,
       description: description || "",
-      priority: priority || "",
+      priority: resolvedPriority,
       number: nextTaskNumber + 1,
       position: nextPosition,
     })

--- a/apps/api/src/task/controllers/import-tasks.ts
+++ b/apps/api/src/task/controllers/import-tasks.ts
@@ -3,6 +3,11 @@ import { HTTPException } from "hono/http-exception";
 import db from "../../database";
 import { columnTable, projectTable, taskTable } from "../../database/schema";
 import { publishEvent } from "../../events";
+import {
+  coercePriority,
+  coerceStatus,
+  getValidTaskStatuses,
+} from "../validate-task-fields";
 import getNextTaskNumber from "./get-next-task-number";
 
 type ImportTask = {
@@ -28,15 +33,25 @@ async function importTasks(projectId: string, tasksToImport: ImportTask[]) {
 
   const nextTaskNumber = await getNextTaskNumber(projectId);
   let taskNumber = nextTaskNumber;
+  const validStatuses = await getValidTaskStatuses(projectId);
 
   const results = [];
 
   for (const taskData of tasksToImport) {
     try {
+      const { status, warning: statusWarning } = coerceStatus(
+        taskData.status,
+        validStatuses,
+      );
+      const { priority, warning: priorityWarning } = coercePriority(
+        taskData.priority || "low",
+      );
+      const warnings = [statusWarning, priorityWarning].filter(Boolean);
+
       const column = await db.query.columnTable.findFirst({
         where: and(
           eq(columnTable.projectId, projectId),
-          eq(columnTable.slug, taskData.status),
+          eq(columnTable.slug, status),
         ),
       });
 
@@ -46,12 +61,12 @@ async function importTasks(projectId: string, tasksToImport: ImportTask[]) {
           projectId,
           userId: taskData.userId || null,
           title: taskData.title,
-          status: taskData.status,
+          status,
           columnId: column?.id ?? null,
           startDate: taskData.startDate ? new Date(taskData.startDate) : null,
           dueDate: taskData.dueDate ? new Date(taskData.dueDate) : null,
           description: taskData.description || "",
-          priority: taskData.priority || "low",
+          priority,
           number: ++taskNumber,
         })
         .returning();
@@ -67,6 +82,7 @@ async function importTasks(projectId: string, tasksToImport: ImportTask[]) {
         results.push({
           success: true,
           task: createdTask,
+          ...(warnings.length > 0 && { warnings }),
         });
       } else {
         results.push({
@@ -76,6 +92,9 @@ async function importTasks(projectId: string, tasksToImport: ImportTask[]) {
         });
       }
     } catch (error) {
+      if (error instanceof HTTPException) {
+        throw error;
+      }
       results.push({
         success: false,
         error: error instanceof Error ? error.message : "Unknown error",

--- a/apps/api/src/task/controllers/update-task-status.ts
+++ b/apps/api/src/task/controllers/update-task-status.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import db from "../../database";
 import { columnTable, taskTable } from "../../database/schema";
+import { assertValidTaskStatus } from "../validate-task-fields";
 
 async function updateTaskStatus({
   id,
@@ -19,6 +20,8 @@ async function updateTaskStatus({
       message: "Task not found",
     });
   }
+
+  await assertValidTaskStatus(status, existingTask.projectId);
 
   const column = await db.query.columnTable.findFirst({
     where: and(

--- a/apps/api/src/task/controllers/update-task.ts
+++ b/apps/api/src/task/controllers/update-task.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import db from "../../database";
 import { columnTable, taskTable } from "../../database/schema";
+import { assertValidTaskStatus } from "../validate-task-fields";
 
 async function updateTask(
   id: string,
@@ -24,6 +25,8 @@ async function updateTask(
       message: "Task not found",
     });
   }
+
+  await assertValidTaskStatus(status, projectId);
 
   const column = await db.query.columnTable.findFirst({
     where: and(

--- a/apps/api/src/task/index.ts
+++ b/apps/api/src/task/index.ts
@@ -35,6 +35,7 @@ import updateTaskDueDate from "./controllers/update-task-due-date";
 import updateTaskPriority from "./controllers/update-task-priority";
 import updateTaskStatus from "./controllers/update-task-status";
 import updateTaskTitle from "./controllers/update-task-title";
+import { VALID_PRIORITIES } from "./validate-task-fields";
 
 const task = new Hono<{
   Variables: {
@@ -180,7 +181,7 @@ const task = new Hono<{
         description: v.string(),
         startDate: v.optional(v.string()),
         dueDate: v.optional(v.string()),
-        priority: v.string(),
+        priority: v.picklist(VALID_PRIORITIES),
         status: v.string(),
         userId: v.optional(v.string()),
       }),
@@ -260,7 +261,7 @@ const task = new Hono<{
         description: v.string(),
         startDate: v.optional(v.string()),
         dueDate: v.optional(v.string()),
-        priority: v.string(),
+        priority: v.picklist(VALID_PRIORITIES),
         status: v.string(),
         projectId: v.string(),
         position: v.number(),
@@ -473,7 +474,7 @@ const task = new Hono<{
       },
     }),
     validator("param", v.object({ id: v.string() })),
-    validator("json", v.object({ priority: v.string() })),
+    validator("json", v.object({ priority: v.picklist(VALID_PRIORITIES) })),
     workspaceAccess.fromTask(),
     async (c) => {
       const { id } = c.req.valid("param");

--- a/apps/api/src/task/validate-task-fields.ts
+++ b/apps/api/src/task/validate-task-fields.ts
@@ -1,0 +1,73 @@
+import { asc, eq } from "drizzle-orm";
+import { HTTPException } from "hono/http-exception";
+import db from "../database";
+import { columnTable } from "../database/schema";
+
+export const VALID_PRIORITIES = [
+  "no-priority",
+  "low",
+  "medium",
+  "high",
+  "urgent",
+] as const;
+
+export const VIRTUAL_STATUSES = ["planned", "archived"] as const;
+
+export function assertValidPriority(priority: string): void {
+  if (!(VALID_PRIORITIES as readonly string[]).includes(priority)) {
+    throw new HTTPException(400, {
+      message: `Invalid priority "${priority}". Valid values: ${VALID_PRIORITIES.join(", ")}`,
+    });
+  }
+}
+
+export async function getValidTaskStatuses(
+  projectId: string,
+): Promise<string[]> {
+  const columns = await db
+    .select({ slug: columnTable.slug })
+    .from(columnTable)
+    .where(eq(columnTable.projectId, projectId))
+    .orderBy(asc(columnTable.position));
+
+  return [...columns.map((c) => c.slug), ...VIRTUAL_STATUSES];
+}
+
+export async function assertValidTaskStatus(
+  status: string,
+  projectId: string,
+): Promise<void> {
+  const validStatuses = await getValidTaskStatuses(projectId);
+
+  if (!validStatuses.includes(status)) {
+    throw new HTTPException(400, {
+      message: `Invalid status "${status}". Valid statuses for this project: ${validStatuses.join(", ")}`,
+    });
+  }
+}
+
+export function coerceStatus(
+  status: string,
+  validStatuses: string[],
+): { status: string; warning?: string } {
+  if (validStatuses.includes(status)) {
+    return { status };
+  }
+  return {
+    status: "planned",
+    warning: `Unknown status "${status}" mapped to "planned"`,
+  };
+}
+
+export function coercePriority(priority: string): {
+  priority: string;
+  warning?: string;
+} {
+  if ((VALID_PRIORITIES as readonly string[]).includes(priority)) {
+    return { priority };
+  }
+  return {
+    priority: "no-priority",
+    warning: `Unknown priority "${priority}" mapped to "no-priority"`,
+  };
+}


### PR DESCRIPTION
## Summary

Tasks become invisible when their `status` field is set to a value that doesn't match any column slug or the virtual statuses `"planned"`/`"archived"`. The API accepts arbitrary strings for `status` and `priority` on all write endpoints, allowing external consumers (CLI tools, LLM agents, integrations) to create tasks that silently vanish from all UI views.

### Root cause

The database stores `status` and `priority` as free-text columns. The response schema in `schemas.ts` declares `priority` as a `picklist`, but all input validators use `v.string()` — no constraint whatsoever. For `status`, valid values are dynamic per-project (column slugs + virtual statuses), so validation must happen at the controller level.

### Changes

**New file: `apps/api/src/task/validate-task-fields.ts`**
- `VALID_PRIORITIES` / `VIRTUAL_STATUSES` constants
- `assertValidPriority(priority)` — throws 400 if invalid
- `assertValidTaskStatus(status, projectId)` — validates against project column slugs + virtual statuses
- `coerceStatus()` / `coercePriority()` — lenient coercion for import (maps unknown values to defaults with warnings)

**Priority validation (static, Valibot level):**
- `POST /:projectId` (create), `PUT /:id` (update), `PUT /priority/:id` — `v.string()` replaced with `v.picklist(VALID_PRIORITIES)`

**Status validation (dynamic, controller level):**
- `create-task.ts`, `update-task.ts`, `update-task-status.ts` — add `assertValidTaskStatus` call
- `bulk-update-tasks.ts` — validate in `updateStatus` (per-project) and `updatePriority` cases

**Import endpoint (lenient):**
- Coerces unknown statuses to `"planned"` and unknown priorities to `"no-priority"` with per-task warnings
- Re-throws `HTTPException` in catch block instead of swallowing infrastructure errors

**Column slug guards:**
- Prevent creating columns with reserved slugs (`"planned"`, `"archived"`)
- Prevent creating columns with empty slugs (from names like `"!!!"`)

**Additional fixes (pre-existing):**
- Fix `create-task.ts` writing empty string for status/priority when falsy — now uses resolved fallback values consistently
- Fix bulk `updateDueDate` silently accepting invalid date strings (`new Date("garbage")`)
- Add `default` case to bulk operations switch statement

## Test plan

- [x] Create task with invalid status (e.g., `"backlog"`) via API — should return 400
- [x] Create task with invalid priority (e.g., `"critical"`) via API — should return 400
- [x] Create task with valid status/priority from frontend — should work as before
- [x] Import tasks with unknown statuses — should coerce to "planned" with warnings
- [x] Create column named "Planned" or "Archived" — should return 409
- [x] Create column named "!!!" — should return 400
- [x] Bulk update with invalid status — should return 400
- [x] Bulk update due date with invalid date string — should return 400
- [x] Full monorepo build passes (`pnpm build`)