### PR TITLE
fix: properly construct WS URL

### DIFF
--- a/apps/web/src/hooks/use-project-websocket.test.ts
+++ b/apps/web/src/hooks/use-project-websocket.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@kaneo/libs", () => ({
+  windowId: "test-window-id",
+}));
+
+import { getWsUrl } from "./use-project-websocket";
+
+describe("getWsUrl", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_API_URL", "http://localhost:1337");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("builds a ws:// URL from an http API base", () => {
+    expect(getWsUrl("project-123")).toBe(
+      "ws://localhost:1337/api/ws/project-123?windowId=test-window-id",
+    );
+  });
+
+  it("builds a wss:// URL from an https API base", () => {
+    vi.stubEnv("VITE_API_URL", "https://example.com");
+    expect(getWsUrl("project-123")).toBe(
+      "wss://example.com/api/ws/project-123?windowId=test-window-id",
+    );
+  });
+
+  it("does not append /api when the base already ends with /api", () => {
+    vi.stubEnv("VITE_API_URL", "https://example.com/api");
+    expect(getWsUrl("p1")).toBe(
+      "wss://example.com/api/ws/p1?windowId=test-window-id",
+    );
+  });
+
+  it("trims trailing slashes from the API base", () => {
+    vi.stubEnv("VITE_API_URL", "http://localhost:1337///");
+    expect(getWsUrl("p1")).toBe(
+      "ws://localhost:1337/api/ws/p1?windowId=test-window-id",
+    );
+  });
+
+  it("URL-encodes the projectId", () => {
+    expect(getWsUrl("a b/c?d")).toBe(
+      "ws://localhost:1337/api/ws/a%20b%2Fc%3Fd?windowId=test-window-id",
+    );
+  });
+});

--- a/apps/web/src/hooks/use-project-websocket.ts
+++ b/apps/web/src/hooks/use-project-websocket.ts
@@ -1,14 +1,13 @@
 import { windowId } from "@kaneo/libs";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
+import { getApiUrl } from "@/fetchers/get-api-url.ts";
 import { authClient } from "@/lib/auth-client";
 
-function getWsUrl(projectId: string) {
-  const base = (
-    import.meta.env.VITE_API_URL || "http://localhost:1337"
-  ).replace(/\/+$/, "");
+export function getWsUrl(projectId: string) {
+  const base = getApiUrl("ws");
   const wsBase = base.replace(/^http/, "ws");
-  return `${wsBase}/ws/${encodeURIComponent(projectId)}?windowId=${encodeURIComponent(windowId)}`;
+  return `${wsBase}/${encodeURIComponent(projectId)}?windowId=${encodeURIComponent(windowId)}`;
 }
 
 const MAX_RETRIES = 5;

--- a/apps/web/src/hooks/use-project-websocket.ts
+++ b/apps/web/src/hooks/use-project-websocket.ts
@@ -1,7 +1,7 @@
 import { windowId } from "@kaneo/libs";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
-import { getApiUrl } from "@/fetchers/get-api-url.ts";
+import { getApiUrl } from "@/fetchers/get-api-url";
 import { authClient } from "@/lib/auth-client";
 
 export function getWsUrl(projectId: string) {


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->
This PR properly construct the WS URL.

Explanation
https://github.com/usekaneo/kaneo/pull/1228#issuecomment-4417111823

## Related Issue(s)
<!-- Link to the related issue(s) this PR addresses -->
Fixes #
https://github.com/usekaneo/kaneo/commit/70596832d4eb325001a661cfadf6d4044a73863e
https://github.com/usekaneo/kaneo/pull/1228

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any other context about the PR here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for websocket URL construction, covering protocol conversion, API path handling, trailing-slash trimming, and project ID encoding.

* **Refactor**
  * Refactored websocket URL construction to use a shared utility for more consistent and maintainable URL generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usekaneo/kaneo/pull/1254)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->