### PR TITLE
fix(web): show all workspace members in assignee popovers

### DIFF
--- a/apps/web/src/components/task/subtask-assignee-popover.tsx
+++ b/apps/web/src/components/task/subtask-assignee-popover.tsx
@@ -80,8 +80,8 @@ export default function SubtaskAssigneePopover({
   return (
     <Popover open={open} onOpenChange={setOpen} modal={false}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent className="w-48 p-0" align="start">
-        <div className="space-y-1 p-1">
+      <PopoverContent className="w-56 p-0" align="start">
+        <div className="max-h-80 space-y-1 overflow-y-auto p-1">
           <Button
             variant="ghost"
             size="sm"
@@ -105,7 +105,7 @@ export default function SubtaskAssigneePopover({
               <ShortcutNumber number={1} />
             )}
           </Button>
-          {usersOptions?.slice(0, 8).map((user, index) => (
+          {usersOptions?.map((user, index) => (
             <Button
               key={user.value}
               variant="ghost"
@@ -122,9 +122,9 @@ export default function SubtaskAssigneePopover({
               <span className="text-sm truncate">{user.label}</span>
               {currentAssignee === user.value ? (
                 <Check className="ml-auto h-4 w-4 shrink-0" />
-              ) : (
+              ) : index < 8 ? (
                 <ShortcutNumber number={index + 2} />
-              )}
+              ) : null}
             </Button>
           ))}
         </div>

--- a/apps/web/src/components/task/subtask-assignee-popover.tsx
+++ b/apps/web/src/components/task/subtask-assignee-popover.tsx
@@ -15,6 +15,9 @@ import { useNumberedShortcuts } from "@/hooks/use-numbered-shortcuts";
 import { toast } from "@/lib/toast";
 import type Task from "@/types/task";
 
+const INITIAL_VISIBLE_USERS = 40;
+const VISIBLE_USERS_STEP = 40;
+
 type SubtaskAssigneePopoverProps = {
   tasks: Task[];
   workspaceId: string;
@@ -28,6 +31,9 @@ export default function SubtaskAssigneePopover({
 }: SubtaskAssigneePopoverProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const [visibleUsersCount, setVisibleUsersCount] = useState(
+    INITIAL_VISIBLE_USERS,
+  );
   const { mutateAsync: updateTaskAssignee } = useUpdateTaskAssignee();
   const { data: workspaceUsers } = useGetActiveWorkspaceUsers(workspaceId);
 
@@ -75,13 +81,43 @@ export default function SubtaskAssigneePopover({
     return [unassignedOption, ...userOptions];
   }, [usersOptions, handleAssigneeChange]);
 
+  const visibleUsersOptions = useMemo(() => {
+    return usersOptions?.slice(0, visibleUsersCount) ?? [];
+  }, [usersOptions, visibleUsersCount]);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      setVisibleUsersCount(INITIAL_VISIBLE_USERS);
+    }
+  }, []);
+
+  const handleListScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      const target = event.currentTarget;
+      const nearBottom =
+        target.scrollHeight - target.scrollTop - target.clientHeight < 48;
+
+      if (!nearBottom) return;
+
+      setVisibleUsersCount((current) => {
+        const totalUsers = usersOptions?.length ?? current;
+        return Math.min(current + VISIBLE_USERS_STEP, totalUsers);
+      });
+    },
+    [usersOptions?.length],
+  );
+
   useNumberedShortcuts(open, shortcutOptions);
 
   return (
-    <Popover open={open} onOpenChange={setOpen} modal={false}>
+    <Popover open={open} onOpenChange={handleOpenChange} modal={false}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent className="w-56 p-0" align="start">
-        <div className="max-h-80 space-y-1 overflow-y-auto p-1">
+        <div
+          className="max-h-80 space-y-1 overflow-y-auto p-1"
+          onScroll={handleListScroll}
+        >
           <Button
             variant="ghost"
             size="sm"
@@ -105,7 +141,7 @@ export default function SubtaskAssigneePopover({
               <ShortcutNumber number={1} />
             )}
           </Button>
-          {usersOptions?.map((user, index) => (
+          {visibleUsersOptions.map((user, index) => (
             <Button
               key={user.value}
               variant="ghost"

--- a/apps/web/src/components/task/task-assignee-popover.tsx
+++ b/apps/web/src/components/task/task-assignee-popover.tsx
@@ -72,8 +72,8 @@ export default function TaskAssigneePopover({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent className="w-48 p-0" align="start">
-        <div className="space-y-1 p-1">
+      <PopoverContent className="w-56 p-0" align="start">
+        <div className="max-h-80 space-y-1 overflow-y-auto p-1">
           <Button
             variant="ghost"
             size="sm"
@@ -97,7 +97,7 @@ export default function TaskAssigneePopover({
               <ShortcutNumber number={1} />
             )}
           </Button>
-          {usersOptions?.slice(0, 8).map((user, index) => (
+          {usersOptions?.map((user, index) => (
             <Button
               key={user.value}
               variant="ghost"
@@ -114,9 +114,9 @@ export default function TaskAssigneePopover({
               <span className="text-sm truncate">{user.label}</span>
               {task.userId === user.value ? (
                 <Check className="ml-auto h-4 w-4 shrink-0" />
-              ) : (
+              ) : index < 8 ? (
                 <ShortcutNumber number={index + 2} />
-              )}
+              ) : null}
             </Button>
           ))}
         </div>

--- a/apps/web/src/components/task/task-assignee-popover.tsx
+++ b/apps/web/src/components/task/task-assignee-popover.tsx
@@ -15,6 +15,9 @@ import { useNumberedShortcuts } from "@/hooks/use-numbered-shortcuts";
 import { toast } from "@/lib/toast";
 import type Task from "@/types/task";
 
+const INITIAL_VISIBLE_USERS = 40;
+const VISIBLE_USERS_STEP = 40;
+
 type TaskAssigneePopoverProps = {
   task: Task;
   workspaceId: string;
@@ -28,6 +31,9 @@ export default function TaskAssigneePopover({
 }: TaskAssigneePopoverProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const [visibleUsersCount, setVisibleUsersCount] = useState(
+    INITIAL_VISIBLE_USERS,
+  );
   const { mutateAsync: updateTaskAssignee } = useUpdateTaskAssignee();
   const { data: workspaceUsers } = useGetActiveWorkspaceUsers(workspaceId);
 
@@ -67,13 +73,43 @@ export default function TaskAssigneePopover({
     return [unassignedOption, ...userOptions];
   }, [usersOptions, handleAssigneeChange]);
 
+  const visibleUsersOptions = useMemo(() => {
+    return usersOptions?.slice(0, visibleUsersCount) ?? [];
+  }, [usersOptions, visibleUsersCount]);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      setVisibleUsersCount(INITIAL_VISIBLE_USERS);
+    }
+  }, []);
+
+  const handleListScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      const target = event.currentTarget;
+      const nearBottom =
+        target.scrollHeight - target.scrollTop - target.clientHeight < 48;
+
+      if (!nearBottom) return;
+
+      setVisibleUsersCount((current) => {
+        const totalUsers = usersOptions?.length ?? current;
+        return Math.min(current + VISIBLE_USERS_STEP, totalUsers);
+      });
+    },
+    [usersOptions?.length],
+  );
+
   useNumberedShortcuts(open, shortcutOptions);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent className="w-56 p-0" align="start">
-        <div className="max-h-80 space-y-1 overflow-y-auto p-1">
+        <div
+          className="max-h-80 space-y-1 overflow-y-auto p-1"
+          onScroll={handleListScroll}
+        >
           <Button
             variant="ghost"
             size="sm"
@@ -97,7 +133,7 @@ export default function TaskAssigneePopover({
               <ShortcutNumber number={1} />
             )}
           </Button>
-          {usersOptions?.map((user, index) => (
+          {visibleUsersOptions.map((user, index) => (
             <Button
               key={user.value}
               variant="ghost"


### PR DESCRIPTION
## Description
Fixes the assignee picker limit in task and subtask popovers so all workspace members are assignabe.

### What changed
- Removed the hard cap (`slice(0, 8)`) when rendering assignee options.
- Kept numeric keyboard shortcuts for the first 8 assignable users plus `1` for “Unassigned”.
- Added scroll support for longer member lists and slightly widened the popover for readability.

## Related Issue(s)
Fixes #1168

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Other (please describe): `pnpm -C apps/web exec biome check src/components/task/task-assignee-popover.tsx src/components/task/subtask-assignee-popover.tsx`

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded assignee selection popovers for better visibility.
  * Made assignee lists scrollable with progressive/infinite loading so more users load as you browse.
  * Removed the previous hard limit restricting assignee selection to 8 users.
  * Reset visible user list when opening the popover for consistent behavior.
  * Refined keyboard shortcut number display for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->