### PR TITLE
fix(api): dedupe task numbers before unique constraint in migration 0021

### DIFF
--- a/apps/api/drizzle/0021_pretty_smiling_tiger.sql
+++ b/apps/api/drizzle/0021_pretty_smiling_tiger.sql
@@ -4,4 +4,36 @@ CREATE INDEX "activity_task_id_idx" ON "activity" USING btree ("task_id");--> st
 CREATE INDEX "label_task_id_idx" ON "label" USING btree ("task_id");--> statement-breakpoint
 CREATE INDEX "label_workspace_id_idx" ON "label" USING btree ("workspace_id");--> statement-breakpoint
 CREATE INDEX "task_projectId_idx" ON "task" USING btree ("project_id");--> statement-breakpoint
+WITH numbered AS (
+	SELECT
+		id,
+		project_id,
+		number,
+		ROW_NUMBER() OVER (
+			PARTITION BY project_id, number
+			ORDER BY created_at ASC, id ASC
+		) AS dup_rank
+	FROM task
+),
+to_reassign AS (
+	SELECT n.id, n.project_id
+	FROM numbered n
+	WHERE n.dup_rank > 1
+),
+max_per_project AS (
+	SELECT project_id, MAX(number) AS max_num
+	FROM task
+	GROUP BY project_id
+),
+new_numbers AS (
+	SELECT
+		tr.id,
+		(mpp.max_num + ROW_NUMBER() OVER (PARTITION BY tr.project_id ORDER BY tr.id))::integer AS new_number
+	FROM to_reassign tr
+	JOIN max_per_project mpp ON mpp.project_id = tr.project_id
+)
+UPDATE task t
+SET number = nn.new_number
+FROM new_numbers nn
+WHERE t.id = nn.id;--> statement-breakpoint
 ALTER TABLE "task" ADD CONSTRAINT "task_project_number_unique" UNIQUE("project_id","number");


### PR DESCRIPTION
## Description

Migration `0021_pretty_smiling_tiger` adds `UNIQUE (project_id, number)` on `task`. Existing databases can already contain duplicate task numbers per project (allowed before this constraint). This PR updates that migration to **renumber duplicate rows** before adding the constraint: for each `(project_id, number)` group, the first task (by `created_at`, then `id`) keeps its number; additional rows get new numbers after the current per-project `MAX(number)`.

## Related Issue(s)

<!-- No linked issue; addresses failed upgrades to v2.5.0 when duplicates exist. -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

`pnpm --filter @kaneo/api build` succeeds. Migration SQL reviewed for PostgreSQL semantics.

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Note:** This edits migration `0021` in place. Instances that **already applied** the previous `0021` successfully will not re-run it. Instances that **failed** on `ADD CONSTRAINT` (transaction rolled back) will retry with the updated SQL. Anyone who manually partially applied migration steps outside a transaction may need manual cleanup.
