### PR TITLE
fix: show all board columns on public project link

### DIFF
--- a/apps/web/src/components/public-project/kanban-view.tsx
+++ b/apps/web/src/components/public-project/kanban-view.tsx
@@ -1,15 +1,7 @@
-import type { LucideIcon } from "lucide-react";
-import { DEFAULT_COLUMNS } from "@/constants/columns";
+import { getColumnIcon } from "@/lib/column";
 import type { ProjectWithTasks } from "@/types/project";
 import type Task from "@/types/task";
 import { PublicTaskCard } from "./task-card";
-
-type Column = {
-  id: string;
-  name: string;
-  icon: LucideIcon;
-  tasks: Task[];
-};
 
 type PublicKanbanViewProps = {
   project: ProjectWithTasks;
@@ -20,16 +12,12 @@ export function PublicKanbanView({
   project,
   onTaskClick,
 }: PublicKanbanViewProps) {
-  const columns: Column[] = DEFAULT_COLUMNS.map((column) => ({
-    ...column,
-    tasks: project.columns?.find((col) => col.id === column.id)?.tasks || [],
-  }));
+  const columns = project.columns ?? [];
 
   return (
     <div className="flex-1 min-h-0 overflow-x-auto [-webkit-overflow-scrolling:touch]">
       <div className="flex gap-3 p-3 h-full min-w-max transition-all duration-200 ease-out">
         {columns.map((column) => {
-          const IconComponent = column.icon;
           return (
             <div
               key={column.id}
@@ -39,7 +27,7 @@ export function PublicKanbanView({
                 <div className="p-2 shrink-0">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
-                      <IconComponent className="w-4 h-4 text-muted-foreground" />
+                      {getColumnIcon(column.id, column.isFinal)}
                       <h3 className="font-medium text-foreground">
                         {column.name}
                       </h3>
@@ -65,7 +53,7 @@ export function PublicKanbanView({
                   {column.tasks.length === 0 && (
                     <div className="text-center text-sm text-muted-foreground py-12 px-4">
                       <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center mx-auto mb-2">
-                        <IconComponent className="w-4 h-4" />
+                        {getColumnIcon(column.id, column.isFinal)}
                       </div>
                       No tasks in {column.name.toLowerCase()}
                     </div>

--- a/apps/web/src/components/public-project/list-view.tsx
+++ b/apps/web/src/components/public-project/list-view.tsx
@@ -1,15 +1,7 @@
-import type { LucideIcon } from "lucide-react";
-import { DEFAULT_COLUMNS } from "@/constants/columns";
+import { getColumnIcon } from "@/lib/column";
 import type { ProjectWithTasks } from "@/types/project";
 import type Task from "@/types/task";
 import { PublicTaskRow } from "./task-row";
-
-type Column = {
-  id: string;
-  name: string;
-  icon: LucideIcon;
-  tasks: Task[];
-};
 
 type PublicListViewProps = {
   project: ProjectWithTasks;
@@ -17,20 +9,18 @@ type PublicListViewProps = {
 };
 
 export function PublicListView({ project, onTaskClick }: PublicListViewProps) {
-  const columns: Column[] = DEFAULT_COLUMNS.map((column) => ({
-    ...column,
-    tasks: project.columns?.find((col) => col.id === column.id)?.tasks || [],
-  }));
+  const columns = project.columns ?? [];
 
   return (
     <div className="flex-1 min-h-0 overflow-y-auto">
       <div className="p-6 space-y-8 max-w-5xl mx-auto">
         {columns.map((column) => {
-          const IconComponent = column.icon;
           return (
             <div key={column.id} className="space-y-4">
               <div className="flex items-center gap-3 px-2">
-                <IconComponent className="w-5 h-5 text-muted-foreground" />
+                <span className="flex [&_svg]:!h-5 [&_svg]:!w-5">
+                  {getColumnIcon(column.id, column.isFinal)}
+                </span>
                 <h3 className="font-semibold text-lg text-foreground">
                   {column.name}
                 </h3>
@@ -52,7 +42,7 @@ export function PublicListView({ project, onTaskClick }: PublicListViewProps) {
                 {column.tasks.length === 0 && (
                   <div className="text-center text-sm text-muted-foreground py-8 bg-muted/50 rounded-lg border border-dashed border-border">
                     <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center mx-auto mb-2">
-                      <IconComponent className="w-4 h-4" />
+                      {getColumnIcon(column.id, column.isFinal)}
                     </div>
                     No tasks in {column.name.toLowerCase()}
                   </div>


### PR DESCRIPTION
## Description

Public board and list views (`PublicKanbanView`, `PublicListView`) previously rendered only the four default column slugs from `DEFAULT_COLUMNS`, so tasks in custom columns never appeared on shared links. They now render **`project.columns`** from the API (same payload as the authenticated board) and use **`getColumnIcon`** for column icons, including sensible fallbacks for custom slugs.

## Related Issue(s)

Fixes #1129

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

Pre-commit ran `biome check` and full monorepo `pnpm run build` successfully after the change.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated column display logic in Kanban and List views to streamline data handling.
  * Modified icon rendering for columns to use a unified icon system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->