### PR TITLE
fix(web): stable list keys and Husky Biome version

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
-pnpm dlx @biomejs/biome@2.0.6 ci .
+pnpm exec biome ci .
 pnpm run build

--- a/apps/web/src/components/keyboard-shortcuts-help.tsx
+++ b/apps/web/src/components/keyboard-shortcuts-help.tsx
@@ -171,9 +171,9 @@ export function KeyboardShortcutsHelp() {
                   {category.title}
                 </h3>
                 <div className="space-y-1">
-                  {category.shortcuts.map((shortcut, index) => (
+                  {category.shortcuts.map((shortcut) => (
                     <div
-                      key={`${category.title}-${index}`}
+                      key={`${category.title}-${shortcut.description}-${shortcut.keys.join("+")}`}
                       className="flex items-center justify-between py-1.5 px-2 rounded-md hover:bg-muted/50"
                     >
                       <span className="text-xs">{shortcut.description}</span>

--- a/apps/web/src/components/project/repository-browser-modal.tsx
+++ b/apps/web/src/components/project/repository-browser-modal.tsx
@@ -133,9 +133,9 @@ export function RepositoryBrowserModal({
         <div className="flex-1 overflow-y-auto min-h-[300px]">
           {isLoading && (
             <div className="px-6 py-4 space-y-3">
-              {Array.from({ length: 5 }, (_, i) => (
+              {[0, 1, 2, 3, 4].map((slot) => (
                 <div
-                  key={`loading-skeleton-repo-${i}-${Date.now()}`}
+                  key={`loading-skeleton-repo-${slot}`}
                   className="p-4 border border-border rounded-md bg-sidebar animate-pulse"
                 >
                   <div className="flex items-center gap-3">

--- a/apps/web/src/components/ui/error-display.tsx
+++ b/apps/web/src/components/ui/error-display.tsx
@@ -62,11 +62,8 @@ export function ErrorDisplay({
                 Troubleshooting steps:
               </h4>
               <ul className="text-xs text-muted-foreground space-y-1">
-                {troubleshootingSteps.map((step, index) => (
-                  <li
-                    key={`step-${index}-${step.slice(0, 10)}`}
-                    className="flex items-start gap-2"
-                  >
+                {troubleshootingSteps.map((step) => (
+                  <li key={step} className="flex items-start gap-2">
                     <span className="text-muted-foreground mt-0.5">•</span>
                     <span>{step}</span>
                   </li>


### PR DESCRIPTION
## Description

Resolves Biome lint rule noArrayIndexKey in the web app by using stable React keys:

- **keyboard-shortcuts-help.tsx**: keys from category title, description, and joined key chords.
- **repository-browser-modal.tsx**: loading skeletons use fixed slots 0–4 instead of index-based keys; removed Date.now() from keys so skeletons are not remounted every render.
- **error-display.tsx**: troubleshooting list items use the step text as the key.

Aligns the Husky pre-commit Biome command with the repo: run **pnpm exec biome ci .** instead of pinning Biome 2.0.6 via dlx, so the CLI matches the devDependency and biome.json schema.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Other (please describe): pnpm lint and pnpm exec biome ci . pass locally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Pre-commit previously pinned Biome 2.0.6 while the project and biome.json use 2.4.x, which caused schema/version mismatch errors during git commit. Using pnpm exec biome fixes that drift.