### PR TITLE
fix: read workspace description from organization field

### DIFF
--- a/apps/web/src/routes/_layout/_authenticated/dashboard/settings/workspace/general.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/settings/workspace/general.tsx
@@ -56,6 +56,29 @@ function normalizeWorkspaceValues(
   };
 }
 
+/** Better Auth persists description as an organization additional field (DB column), not only inside metadata. */
+function getWorkspaceDescription(
+  workspace:
+    | { description?: string | null; metadata?: unknown }
+    | null
+    | undefined,
+): string {
+  if (!workspace) return "";
+  if (typeof workspace.description === "string") {
+    return workspace.description;
+  }
+  if (
+    typeof workspace.metadata === "object" &&
+    workspace.metadata &&
+    "description" in workspace.metadata
+  ) {
+    return String(
+      (workspace.metadata as { description?: unknown }).description ?? "",
+    );
+  }
+  return "";
+}
+
 function RouteComponent() {
   const { t } = useTranslation();
   const workspaceSchema = useMemo(
@@ -82,12 +105,7 @@ function RouteComponent() {
   const { mutateAsync: updateWorkspace } = useUpdateWorkspace();
   const { mutateAsync: deleteWorkspace, isPending: isDeleting } =
     useDeleteWorkspace();
-  const workspaceDescription =
-    typeof workspace?.metadata === "object" &&
-    workspace?.metadata &&
-    "description" in workspace.metadata
-      ? String(workspace.metadata.description ?? "")
-      : "";
+  const workspaceDescription = getWorkspaceDescription(workspace);
 
   const workspaceForm = useForm<WorkspaceFormValues>({
     resolver: standardSchemaResolver(workspaceSchema),


### PR DESCRIPTION
## Description

Workspace settings read the description only from `metadata.description`, but Better Auth stores it as an organization additional field on the workspace row (`description` column). After a successful save, React Query refetched the org and the form synced from empty `metadata.description`, which cleared the field and looked like a refresh even though the update succeeded.

This PR adds `getWorkspaceDescription()` to prefer `workspace.description`, with a fallback to `metadata.description` for compatibility.

## Related Issue(s)

Fixes #1130

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced workspace description retrieval to ensure descriptions are properly loaded and displayed in workspace settings, with support for multiple data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->