### PR TITLE
fix(api): emit task.status_changed for git webhook status updates

### DIFF
--- a/apps/api/src/plugins/gitea/webhooks/pull-request-closed.ts
+++ b/apps/api/src/plugins/gitea/webhooks/pull-request-closed.ts
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import db from "../../../database";
 import { externalLinkTable } from "../../../database/schema";
+import { publishEvent } from "../../../events";
 import { updateExternalLink } from "../../github/services/link-manager";
 import {
   findTaskById,
@@ -101,7 +102,22 @@ export async function handleGiteaPullRequestClosed(payload: PRClosedPayload) {
           "pr_merged",
           config.statusTransitions?.onPRMerge || "done",
         );
-        await updateTaskStatus(task.id, targetStatus);
+        const statusResult = await updateTaskStatus(task.id, targetStatus);
+        if (
+          statusResult.applied &&
+          statusResult.before.status !== statusResult.after.status
+        ) {
+          await publishEvent("task.status_changed", {
+            taskId: statusResult.after.id,
+            projectId: statusResult.after.projectId,
+            userId: null,
+            oldStatus: statusResult.before.status,
+            newStatus: statusResult.after.status,
+            title: statusResult.after.title,
+            assigneeId: statusResult.after.userId,
+            type: "status_changed",
+          });
+        }
       }
     }
 

--- a/apps/api/src/plugins/gitea/webhooks/pull-request-opened.ts
+++ b/apps/api/src/plugins/gitea/webhooks/pull-request-opened.ts
@@ -1,3 +1,4 @@
+import { publishEvent } from "../../../events";
 import {
   createExternalLink,
   findExternalLink,
@@ -122,7 +123,22 @@ export async function handleGiteaPullRequestOpened(payload: PROpenedPayload) {
     const isTaskFinal = await isTaskInFinalState(task);
 
     if (task.status !== targetStatus && !isTaskFinal) {
-      await updateTaskStatus(task.id, targetStatus);
+      const statusResult = await updateTaskStatus(task.id, targetStatus);
+      if (
+        statusResult.applied &&
+        statusResult.before.status !== statusResult.after.status
+      ) {
+        await publishEvent("task.status_changed", {
+          taskId: statusResult.after.id,
+          projectId: statusResult.after.projectId,
+          userId: null,
+          oldStatus: statusResult.before.status,
+          newStatus: statusResult.after.status,
+          title: statusResult.after.title,
+          assigneeId: statusResult.after.userId,
+          type: "status_changed",
+        });
+      }
     }
 
     return;

--- a/apps/api/src/plugins/gitea/webhooks/push.ts
+++ b/apps/api/src/plugins/gitea/webhooks/push.ts
@@ -1,3 +1,4 @@
+import { publishEvent } from "../../../events";
 import { createOrUpdateExternalLink } from "../../github/services/link-manager";
 import {
   findTaskByNumber,
@@ -140,7 +141,22 @@ export async function handleGiteaPush(payload: PushPayload) {
     const isTaskFinal = await isTaskInFinalState(task);
 
     if (task.status !== targetStatus && !isTaskFinal) {
-      await updateTaskStatus(task.id, targetStatus);
+      const statusResult = await updateTaskStatus(task.id, targetStatus);
+      if (
+        statusResult.applied &&
+        statusResult.before.status !== statusResult.after.status
+      ) {
+        await publishEvent("task.status_changed", {
+          taskId: statusResult.after.id,
+          projectId: statusResult.after.projectId,
+          userId: null,
+          oldStatus: statusResult.before.status,
+          newStatus: statusResult.after.status,
+          title: statusResult.after.title,
+          assigneeId: statusResult.after.userId,
+          type: "status_changed",
+        });
+      }
     }
   }
 }

--- a/apps/api/src/plugins/github/webhooks/issue-closed.ts
+++ b/apps/api/src/plugins/github/webhooks/issue-closed.ts
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import db from "../../../database";
 import { externalLinkTable, taskTable } from "../../../database/schema";
+import { publishEvent } from "../../../events";
 import { updateExternalLink } from "../services/link-manager";
 import {
   findAllIntegrationsByRepo,
@@ -66,7 +67,22 @@ export async function handleIssueClosed(payload: IssueClosedPayload) {
       "done",
     );
 
-    await updateTaskStatus(task.id, targetStatus);
+    const statusResult = await updateTaskStatus(task.id, targetStatus);
+    if (
+      statusResult.applied &&
+      statusResult.before.status !== statusResult.after.status
+    ) {
+      await publishEvent("task.status_changed", {
+        taskId: statusResult.after.id,
+        projectId: statusResult.after.projectId,
+        userId: null,
+        oldStatus: statusResult.before.status,
+        newStatus: statusResult.after.status,
+        title: statusResult.after.title,
+        assigneeId: statusResult.after.userId,
+        type: "status_changed",
+      });
+    }
 
     await updateExternalLink(externalLink.id, {
       metadata: {

--- a/apps/api/src/plugins/github/webhooks/issue-labeled.ts
+++ b/apps/api/src/plugins/github/webhooks/issue-labeled.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import db from "../../../database";
 import { labelTable, taskTable } from "../../../database/schema";
+import { publishEvent } from "../../../events";
 import { findExternalLink } from "../services/link-manager";
 import {
   findAllIntegrationsByRepo,
@@ -57,7 +58,22 @@ export async function handleIssueLabeled(payload: IssueLabeledPayload) {
     }
 
     if (status) {
-      await updateTaskStatus(existingLink.taskId, status);
+      const statusResult = await updateTaskStatus(existingLink.taskId, status);
+      if (
+        statusResult.applied &&
+        statusResult.before.status !== statusResult.after.status
+      ) {
+        await publishEvent("task.status_changed", {
+          taskId: statusResult.after.id,
+          projectId: statusResult.after.projectId,
+          userId: null,
+          oldStatus: statusResult.before.status,
+          newStatus: statusResult.after.status,
+          title: statusResult.after.title,
+          assigneeId: statusResult.after.userId,
+          type: "status_changed",
+        });
+      }
     }
 
     if (!addedLabel) {

--- a/apps/api/src/plugins/github/webhooks/pull-request-closed.ts
+++ b/apps/api/src/plugins/github/webhooks/pull-request-closed.ts
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import db from "../../../database";
 import { externalLinkTable } from "../../../database/schema";
+import { publishEvent } from "../../../events";
 import type { GitHubConfig } from "../config";
 import { updateExternalLink } from "../services/link-manager";
 import {
@@ -91,7 +92,22 @@ export async function handlePullRequestClosed(payload: PRClosedPayload) {
           "pr_merged",
           config.statusTransitions?.onPRMerge || "done",
         );
-        await updateTaskStatus(task.id, targetStatus);
+        const statusResult = await updateTaskStatus(task.id, targetStatus);
+        if (
+          statusResult.applied &&
+          statusResult.before.status !== statusResult.after.status
+        ) {
+          await publishEvent("task.status_changed", {
+            taskId: statusResult.after.id,
+            projectId: statusResult.after.projectId,
+            userId: null,
+            oldStatus: statusResult.before.status,
+            newStatus: statusResult.after.status,
+            title: statusResult.after.title,
+            assigneeId: statusResult.after.userId,
+            type: "status_changed",
+          });
+        }
       }
     }
 

--- a/apps/api/src/plugins/github/webhooks/pull-request-opened.ts
+++ b/apps/api/src/plugins/github/webhooks/pull-request-opened.ts
@@ -1,3 +1,4 @@
+import { publishEvent } from "../../../events";
 import type { GitHubConfig } from "../config";
 import { createExternalLink, findExternalLink } from "../services/link-manager";
 import {
@@ -100,7 +101,22 @@ export async function handlePullRequestOpened(payload: PROpenedPayload) {
     const isTaskFinal = await isTaskInFinalState(task);
 
     if (task.status !== targetStatus && !isTaskFinal) {
-      await updateTaskStatus(task.id, targetStatus);
+      const statusResult = await updateTaskStatus(task.id, targetStatus);
+      if (
+        statusResult.applied &&
+        statusResult.before.status !== statusResult.after.status
+      ) {
+        await publishEvent("task.status_changed", {
+          taskId: statusResult.after.id,
+          projectId: statusResult.after.projectId,
+          userId: null,
+          oldStatus: statusResult.before.status,
+          newStatus: statusResult.after.status,
+          title: statusResult.after.title,
+          assigneeId: statusResult.after.userId,
+          type: "status_changed",
+        });
+      }
     }
 
     return;

--- a/apps/api/src/plugins/github/webhooks/push.ts
+++ b/apps/api/src/plugins/github/webhooks/push.ts
@@ -1,3 +1,4 @@
+import { publishEvent } from "../../../events";
 import type { GitHubConfig } from "../config";
 import { createOrUpdateExternalLink } from "../services/link-manager";
 import {
@@ -134,7 +135,22 @@ export async function handlePush(payload: PushPayload) {
       console.log(
         `[Push] Updating task ${task.id} status from ${task.status} to ${targetStatus}`,
       );
-      await updateTaskStatus(task.id, targetStatus);
+      const statusResult = await updateTaskStatus(task.id, targetStatus);
+      if (
+        statusResult.applied &&
+        statusResult.before.status !== statusResult.after.status
+      ) {
+        await publishEvent("task.status_changed", {
+          taskId: statusResult.after.id,
+          projectId: statusResult.after.projectId,
+          userId: null,
+          oldStatus: statusResult.before.status,
+          newStatus: statusResult.after.status,
+          title: statusResult.after.title,
+          assigneeId: statusResult.after.userId,
+          type: "status_changed",
+        });
+      }
     } else {
       console.log(`[Push] Skipping status update - already ${task.status}`);
     }


### PR DESCRIPTION
## Description

Integration webhooks update task status through `updateTaskStatus()` in `apps/api/src/plugins/github/services/task-service.ts`, which only persists the row and does not emit `task.status_changed`. The HTTP API path uses `publishEvent("task.status_changed", …)`, which is what drives the plugin registry (Telegram, Slack, Discord, etc.).

This PR publishes `task.status_changed` after successful integration-driven status changes when the status actually changes, matching the payload shape used elsewhere (`userId: null` for non-user actors).

**Gitea:** `push`, `pull_request` opened/closed webhooks.  
**GitHub (same gap):** `push`, `pull_request` opened/closed, `issues` labeled/closed webhooks.

## Related Issue(s)

Fixes #1256

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Other (please describe): `pnpm exec biome check` on touched files; pre-commit `biome ci` + `pnpm run build` passed on commit.

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Webhook-triggered task status updates from Gitea and GitHub pull requests, issues, and push events now emit status change events, enabling other integrations and workflows to react automatically when task statuses change.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usekaneo/kaneo/pull/1263)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->