### PR TITLE
fix(github): skip issues opened by the configured app bot

### DIFF
--- a/apps/api/src/plugins/github/webhooks/issue-opened.ts
+++ b/apps/api/src/plugins/github/webhooks/issue-opened.ts
@@ -39,6 +39,14 @@ export async function handleIssueOpened(payload: IssueOpenedPayload) {
 
   const { issue, repository } = payload;
 
+  const appName = process.env.GITHUB_APP_NAME;
+  if (appName && issue.user?.login === `${appName}[bot]`) {
+    console.log(
+      `Issue #${issue.number} was created by the configured GitHub App, skipping task creation`,
+    );
+    return;
+  }
+
   const integrations = await findAllIntegrationsByRepo(
     repository.owner.login,
     repository.name,


### PR DESCRIPTION
## Problem

When I create a Kaneo task in a project connected to a GitHub repository, Kaneo correctly creates a GitHub issue for that task. However, GitHub then sends an `issues.opened` webhook back to Kaneo. The webhook handler can treat that issue as if it was manually created in GitHub, so it creates a second Kaneo task from the same GitHub issue.

The result is:

1. I create a Kaneo task, for example `ORA-4`.
2. Kaneo creates a GitHub issue for that task.
3. GitHub sends an `issues.opened` webhook.
4. Kaneo creates another task, for example `ORA-5`, from that same issue.
5. Both Kaneo tasks end up linked to the same GitHub issue.
6. If "comment Kaneo link on new issues" is enabled, Kaneo comments on the GitHub issue with the duplicate task link instead of the original task link.

In my case, the duplicate task description included the original task id, which made the loop visible:

```text
Task: <original Kaneo task id>
```

## Expected behavior

Kaneo should not create a new task from a GitHub issue that was created by Kaneo itself.

The intended sync behavior should remain:

- Kaneo task → GitHub issue
- GitHub manually-created issue → Kaneo task

But this loop should be prevented:

- Kaneo task → GitHub issue → Kaneo duplicate task

## Root cause

The `issues.opened` webhook handler currently relies on checking whether an external link already exists for the incoming GitHub issue.

That is not always enough. If the GitHub webhook is delivered before the original task-to-issue external link is available, Kaneo sees no existing link and creates a duplicate task.

## Fix

In `apps/api/src/plugins/github/webhooks/issue-opened.ts`, ignore `issues.opened` webhooks when the issue author matches the configured GitHub App bot:

```ts
const appName = process.env.GITHUB_APP_NAME;
if (appName && issue.user?.login === `${appName}[bot]`) {
  console.log(
    `Issue #${issue.number} was created by the configured GitHub App, skipping task creation`,
  );
  return;
}
```

This is intentionally small and avoids a database migration. It preserves the bidirectional sync model:

- Kaneo-created tasks can still create GitHub issues.
- Manually-created GitHub issues can still create Kaneo tasks.
- GitHub webhook retries are still covered by the existing external-link lookup.
- Self-created GitHub issues no longer get imported back into Kaneo as duplicate tasks.

When `GITHUB_APP_NAME` is unset, the existing external-link check remains the fallback behavior, so this change is safe for instances that haven't configured the optional app name.

The check is generalized and not specific to any deployment — it uses the configured `GITHUB_APP_NAME` rather than hardcoding any particular app slug.

## Test plan

- [ ] Create a Kaneo task in a project with a GitHub integration → only one Kaneo task exists after the webhook fires.
- [ ] Open an issue manually in the GitHub UI → Kaneo still creates a task for it.
- [ ] Replay a duplicate `issues.opened` webhook for an existing linked issue → existing external-link check still skips it.
- [ ] Unset `GITHUB_APP_NAME` → behavior reverts to the prior external-link-only path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issues opened by the configured GitHub App bot are now skipped from task creation and linking logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usekaneo/kaneo/pull/1281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->