### PR TITLE
fix(chart): add KANEO_CLIENT_URL to web container and api.extraEnv support

### DIFF
--- a/charts/kaneo/Chart.yaml
+++ b/charts/kaneo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kaneo
 description: Kaneo - All you need. Nothing you don't. Open source project management that works for you.
 type: application
-# Bumped to 0.2.0 due to breaking auth and probe changes
-version: 0.2.0
+# 0.3.0: add api.extraEnv for custom env vars; fix missing KANEO_CLIENT_URL on web container
+version: 0.3.0
 # Bumped to the latest v2 release
 appVersion: "2.3.5"
 keywords:

--- a/charts/kaneo/templates/deployment.yaml
+++ b/charts/kaneo/templates/deployment.yaml
@@ -90,6 +90,9 @@ spec:
               value: {{ .Values.api.env.disableRegistration | quote }}
             - name: DISABLE_PASSWORD_REGISTRATION
               value: {{ .Values.api.env.disablePasswordRegistration | quote }}
+            {{- with .Values.api.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.api.livenessProbe | nindent 12 }}
           readinessProbe:
@@ -112,6 +115,12 @@ spec:
                 {{- .Values.web.env.apiUrl -}}
               {{- else -}}
                 http://localhost:{{ .Values.api.service.targetPort }}
+              {{- end -}}"
+            - name: KANEO_CLIENT_URL
+              value: "{{- if .Values.web.env.apiUrl -}}
+                {{- .Values.web.env.apiUrl -}}
+              {{- else -}}
+                http://localhost:{{ .Values.web.service.targetPort }}
               {{- end -}}"
           livenessProbe:
             {{- toYaml .Values.web.livenessProbe | nindent 12 }}

--- a/charts/kaneo/values.yaml
+++ b/charts/kaneo/values.yaml
@@ -111,6 +111,18 @@ api:
           enabled: false
           name: ""
           passwordKey: postgres_uri
+  # Additional environment variables for the API container.
+  # Each entry is a standard Kubernetes EnvVar (supports `value` or `valueFrom`).
+  # Useful for CUSTOM_OAUTH_*, SMTP_*, etc. without editing the chart.
+  extraEnv: []
+  # extraEnv:
+  #   - name: CUSTOM_OAUTH_DISCOVERY_URL
+  #     value: "https://idp.example.com/.well-known/openid-configuration"
+  #   - name: CUSTOM_OAUTH_CLIENT_ID
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: oauth-secret
+  #         key: client-id
   livenessProbe:
     httpGet:
       path: /api/health


### PR DESCRIPTION
## Summary

Two independent Helm chart fixes encountered while self-hosting Kaneo v2.6.8 with a custom OIDC provider (Authentik):

- **Add \`KANEO_CLIENT_URL\` to the web container env.** The web image's \`env.sh\` substitutes \`KANEO_CLIENT_URL\` placeholders in the built JS at container start. Currently the chart only sets \`KANEO_API_URL\` on the web container, so \`VITE_CLIENT_URL\` never gets substituted and the compiled bundle keeps the literal string \`KANEO_CLIENT_URL\`. Better Auth then rejects the OAuth sign-in request:
  \`\`\`
  POST /api/auth/sign-in/oauth2
  { \"providerId\": \"custom\", \"callbackURL\": \"KANEO_CLIENT_URL/dashboard\", \"errorCallbackURL\": \"KANEO_CLIENT_URL/auth/sign-in\" }
  -> 403 { \"message\": \"Invalid callbackURL\", \"code\": \"INVALID_CALLBACK_URL\" }
  \`\`\`
  Fix: emit \`KANEO_CLIENT_URL\` alongside \`KANEO_API_URL\`, using the same \`web.env.apiUrl\` fallback logic already used for the API container.

- **Add \`api.extraEnv\`** so custom env vars (\`CUSTOM_OAUTH_*\`, \`SMTP_*\`, \`DEVICE_AUTH_CLIENT_IDS\`, …) can be injected without forking the chart. Standard \`EnvVar\` list, supports both \`value\` and \`valueFrom\`.

Chart bumped 0.2.0 → 0.3.0.

## Test plan
- [x] \`helm lint charts/kaneo\`
- [x] \`helm template\` with \`--set api.extraEnv[0].name=FOO --set api.extraEnv[0].value=bar\` — renders \`FOO\` on api container, \`KANEO_CLIENT_URL\` on web container
- [x] Deployed to my homelab cluster with Authentik as OIDC provider — \`/api/auth/sign-in/oauth2\` now returns 200 and the flow completes successfully (hard-refresh required after upgrade because the JS is cached)

Happy to split into two PRs if preferred.