### PR TITLE
fix(api): avoid checksum query params in presigned S3 uploads

### DIFF
--- a/apps/api/src/storage/s3.ts
+++ b/apps/api/src/storage/s3.ts
@@ -145,6 +145,9 @@ function getClient(config: StorageConfig) {
     endpoint: config.endpoint,
     region: config.region,
     forcePathStyle: config.forcePathStyle,
+    // Avoid auto-injecting checksum params for presigned PUT URLs. Some
+    // S3-compatible providers (e.g. Garage/R2) reject mismatched hoisted CRCs.
+    requestChecksumCalculation: "WHEN_REQUIRED",
     credentials: {
       accessKeyId: config.accessKeyId,
       secretAccessKey: config.secretAccessKey,

--- a/tests/api/storage/s3.test.ts
+++ b/tests/api/storage/s3.test.ts
@@ -3,6 +3,7 @@ import {
   assertTaskImageKeyMatchesContext,
   buildObjectKey,
   buildObjectKeyPrefix,
+  createTaskImageUploadUrl,
   getFileExtension,
   isImageContentType,
   parseBoolean,
@@ -13,6 +14,12 @@ import {
 
 describe("S3 helpers", () => {
   const originalMaxSize = process.env.S3_MAX_IMAGE_UPLOAD_BYTES;
+  const originalEndpoint = process.env.S3_ENDPOINT;
+  const originalBucket = process.env.S3_BUCKET;
+  const originalAccessKeyId = process.env.S3_ACCESS_KEY_ID;
+  const originalSecretAccessKey = process.env.S3_SECRET_ACCESS_KEY;
+  const originalRegion = process.env.S3_REGION;
+  const originalPathStyle = process.env.S3_FORCE_PATH_STYLE;
 
   beforeEach(() => {
     delete process.env.S3_MAX_IMAGE_UPLOAD_BYTES;
@@ -20,12 +27,48 @@ describe("S3 helpers", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+
     if (originalMaxSize === undefined) {
       delete process.env.S3_MAX_IMAGE_UPLOAD_BYTES;
-      return;
+    } else {
+      process.env.S3_MAX_IMAGE_UPLOAD_BYTES = originalMaxSize;
     }
 
-    process.env.S3_MAX_IMAGE_UPLOAD_BYTES = originalMaxSize;
+    if (originalEndpoint === undefined) {
+      delete process.env.S3_ENDPOINT;
+    } else {
+      process.env.S3_ENDPOINT = originalEndpoint;
+    }
+
+    if (originalBucket === undefined) {
+      delete process.env.S3_BUCKET;
+    } else {
+      process.env.S3_BUCKET = originalBucket;
+    }
+
+    if (originalAccessKeyId === undefined) {
+      delete process.env.S3_ACCESS_KEY_ID;
+    } else {
+      process.env.S3_ACCESS_KEY_ID = originalAccessKeyId;
+    }
+
+    if (originalSecretAccessKey === undefined) {
+      delete process.env.S3_SECRET_ACCESS_KEY;
+    } else {
+      process.env.S3_SECRET_ACCESS_KEY = originalSecretAccessKey;
+    }
+
+    if (originalRegion === undefined) {
+      delete process.env.S3_REGION;
+    } else {
+      process.env.S3_REGION = originalRegion;
+    }
+
+    if (originalPathStyle === undefined) {
+      delete process.env.S3_FORCE_PATH_STYLE;
+    } else {
+      process.env.S3_FORCE_PATH_STYLE = originalPathStyle;
+    }
   });
 
   it("recognizes allowed image content types case-insensitively", () => {
@@ -97,5 +140,27 @@ describe("S3 helpers", () => {
       validateTaskAssetUploadInput("image/png", 2 * 1024 * 1024),
     ).toThrow("Upload exceeds the maximum upload size of 1MB.");
     expect(() => validateTaskAssetUploadInput("image/png", 512)).not.toThrow();
+  });
+
+  it("creates presigned upload URLs without hoisted checksum query params", async () => {
+    process.env.S3_ENDPOINT = "https://storage.example.test";
+    process.env.S3_BUCKET = "kaneo";
+    process.env.S3_ACCESS_KEY_ID = "test-access-key";
+    process.env.S3_SECRET_ACCESS_KEY = "test-secret-key";
+    process.env.S3_REGION = "us-east-1";
+    process.env.S3_FORCE_PATH_STYLE = "true";
+
+    const upload = await createTaskImageUploadUrl({
+      workspaceId: "workspace-1",
+      projectId: "project-1",
+      taskId: "task-1",
+      surface: "description",
+      filename: "report.png",
+      contentType: "image/png",
+    });
+
+    const searchParams = new URL(upload.uploadUrl).searchParams;
+    expect(searchParams.has("x-amz-checksum-crc32")).toBe(false);
+    expect(searchParams.has("x-amz-sdk-checksum-algorithm")).toBe(false);
   });
 });


### PR DESCRIPTION
## Description
This PR fixes S3-compatible attachment uploads (Garage/R2) failing with `InvalidDigest` due to presigned PUT URLs containing auto-generated checksum query parameters (`x-amz-checksum-crc32` / `x-amz-sdk-checksum-algorithm`) that did not match uploaded file contents.

Changes included:
- Set the API S3 client to `requestChecksumCalculation: "WHEN_REQUIRED"` when generating presigned URLs.
- Added a regression unit test to verify generated upload URLs do not include hoisted checksum query params.

## Related Issue(s)
Fixes #1173

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

Test command run:
- `pnpm --filter @kaneo/api test:unit -- tests/api/storage/s3.test.ts`

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated S3 checksum handling for presigned upload URLs.

* **Tests**
  * Added test validation for presigned upload URL parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->