### PR TITLE
fix: Update healthcheck URL

### DIFF
--- a/Dockerfile.kaneo
+++ b/Dockerfile.kaneo
@@ -95,6 +95,6 @@ USER appuser
 EXPOSE 5173
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:5173/api/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:5173/api/health || exit 1
 
 CMD ["/usr/local/bin/kaneo-entrypoint.sh"]


### PR DESCRIPTION
## Description
This PR introduces the change to the Healthcheck inside of the Dockerfile that changes the healthcheck URL from `localhost` to `127.0.0.1`

## Related Issue(s)
None.

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
Discovered this in my production env when switching from the web&api images to the single kaneo image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service health check reliability by updating the health check endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->