### PR TITLE
fix: remove duplicate import tasks modal close button

### DIFF
--- a/apps/web/src/components/project/tasks-import-export.tsx
+++ b/apps/web/src/components/project/tasks-import-export.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { saveAs } from "file-saver";
-import { Download, Loader2, Upload, X } from "lucide-react";
+import { Download, Loader2, Upload } from "lucide-react";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
@@ -175,12 +175,6 @@ export function TasksImportExport({ project }: TasksImportExportProps) {
               <DialogTitle className="text-lg font-semibold text-foreground">
                 {t("settings:tasksImportExport.dialogTitle")}
               </DialogTitle>
-              <DialogClose
-                className="text-muted-foreground hover:text-foreground"
-                render={<button type="button" />}
-              >
-                <X size={20} className="cursor-pointer" />
-              </DialogClose>
             </div>
 
             <div className="p-4">


### PR DESCRIPTION
## Description
Removes the duplicate close icon from the Project Settings import tasks modal. The modal still keeps the existing footer cancel/close action, so users have a single clear way to dismiss it without two competing close controls.

## Related Issue(s)
No existing issue found.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Other (please describe):
  - `pnpm --filter @kaneo/web lint`
  - `pnpm run build`

## Screenshots (if applicable)
Before: 
<img width="469" height="564" alt="Screenshot 2026-05-13 at 18 48 55" src="https://github.com/user-attachments/assets/670e8aaf-a8a9-4ba0-9392-568dc91f4778" />

After:
<img width="483" height="579" alt="Screenshot 2026-05-13 at 18 52 58" src="https://github.com/user-attachments/assets/479c3c61-f01e-412b-97e9-2f2715bfadeb" />




## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
This is a small UI-only cleanup, so no automated tests were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the import dialog by removing the close button from the header; users can still cancel via the footer action.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usekaneo/kaneo/pull/1264)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->