### PR TITLE
fix(web): renaming column ignored

### DIFF
--- a/apps/web/src/components/task/subtask-assignee-popover.tsx
+++ b/apps/web/src/components/task/subtask-assignee-popover.tsx
@@ -80,8 +80,8 @@ export default function SubtaskAssigneePopover({
   return (
     <Popover open={open} onOpenChange={setOpen} modal={false}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent className="w-48 p-0" align="start">
-        <div className="space-y-1 p-1">
+      <PopoverContent className="w-56 p-0" align="start">
+        <div className="max-h-80 space-y-1 overflow-y-auto p-1">
           <Button
             variant="ghost"
             size="sm"
@@ -105,7 +105,7 @@ export default function SubtaskAssigneePopover({
               <ShortcutNumber number={1} />
             )}
           </Button>
-          {usersOptions?.slice(0, 8).map((user, index) => (
+          {usersOptions?.map((user, index) => (
             <Button
               key={user.value}
               variant="ghost"
@@ -122,9 +122,9 @@ export default function SubtaskAssigneePopover({
               <span className="text-sm truncate">{user.label}</span>
               {currentAssignee === user.value ? (
                 <Check className="ml-auto h-4 w-4 shrink-0" />
-              ) : (
+              ) : index < 8 ? (
                 <ShortcutNumber number={index + 2} />
-              )}
+              ) : null}
             </Button>
           ))}
         </div>

--- a/apps/web/src/components/task/subtask-assignee-popover.tsx
+++ b/apps/web/src/components/task/subtask-assignee-popover.tsx
@@ -15,6 +15,9 @@ import { useNumberedShortcuts } from "@/hooks/use-numbered-shortcuts";
 import { toast } from "@/lib/toast";
 import type Task from "@/types/task";
 
+const INITIAL_VISIBLE_USERS = 40;
+const VISIBLE_USERS_STEP = 40;
+
 type SubtaskAssigneePopoverProps = {
   tasks: Task[];
   workspaceId: string;
@@ -28,6 +31,9 @@ export default function SubtaskAssigneePopover({
 }: SubtaskAssigneePopoverProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const [visibleUsersCount, setVisibleUsersCount] = useState(
+    INITIAL_VISIBLE_USERS,
+  );
   const { mutateAsync: updateTaskAssignee } = useUpdateTaskAssignee();
   const { data: workspaceUsers } = useGetActiveWorkspaceUsers(workspaceId);
 
@@ -75,13 +81,43 @@ export default function SubtaskAssigneePopover({
     return [unassignedOption, ...userOptions];
   }, [usersOptions, handleAssigneeChange]);
 
+  const visibleUsersOptions = useMemo(() => {
+    return usersOptions?.slice(0, visibleUsersCount) ?? [];
+  }, [usersOptions, visibleUsersCount]);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      setVisibleUsersCount(INITIAL_VISIBLE_USERS);
+    }
+  }, []);
+
+  const handleListScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      const target = event.currentTarget;
+      const nearBottom =
+        target.scrollHeight - target.scrollTop - target.clientHeight < 48;
+
+      if (!nearBottom) return;
+
+      setVisibleUsersCount((current) => {
+        const totalUsers = usersOptions?.length ?? current;
+        return Math.min(current + VISIBLE_USERS_STEP, totalUsers);
+      });
+    },
+    [usersOptions?.length],
+  );
+
   useNumberedShortcuts(open, shortcutOptions);
 
   return (
-    <Popover open={open} onOpenChange={setOpen} modal={false}>
+    <Popover open={open} onOpenChange={handleOpenChange} modal={false}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent className="w-56 p-0" align="start">
-        <div className="max-h-80 space-y-1 overflow-y-auto p-1">
+        <div
+          className="max-h-80 space-y-1 overflow-y-auto p-1"
+          onScroll={handleListScroll}
+        >
           <Button
             variant="ghost"
             size="sm"
@@ -105,7 +141,7 @@ export default function SubtaskAssigneePopover({
               <ShortcutNumber number={1} />
             )}
           </Button>
-          {usersOptions?.map((user, index) => (
+          {visibleUsersOptions.map((user, index) => (
             <Button
               key={user.value}
               variant="ghost"

--- a/apps/web/src/components/task/subtask-status-popover.tsx
+++ b/apps/web/src/components/task/subtask-status-popover.tsx
@@ -12,6 +12,7 @@ import { useUpdateTaskStatus } from "@/hooks/mutations/task/use-update-task-stat
 import { useGetColumns } from "@/hooks/queries/column/use-get-columns";
 import { useNumberedShortcuts } from "@/hooks/use-numbered-shortcuts";
 import { getColumnIcon } from "@/lib/column";
+import { getStatusDisplayLabel } from "@/lib/i18n/domain";
 import { toast } from "@/lib/toast";
 import type Task from "@/types/task";
 
@@ -87,7 +88,9 @@ export default function SubtaskStatusPopover({
               onClick={() => handleStatusChange(status.value)}
             >
               {getColumnIcon(status.value, status.isFinal)}
-              <span className="text-sm">{status.label}</span>
+              <span className="text-sm">
+                {getStatusDisplayLabel(status.value, status.label)}
+              </span>
               {currentStatus === status.value ? (
                 <Check className="ml-auto h-4 w-4" />
               ) : (

--- a/apps/web/src/components/task/subtask-status-popover.tsx
+++ b/apps/web/src/components/task/subtask-status-popover.tsx
@@ -12,7 +12,6 @@ import { useUpdateTaskStatus } from "@/hooks/mutations/task/use-update-task-stat
 import { useGetColumns } from "@/hooks/queries/column/use-get-columns";
 import { useNumberedShortcuts } from "@/hooks/use-numbered-shortcuts";
 import { getColumnIcon } from "@/lib/column";
-import { getStatusLabel } from "@/lib/i18n/domain";
 import { toast } from "@/lib/toast";
 import type Task from "@/types/task";
 
@@ -88,9 +87,7 @@ export default function SubtaskStatusPopover({
               onClick={() => handleStatusChange(status.value)}
             >
               {getColumnIcon(status.value, status.isFinal)}
-              <span className="text-sm">
-                {getStatusLabel(status.value) || status.label}
-              </span>
+              <span className="text-sm">{status.label}</span>
               {currentStatus === status.value ? (
                 <Check className="ml-auto h-4 w-4" />
               ) : (

--- a/apps/web/src/components/task/task-assignee-popover.tsx
+++ b/apps/web/src/components/task/task-assignee-popover.tsx
@@ -72,8 +72,8 @@ export default function TaskAssigneePopover({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent className="w-48 p-0" align="start">
-        <div className="space-y-1 p-1">
+      <PopoverContent className="w-56 p-0" align="start">
+        <div className="max-h-80 space-y-1 overflow-y-auto p-1">
           <Button
             variant="ghost"
             size="sm"
@@ -97,7 +97,7 @@ export default function TaskAssigneePopover({
               <ShortcutNumber number={1} />
             )}
           </Button>
-          {usersOptions?.slice(0, 8).map((user, index) => (
+          {usersOptions?.map((user, index) => (
             <Button
               key={user.value}
               variant="ghost"
@@ -114,9 +114,9 @@ export default function TaskAssigneePopover({
               <span className="text-sm truncate">{user.label}</span>
               {task.userId === user.value ? (
                 <Check className="ml-auto h-4 w-4 shrink-0" />
-              ) : (
+              ) : index < 8 ? (
                 <ShortcutNumber number={index + 2} />
-              )}
+              ) : null}
             </Button>
           ))}
         </div>

--- a/apps/web/src/components/task/task-assignee-popover.tsx
+++ b/apps/web/src/components/task/task-assignee-popover.tsx
@@ -15,6 +15,9 @@ import { useNumberedShortcuts } from "@/hooks/use-numbered-shortcuts";
 import { toast } from "@/lib/toast";
 import type Task from "@/types/task";
 
+const INITIAL_VISIBLE_USERS = 40;
+const VISIBLE_USERS_STEP = 40;
+
 type TaskAssigneePopoverProps = {
   task: Task;
   workspaceId: string;
@@ -28,6 +31,9 @@ export default function TaskAssigneePopover({
 }: TaskAssigneePopoverProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const [visibleUsersCount, setVisibleUsersCount] = useState(
+    INITIAL_VISIBLE_USERS,
+  );
   const { mutateAsync: updateTaskAssignee } = useUpdateTaskAssignee();
   const { data: workspaceUsers } = useGetActiveWorkspaceUsers(workspaceId);
 
@@ -67,13 +73,43 @@ export default function TaskAssigneePopover({
     return [unassignedOption, ...userOptions];
   }, [usersOptions, handleAssigneeChange]);
 
+  const visibleUsersOptions = useMemo(() => {
+    return usersOptions?.slice(0, visibleUsersCount) ?? [];
+  }, [usersOptions, visibleUsersCount]);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      setVisibleUsersCount(INITIAL_VISIBLE_USERS);
+    }
+  }, []);
+
+  const handleListScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      const target = event.currentTarget;
+      const nearBottom =
+        target.scrollHeight - target.scrollTop - target.clientHeight < 48;
+
+      if (!nearBottom) return;
+
+      setVisibleUsersCount((current) => {
+        const totalUsers = usersOptions?.length ?? current;
+        return Math.min(current + VISIBLE_USERS_STEP, totalUsers);
+      });
+    },
+    [usersOptions?.length],
+  );
+
   useNumberedShortcuts(open, shortcutOptions);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent className="w-56 p-0" align="start">
-        <div className="max-h-80 space-y-1 overflow-y-auto p-1">
+        <div
+          className="max-h-80 space-y-1 overflow-y-auto p-1"
+          onScroll={handleListScroll}
+        >
           <Button
             variant="ghost"
             size="sm"
@@ -97,7 +133,7 @@ export default function TaskAssigneePopover({
               <ShortcutNumber number={1} />
             )}
           </Button>
-          {usersOptions?.map((user, index) => (
+          {visibleUsersOptions.map((user, index) => (
             <Button
               key={user.value}
               variant="ghost"

--- a/apps/web/src/components/task/task-properties-sidebar.tsx
+++ b/apps/web/src/components/task/task-properties-sidebar.tsx
@@ -22,6 +22,7 @@ import labelColors from "@/constants/label-colors";
 import useGetGiteaIntegration from "@/hooks/queries/gitea-integration/use-get-gitea-integration";
 import useGetGithubIntegration from "@/hooks/queries/github-integration/use-get-github-integration";
 import useGetLabelsByTask from "@/hooks/queries/label/use-get-labels-by-task";
+import { useGetColumns } from "@/hooks/queries/column/use-get-columns";
 import useGetProject from "@/hooks/queries/project/use-get-project";
 import useGetProjects from "@/hooks/queries/project/use-get-projects";
 import useGetTask from "@/hooks/queries/task/use-get-task";
@@ -30,7 +31,7 @@ import { cn } from "@/lib/cn";
 import { getColumnIcon } from "@/lib/column";
 import { dueDateStatusColors, getDueDateStatus } from "@/lib/due-date-status";
 import { formatDateShort } from "@/lib/format";
-import { getPriorityLabel, getStatusLabel } from "@/lib/i18n/domain";
+import { getPriorityLabel, getStatusDisplayLabel } from "@/lib/i18n/domain";
 import { getPriorityIcon } from "@/lib/priority";
 import { toast } from "@/lib/toast";
 import TaskAssigneePopover from "./task-assignee-popover";
@@ -81,6 +82,7 @@ export default function TaskPropertiesSidebar({
   const { t } = useTranslation();
   const { data: task } = useGetTask(taskId ?? "");
   const { data: project } = useGetProject({ id: projectId, workspaceId });
+  const { data: columns = [] } = useGetColumns(projectId);
   const { data: workspaceUsers } = useGetActiveWorkspaceUsers(workspaceId);
   const { data: taskLabels = [] } = useGetLabelsByTask(taskId ?? "");
   const { data: githubIntegration } = useGetGithubIntegration(projectId);
@@ -88,10 +90,10 @@ export default function TaskPropertiesSidebar({
   const { data: workspaceProjects = [] } = useGetProjects({ workspaceId });
   const canMoveTask =
     Boolean(task) && workspaceProjects.some((p) => p.id !== task?.projectId);
-  const statusColumn = project?.columns?.find(
-    (column) => column.id === task?.status,
+  const statusColumn = columns.find(
+    (column) => column.slug === task?.status || column.id === task?.status,
   );
-  const statusLabel = statusColumn?.name || getStatusLabel(task?.status ?? "");
+  const statusLabel = getStatusDisplayLabel(task?.status ?? "", statusColumn?.name);
   const statusIsFinal = statusColumn?.isFinal ?? false;
 
   const projectSlug = project?.slug;

--- a/apps/web/src/components/task/task-properties-sidebar.tsx
+++ b/apps/web/src/components/task/task-properties-sidebar.tsx
@@ -88,6 +88,11 @@ export default function TaskPropertiesSidebar({
   const { data: workspaceProjects = [] } = useGetProjects({ workspaceId });
   const canMoveTask =
     Boolean(task) && workspaceProjects.some((p) => p.id !== task?.projectId);
+  const statusColumn = project?.columns?.find(
+    (column) => column.id === task?.status,
+  );
+  const statusLabel = statusColumn?.name || getStatusLabel(task?.status ?? "");
+  const statusIsFinal = statusColumn?.isFinal ?? false;
 
   const projectSlug = project?.slug;
   const taskNumber = task?.number;
@@ -188,9 +193,9 @@ export default function TaskPropertiesSidebar({
                     size="sm"
                     className="justify-start h-7 px-1.5 gap-1.5"
                   >
-                    {getColumnIcon(task.status ?? "", false)}
+                    {getColumnIcon(task.status ?? "", statusIsFinal)}
                     <span className="text-xs font-semibold truncate">
-                      {getStatusLabel(task.status ?? "")}
+                      {statusLabel}
                     </span>
                   </Button>
                 </TaskStatusPopover>
@@ -372,9 +377,9 @@ export default function TaskPropertiesSidebar({
                       size="sm"
                       className="justify-start h-7 px-1.5 gap-1.5"
                     >
-                      {getColumnIcon(task.status ?? "", false)}
+                      {getColumnIcon(task.status ?? "", statusIsFinal)}
                       <span className="text-xs font-semibold truncate">
-                        {getStatusLabel(task.status ?? "")}
+                        {statusLabel}
                       </span>
                     </Button>
                   </TaskStatusPopover>
@@ -559,9 +564,9 @@ export default function TaskPropertiesSidebar({
                       size="sm"
                       className="justify-start h-7 px-1.5 gap-1.5 w-full"
                     >
-                      {getColumnIcon(task.status ?? "", false)}
+                      {getColumnIcon(task.status ?? "", statusIsFinal)}
                       <span className="text-xs font-semibold truncate">
-                        {getStatusLabel(task.status ?? "")}
+                        {statusLabel}
                       </span>
                     </Button>
                   </TaskStatusPopover>

--- a/apps/web/src/components/task/task-properties-sidebar.tsx
+++ b/apps/web/src/components/task/task-properties-sidebar.tsx
@@ -19,10 +19,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import labelColors from "@/constants/label-colors";
+import { useGetColumns } from "@/hooks/queries/column/use-get-columns";
 import useGetGiteaIntegration from "@/hooks/queries/gitea-integration/use-get-gitea-integration";
 import useGetGithubIntegration from "@/hooks/queries/github-integration/use-get-github-integration";
 import useGetLabelsByTask from "@/hooks/queries/label/use-get-labels-by-task";
-import { useGetColumns } from "@/hooks/queries/column/use-get-columns";
 import useGetProject from "@/hooks/queries/project/use-get-project";
 import useGetProjects from "@/hooks/queries/project/use-get-projects";
 import useGetTask from "@/hooks/queries/task/use-get-task";
@@ -93,7 +93,10 @@ export default function TaskPropertiesSidebar({
   const statusColumn = columns.find(
     (column) => column.slug === task?.status || column.id === task?.status,
   );
-  const statusLabel = getStatusDisplayLabel(task?.status ?? "", statusColumn?.name);
+  const statusLabel = getStatusDisplayLabel(
+    task?.status ?? "",
+    statusColumn?.name,
+  );
   const statusIsFinal = statusColumn?.isFinal ?? false;
 
   const projectSlug = project?.slug;

--- a/apps/web/src/components/task/task-status-popover.tsx
+++ b/apps/web/src/components/task/task-status-popover.tsx
@@ -11,7 +11,6 @@ import { ShortcutNumber } from "@/components/ui/shortcut-number";
 import { useUpdateTaskStatus } from "@/hooks/mutations/task/use-update-task-status";
 import { useNumberedShortcuts } from "@/hooks/use-numbered-shortcuts";
 import { getColumnIcon } from "@/lib/column";
-import { getStatusLabel } from "@/lib/i18n/domain";
 import { toast } from "@/lib/toast";
 import useProjectStore from "@/store/project";
 import type Task from "@/types/task";
@@ -79,9 +78,7 @@ export default function TaskStatusPopover({
               onClick={() => handleStatusChange(status.value)}
             >
               {getColumnIcon(status.value, status.isFinal)}
-              <span className="text-sm">
-                {getStatusLabel(status.value) || status.label}
-              </span>
+              <span className="text-sm">{status.label}</span>
               {task.status === status.value ? (
                 <Check className="ml-auto h-4 w-4" />
               ) : (

--- a/apps/web/src/components/task/task-status-popover.tsx
+++ b/apps/web/src/components/task/task-status-popover.tsx
@@ -11,6 +11,7 @@ import { ShortcutNumber } from "@/components/ui/shortcut-number";
 import { useUpdateTaskStatus } from "@/hooks/mutations/task/use-update-task-status";
 import { useNumberedShortcuts } from "@/hooks/use-numbered-shortcuts";
 import { getColumnIcon } from "@/lib/column";
+import { getStatusDisplayLabel } from "@/lib/i18n/domain";
 import { toast } from "@/lib/toast";
 import useProjectStore from "@/store/project";
 import type Task from "@/types/task";
@@ -78,7 +79,9 @@ export default function TaskStatusPopover({
               onClick={() => handleStatusChange(status.value)}
             >
               {getColumnIcon(status.value, status.isFinal)}
-              <span className="text-sm">{status.label}</span>
+              <span className="text-sm">
+                {getStatusDisplayLabel(status.value, status.label)}
+              </span>
               {task.status === status.value ? (
                 <Check className="ml-auto h-4 w-4" />
               ) : (

--- a/apps/web/src/lib/i18n/domain.ts
+++ b/apps/web/src/lib/i18n/domain.ts
@@ -8,7 +8,9 @@ export function getStatusLabel(status: string) {
 }
 
 export function getStatusDisplayLabel(status: string, columnName?: string) {
-  const defaultName = DEFAULT_COLUMNS.find((column) => column.id === status)?.name;
+  const defaultName = DEFAULT_COLUMNS.find(
+    (column) => column.id === status,
+  )?.name;
 
   if (columnName) {
     if (defaultName && columnName === defaultName) {

--- a/apps/web/src/lib/i18n/domain.ts
+++ b/apps/web/src/lib/i18n/domain.ts
@@ -1,9 +1,24 @@
 import i18n from "i18next";
+import { DEFAULT_COLUMNS } from "@/constants/columns";
 
 export function getStatusLabel(status: string) {
   return i18n.t(`tasks:status.${status}`, {
     defaultValue: toDisplayCase(status),
   });
+}
+
+export function getStatusDisplayLabel(status: string, columnName?: string) {
+  const defaultName = DEFAULT_COLUMNS.find((column) => column.id === status)?.name;
+
+  if (columnName) {
+    if (defaultName && columnName === defaultName) {
+      return getStatusLabel(status);
+    }
+
+    return columnName;
+  }
+
+  return getStatusLabel(status);
 }
 
 export function getPriorityLabel(priority: string) {


### PR DESCRIPTION
## Description
This PR fixes a bug where renamed project columns (especially default ones like `Done`) were not reflected in task status dropdowns and task detail status labels.

### What changed
- Updated task status dropdown rendering to prioritize live project column names.
- Updated subtask status dropdown rendering to prioritize live project column names.
- Updated task detail sidebar status label/icon resolution to use project column metadata first (name + final-state icon), with fallback only when needed.

## Related Issue(s)
Fixes #1175

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Other (please describe): Type check via `pnpm -C apps/web exec tsc --noEmit`

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Assignee popovers progressively load more users as you scroll for smoother performance with large lists.
  * Popover layout made wider with max-height and vertical scrolling for better usability.
  * Status text and icons now use column-derived display names for consistent labeling across popovers and sidebars.
  * Keyboard shortcut badges shown only for the first few assignee items to reduce visual clutter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->