### PR TITLE
fix(web): load public API URL from runtime config in Docker

### DIFF
--- a/apps/web/env.sh
+++ b/apps/web/env.sh
@@ -1,6 +1,27 @@
 #!/bin/sh
 set -e
 
+# Runtime public env for the SPA (avoids relying on sed inside hashed bundles).
+# Values are base64 so shell metacharacters in URLs cannot break the script.
+write_runtime_config_js() {
+  CONFIG_PATH="/usr/share/nginx/html/env-config.js"
+  parts=""
+  if [ -n "$KANEO_API_URL" ]; then
+    b64=$(printf '%s' "$KANEO_API_URL" | base64 | tr -d '\n')
+    parts="VITE_API_URL:atob(\"${b64}\")"
+  fi
+  if [ -n "$KANEO_CLIENT_URL" ]; then
+    b64=$(printf '%s' "$KANEO_CLIENT_URL" | base64 | tr -d '\n')
+    if [ -n "$parts" ]; then
+      parts="${parts},"
+    fi
+    parts="${parts}VITE_CLIENT_URL:atob(\"${b64}\")"
+  fi
+  printf '%s\n' "window.__KANEO_RUNTIME_CONFIG__={${parts}};" > "$CONFIG_PATH"
+}
+
+write_runtime_config_js
+
 echo "Starting environment variable replacement..."
 
 # Process KANEO_API_URL first (with special handling)

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -54,6 +54,7 @@
 
 <body>
   <div id="root"></div>
+  <script src="/env-config.js"></script>
   <script type="module" src="/src/main.tsx"></script>
 </body>
 

--- a/apps/web/public/env-config.js
+++ b/apps/web/public/env-config.js
@@ -1,0 +1,1 @@
+window.__KANEO_RUNTIME_CONFIG__ = {};

--- a/apps/web/src/fetchers/get-api-url.ts
+++ b/apps/web/src/fetchers/get-api-url.ts
@@ -1,6 +1,9 @@
+import { resolvePublicEnvVar } from "@kaneo/libs";
+
 export function getApiUrl(path: string) {
   const trimmedBase = (
-    import.meta.env.VITE_API_URL || "http://localhost:1337"
+    resolvePublicEnvVar("VITE_API_URL", import.meta.env.VITE_API_URL) ||
+    "http://localhost:1337"
   ).replace(/\/+$/, "");
   const apiUrl = trimmedBase.endsWith("/api")
     ? trimmedBase

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,4 +1,5 @@
 import { apiKeyClient } from "@better-auth/api-key/client";
+import { resolvePublicEnvVar } from "@kaneo/libs";
 import {
   anonymousClient,
   deviceAuthorizationClient,
@@ -13,7 +14,9 @@ import { createAuthClient } from "better-auth/react";
 import { ac, admin, member, owner } from "./permissions";
 
 const getBaseURL = () => {
-  const apiUrl = import.meta.env.VITE_API_URL || "http://localhost:1337";
+  const apiUrl =
+    resolvePublicEnvVar("VITE_API_URL", import.meta.env.VITE_API_URL) ||
+    "http://localhost:1337";
   try {
     const url = new URL(apiUrl);
     return `${url.protocol}//${url.host}`;

--- a/apps/web/src/routes/auth/sign-in.tsx
+++ b/apps/web/src/routes/auth/sign-in.tsx
@@ -1,3 +1,4 @@
+import { resolvePublicEnvVar } from "@kaneo/libs";
 import {
   createFileRoute,
   useNavigate,
@@ -54,8 +55,12 @@ function SignIn() {
     return undefined;
   };
 
+  const getClientBaseUrl = () =>
+    resolvePublicEnvVar("VITE_CLIENT_URL", import.meta.env.VITE_CLIENT_URL) ??
+    "";
+
   const getCallbackUrl = () => {
-    const baseUrl = import.meta.env.VITE_CLIENT_URL;
+    const baseUrl = getClientBaseUrl();
     const redirectPath = getSafeRedirectPath();
     if (redirectPath) {
       return `${baseUrl}${redirectPath}`;
@@ -90,7 +95,7 @@ function SignIn() {
       const result = await authClient.signIn.oauth2({
         providerId: "custom",
         callbackURL: getCallbackUrl(),
-        errorCallbackURL: `${import.meta.env.VITE_CLIENT_URL}/auth/sign-in`,
+        errorCallbackURL: `${getClientBaseUrl()}/auth/sign-in`,
       });
       if (result.error) {
         throw new Error(result.error.message);
@@ -110,7 +115,7 @@ function SignIn() {
       const result = await authClient.signIn.social({
         provider: "google",
         callbackURL: getCallbackUrl(),
-        errorCallbackURL: `${import.meta.env.VITE_CLIENT_URL}/auth/sign-in`,
+        errorCallbackURL: `${getClientBaseUrl()}/auth/sign-in`,
       });
       if (result.error) {
         throw new Error(result.error.message);
@@ -130,7 +135,7 @@ function SignIn() {
       const result = await authClient.signIn.social({
         provider: "github",
         callbackURL: getCallbackUrl(),
-        errorCallbackURL: `${import.meta.env.VITE_CLIENT_URL}/auth/sign-in`,
+        errorCallbackURL: `${getClientBaseUrl()}/auth/sign-in`,
       });
       if (result.error) {
         throw new Error(result.error.message);
@@ -150,7 +155,7 @@ function SignIn() {
       const result = await authClient.signIn.social({
         provider: "discord",
         callbackURL: getCallbackUrl(),
-        errorCallbackURL: `${import.meta.env.VITE_CLIENT_URL}/auth/sign-in`,
+        errorCallbackURL: `${getClientBaseUrl()}/auth/sign-in`,
       });
       if (result.error) {
         throw new Error(result.error.message);

--- a/packages/libs/src/hono.ts
+++ b/packages/libs/src/hono.ts
@@ -3,8 +3,11 @@
 import type { AppType } from "@kaneo/api";
 import { hc } from "hono/client";
 import { resolveApiBaseUrl } from "./api-url";
+import { resolvePublicEnvVar } from "./runtime-public-env";
 
-const apiUrl = resolveApiBaseUrl(import.meta.env.VITE_API_URL);
+const apiUrl = resolveApiBaseUrl(
+  resolvePublicEnvVar("VITE_API_URL", import.meta.env.VITE_API_URL),
+);
 
 export const client = hc<AppType>(apiUrl, {
   fetch: (input: RequestInfo | URL, init?: RequestInit) => {

--- a/packages/libs/src/index.ts
+++ b/packages/libs/src/index.ts
@@ -1,2 +1,4 @@
 export { resolveApiBaseUrl } from "./api-url";
 export { client } from "./hono";
+export type { KaneoRuntimePublicConfig } from "./runtime-public-env";
+export { resolvePublicEnvVar } from "./runtime-public-env";

--- a/packages/libs/src/runtime-public-env.test.ts
+++ b/packages/libs/src/runtime-public-env.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolvePublicEnvVar } from "./runtime-public-env";
+
+describe("resolvePublicEnvVar", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns build-time value when window is undefined", () => {
+    expect(resolvePublicEnvVar("VITE_API_URL", "http://localhost:1337")).toBe(
+      "http://localhost:1337",
+    );
+  });
+
+  it("prefers runtime config when set in the browser", () => {
+    vi.stubGlobal("window", {
+      __KANEO_RUNTIME_CONFIG__: {
+        VITE_API_URL: "https://app.example.com/api",
+      },
+    });
+    expect(resolvePublicEnvVar("VITE_API_URL", "http://localhost:1337")).toBe(
+      "https://app.example.com/api",
+    );
+  });
+
+  it("ignores empty runtime strings", () => {
+    vi.stubGlobal("window", {
+      __KANEO_RUNTIME_CONFIG__: { VITE_API_URL: "   " },
+    });
+    expect(resolvePublicEnvVar("VITE_API_URL", "http://x")).toBe("http://x");
+  });
+});

--- a/packages/libs/src/runtime-public-env.ts
+++ b/packages/libs/src/runtime-public-env.ts
@@ -1,0 +1,30 @@
+export type KaneoRuntimePublicConfig = {
+  VITE_API_URL?: string;
+  VITE_CLIENT_URL?: string;
+};
+
+declare global {
+  interface Window {
+    __KANEO_RUNTIME_CONFIG__?: KaneoRuntimePublicConfig;
+  }
+}
+
+function readRuntime(key: keyof KaneoRuntimePublicConfig): string | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+  const raw = window.__KANEO_RUNTIME_CONFIG__?.[key];
+  return typeof raw === "string" && raw.trim() !== "" ? raw : undefined;
+}
+
+/**
+ * In Docker, `env.sh` maps `KANEO_API_URL` / `KANEO_CLIENT_URL` into
+ * `window.__KANEO_RUNTIME_CONFIG__` before the SPA loads so the browser uses the public URL
+ * (for example HTTPS behind a reverse proxy) instead of an internal build-time or sed value.
+ */
+export function resolvePublicEnvVar(
+  key: keyof KaneoRuntimePublicConfig,
+  buildValue: string | undefined,
+): string | undefined {
+  return readRuntime(key) ?? buildValue;
+}


### PR DESCRIPTION
## Description

Adds a small runtime `env-config.js` generated at container startup from `KANEO_API_URL` and `KANEO_CLIENT_URL` (base64-encoded in `env.sh` so URLs cannot break the shell), and loads it before the SPA bundle. The web app and `@kaneo/libs` Hono client now resolve `VITE_API_URL` / `VITE_CLIENT_URL` via `resolvePublicEnvVar()`, which prefers `window.__KANEO_RUNTIME_CONFIG__` over build-time placeholders. This avoids relying on `sed` inside hashed JS chunks for HTTPS reverse-proxy setups where the browser was still calling `http://<internal host>:1337` (mixed content).

## Related Issue(s)

Fixes #1218

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests (`@kaneo/libs` — `runtime-public-env.test.ts`; existing `api-url` tests)
- [ ] Integration tests
- [x] Manual testing (production `pnpm` web build; simulated `env-config.js` generation / `atob` decode)
- [ ] Other (please describe):

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Infrastructure now supports configurable environment settings at deployment time, enabling faster environment setup without rebuilding the application for different deployment targets.

* **Tests**
  * Added test coverage for runtime environment variable resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->