### PR TITLE
feat(helm): publishing helm chart to GHCR

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -1,0 +1,103 @@
+name: Build & publish Helm chart to GHCR
+
+on:
+  pull_request:
+    paths:
+      - "charts/kaneo/**"
+      - ".github/workflows/helm-chart.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "charts/kaneo/**"
+      - ".github/workflows/helm-chart.yml"
+  workflow_dispatch:
+
+env:
+  CHART_PATH: charts/kaneo
+  REGISTRY: ghcr.io
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default
+            args: ""
+          - name: ingress
+            args: >-
+              --set ingress.enabled=true
+              --set kaneo.env.authSecret=secure-auth-secret-at-least-32-characters
+              --set postgresql.auth.password=secure-db-password
+          - name: gateway
+            args: >-
+              --set gateway.enabled=true
+              --set gateway.parentRefs[0].name=gateway
+              --set kaneo.env.authSecret=secure-auth-secret-at-least-32-characters
+              --set postgresql.auth.password=secure-db-password
+          - name: autoscaling
+            args: >-
+              --set autoscaling.enabled=true
+              --set kaneo.resources.requests.cpu=100m
+          - name: external-database
+            args: >-
+              --set postgresql.enabled=false
+              --set kaneo.env.database.external.enabled=true
+              --set kaneo.env.database.external.host=db.example.com
+              --set kaneo.env.database.external.password=secure-db-password
+          - name: bundled-postgresql-secret
+            args: >-
+              --set postgresql.auth.existingSecret=kaneo-secrets
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
+
+      - name: Lint chart
+        run: helm lint "$CHART_PATH"
+
+      - name: Render chart (${{ matrix.name }})
+        run: helm template kaneo "$CHART_PATH" ${{ matrix.args }}
+
+  publish:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    needs: validate
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
+
+      - name: Package chart
+        run: |
+          mkdir -p dist
+          helm package "$CHART_PATH" --destination dist
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login "$REGISTRY" --username "${{ github.actor }}" --password-stdin
+
+      - name: Publish chart
+        run: |
+          OWNER="${GITHUB_REPOSITORY_OWNER,,}"
+          CHART_VERSION=$(helm show chart "$CHART_PATH" | awk '/^version:/ { print $2 }')
+          CHART_REF="oci://$REGISTRY/$OWNER/charts/kaneo"
+
+          if helm show chart "$CHART_REF" --version "$CHART_VERSION" >/dev/null 2>&1; then
+            echo "Chart $CHART_REF:$CHART_VERSION already exists; skipping publish."
+            exit 0
+          fi
+
+          helm push dist/kaneo-"$CHART_VERSION".tgz "oci://$REGISTRY/$OWNER/charts"

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
@@ -77,6 +79,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
@@ -87,7 +91,10 @@ jobs:
           helm package "$CHART_PATH" --destination dist
 
       - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login "$REGISTRY" --username "${{ github.actor }}" --password-stdin
+        env:
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GH_TOKEN" | helm registry login "$REGISTRY" --username "$GH_ACTOR" --password-stdin
 
       - name: Publish chart
         run: |

--- a/charts/kaneo/.helmignore
+++ b/charts/kaneo/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.helmignore
+*.swp
+*.tmp
+*.tgz

--- a/charts/kaneo/Chart.yaml
+++ b/charts/kaneo/Chart.yaml
@@ -2,9 +2,8 @@ apiVersion: v2
 name: kaneo
 description: Kaneo - All you need. Nothing you don't. Open source project management that works for you.
 type: application
-# 0.4.0: add kaneo.extraEnv for arbitrary env vars on the kaneo container
-version: 0.4.0
-appVersion: "2.6.0"
+version: 0.4.1
+appVersion: "2.7.7"
 keywords:
   - project-management
   - kanban
@@ -28,4 +27,4 @@ annotations:
     - Self-hosted: Full control over your data
     - Customizable: Make it yours with extensive customization options
     - Open Source: MIT licensed
-kubeVersion: ">=1.19.0-0"
+kubeVersion: ">=1.23.0-0"

--- a/charts/kaneo/README.md
+++ b/charts/kaneo/README.md
@@ -8,7 +8,7 @@ This chart bootstraps a Kaneo deployment on a Kubernetes cluster using the Helm 
 
 ## Prerequisites
 
-- Kubernetes 1.19+
+- Kubernetes 1.23+
 - Helm 3.2.0+
 - PV provisioner support in the underlying infrastructure (if persistence is enabled)
 
@@ -16,18 +16,15 @@ This chart bootstraps a Kaneo deployment on a Kubernetes cluster using the Helm 
 
 ### Basic Installation
 
-Clone the repository and install with Helm:
+Install directly from GHCR:
 
 ```bash
-# Clone the repo
-git clone https://github.com/usekaneo/kaneo.git
-cd kaneo
-
-# Install with Helm
-helm install kaneo ./charts/kaneo --namespace kaneo --create-namespace
+helm install kaneo oci://ghcr.io/usekaneo/charts/kaneo \
+  --namespace kaneo \
+  --create-namespace
 
 # Access locally
-kubectl port-forward svc/kaneo-web 5173:5173 -n kaneo
+kubectl port-forward svc/kaneo-kaneo 5173:5173 -n kaneo
 ```
 
 Open [http://localhost:5173](http://localhost:5173) and you're ready to go.
@@ -37,7 +34,7 @@ Open [http://localhost:5173](http://localhost:5173) and you're ready to go.
 For real deployments, you'll want proper ingress:
 
 ```bash
-helm install kaneo ./charts/kaneo \
+helm install kaneo oci://ghcr.io/usekaneo/charts/kaneo \
   --namespace kaneo \
   --create-namespace \
   --set ingress.enabled=true \
@@ -50,7 +47,7 @@ helm install kaneo ./charts/kaneo \
 If your cluster already has Gateway API CRDs and a `Gateway` configured, you can expose Kaneo with an `HTTPRoute`:
 
 ```bash
-helm install kaneo ./charts/kaneo \
+helm install kaneo oci://ghcr.io/usekaneo/charts/kaneo \
   --namespace kaneo \
   --create-namespace \
   --set gateway.enabled=true \
@@ -62,7 +59,13 @@ helm install kaneo ./charts/kaneo \
 
 ## Installing the Chart
 
-To install the chart with the release name `my-kaneo`:
+To install the published chart with the release name `my-kaneo`:
+
+```bash
+helm install my-kaneo oci://ghcr.io/usekaneo/charts/kaneo
+```
+
+To install from a local checkout instead:
 
 ```bash
 helm install my-kaneo ./charts/kaneo
@@ -97,6 +100,8 @@ helm uninstall my-kaneo
 | `autoscaling.maxReplicas`           | Maximum number of replicas                                                                                         | `10`        |
 | `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage                                                                         | `80`        |
 
+When CPU autoscaling is enabled, set `kaneo.resources.requests.cpu`; Kubernetes cannot calculate CPU utilization without a CPU request.
+
 ### PostgreSQL Database parameters
 
 | Name                                | Description                                                                                                        | Value                           |
@@ -117,43 +122,33 @@ helm uninstall my-kaneo
 | `postgresql.service.port`           | PostgreSQL service port                                                                                            | `5432`                          |
 | `postgresql.resources`              | Resource requests and limits for PostgreSQL container                                                              | `{}`                            |
 
-### API Backend parameters
+### Kaneo application parameters
 
 | Name                                | Description                                                                                                        | Value                           |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------- |
-| `api.image.repository`              | API image repository                                                                                              | `ghcr.io/usekaneo/api`          |
-| `api.image.tag`                     | API image tag                                                                                                     | `latest`                        |
-| `api.image.pullPolicy`              | API image pull policy                                                                                             | `IfNotPresent`                  |
-| `api.service.type`                  | API service type                                                                                                  | `ClusterIP`                     |
-| `api.service.port`                  | API service port                                                                                                  | `1337`                          |
-| `api.service.targetPort`            | API container port                                                                                                | `1337`                          |
-| `api.env`                           | Environment variables for the API container                                                                       | See `values.yaml`               |
-| `api.env.jwtAccess`                 | Secret key for JWT token generation (ignored if existingSecret is enabled)                                        | `change_me`                     |
-| `api.env.existingSecret.enabled`    | Whether to use an existing secret for JWT access token                                                            | `false`                         |
-| `api.env.existingSecret.name`       | Name of the existing secret containing the JWT access token                                                       | `""`                            |
-| `api.env.existingSecret.key`        | Key in the existing secret that contains the JWT access token                                                     | `jwt-access`                    |
-| `api.env.disableRegistration`       | Disable new user registration                                                                                      | `false`                         |
-| `api.env.disablePasswordRegistration` | Disable password-based account creation while keeping social/OIDC registration available                        | `false`                         |
-| `api.env.database.external.enabled` | Use external PostgreSQL database (set postgresql.enabled to false)                                               | `false`                         |
-| `api.env.database.external.host`    | External PostgreSQL host                                                                                          | `""`                            |
-| `api.env.database.external.port`    | External PostgreSQL port                                                                                          | `5432`                          |
-| `api.env.database.external.database` | External PostgreSQL database name                                                                                | `kaneo`                         |
-| `api.env.database.external.username` | External PostgreSQL username                                                                                     | `kaneo_user`                    |
-| `api.env.database.external.password` | External PostgreSQL password                                                                                     | `""`                            |
-| `api.resources`                     | Resource requests and limits for the API container (optional, disabled by default)                                | `{}`                            |
-
-### Web Frontend parameters
-
-| Name                                | Description                                                                                                        | Value                           |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------- |
-| `web.image.repository`              | Web image repository                                                                                               | `ghcr.io/usekaneo/web`          |
-| `web.image.tag`                     | Web image tag                                                                                                      | `latest`                        |
-| `web.image.pullPolicy`              | Web image pull policy                                                                                              | `IfNotPresent`                  |
-| `web.service.type`                  | Web service type                                                                                                   | `ClusterIP`                     |
-| `web.service.port`                  | Web service port                                                                                                   | `80`                            |
-| `web.service.targetPort`            | Web container port                                                                                                 | `80`                            |
-| `web.env`                           | Environment variables for the Web container                                                                        | See `values.yaml`               |
-| `web.resources`                     | Resource requests and limits for the Web container (optional, disabled by default)                                 | `{}`                            |
+| `kaneo.image.repository`            | Kaneo image repository                                                                                             | `ghcr.io/usekaneo/kaneo`        |
+| `kaneo.image.tag`                   | Kaneo image tag. Defaults to `Chart.appVersion` when empty                                                         | `""`                            |
+| `kaneo.image.pullPolicy`            | Kaneo image pull policy                                                                                            | `IfNotPresent`                  |
+| `kaneo.service.type`                | Kaneo service type                                                                                                 | `ClusterIP`                     |
+| `kaneo.service.port`                | Kaneo service port                                                                                                 | `5173`                          |
+| `kaneo.service.targetPort`          | Kaneo container port                                                                                               | `5173`                          |
+| `kaneo.env`                         | Environment variables for the Kaneo container                                                                      | See `values.yaml`               |
+| `kaneo.env.clientUrl`               | Public URL of the Kaneo instance                                                                                   | `""`                            |
+| `kaneo.env.corsOrigins`             | Allowed CORS origins as a comma-separated string or YAML list                                                      | `[]`                            |
+| `kaneo.env.authSecret`              | Better Auth secret, ignored if existingSecret is enabled                                                           | `change_me_to_at_least_32_characters_long_string` |
+| `kaneo.env.existingSecret.enabled`  | Whether to use an existing secret for `AUTH_SECRET`                                                                | `false`                         |
+| `kaneo.env.existingSecret.name`     | Name of the existing secret containing `AUTH_SECRET`                                                               | `""`                            |
+| `kaneo.env.existingSecret.key`      | Key in the existing secret that contains `AUTH_SECRET`                                                             | `auth-secret`                   |
+| `kaneo.env.disableRegistration`     | Disable new user registration                                                                                      | `false`                         |
+| `kaneo.env.disablePasswordRegistration` | Disable password-based account creation while keeping social/OIDC registration available                        | `false`                         |
+| `kaneo.env.database.external.enabled` | Use external PostgreSQL database (set postgresql.enabled to false)                                               | `false`                         |
+| `kaneo.env.database.external.host`  | External PostgreSQL host                                                                                           | `""`                            |
+| `kaneo.env.database.external.port`  | External PostgreSQL port                                                                                           | `5432`                          |
+| `kaneo.env.database.external.database` | External PostgreSQL database name                                                                               | `kaneo`                         |
+| `kaneo.env.database.external.username` | External PostgreSQL username                                                                                    | `kaneo_user`                    |
+| `kaneo.env.database.external.password` | External PostgreSQL password                                                                                    | `""`                            |
+| `kaneo.extraEnv`                    | Additional Kubernetes EnvVar entries appended to the Kaneo container                                               | `[]`                            |
+| `kaneo.resources`                   | Resource requests and limits for the Kaneo container (optional, disabled by default)                               | `{}`                            |
 
 ### Ingress parameters
 
@@ -182,30 +177,22 @@ helm uninstall my-kaneo
 
 ```yaml
 # values.yaml
-api:
+kaneo:
   env:
-    jwtAccess: "your-secure-jwt-secret"
-
-web:
-  env:
-    apiUrl: "https://your-domain.com"
+    authSecret: "your-secure-auth-secret-at-least-32-characters"
+    clientUrl: "https://your-domain.com"
 
 ingress:
   enabled: true
   className: nginx
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
+  annotations: {}
   hosts:
     - host: your-domain.com
       paths:
-        - path: /?(.*)
+        - path: /
           pathType: Prefix
-          service: web
-          port: 80
-        - path: /api/?(.*)
-          pathType: Prefix
-          service: api
-          port: 1337
+          service: kaneo
+          port: 5173
 ```
 
 ### Production Configuration with TLS
@@ -229,8 +216,8 @@ postgresql:
       cpu: 100m
       memory: 128Mi
 
-# API configuration
-api:
+# Kaneo configuration
+kaneo:
   resources:
     limits:
       cpu: 1000m
@@ -239,19 +226,8 @@ api:
       cpu: 200m
       memory: 256Mi
   env:
-    jwtAccess: "your-secure-jwt-secret"
-
-# Web configuration
-web:
-  resources:
-    limits:
-      cpu: 500m
-      memory: 512Mi
-    requests:
-      cpu: 100m
-      memory: 128Mi
-  env:
-    apiUrl: "https://your-domain.com"
+    authSecret: "your-secure-auth-secret-at-least-32-characters"
+    clientUrl: "https://your-domain.com"
 
 ingress:
   enabled: true
@@ -259,18 +235,13 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
   hosts:
     - host: your-domain.com
       paths:
         - path: /
           pathType: Prefix
-          service: web
-          port: 80
-        - path: /api/?(.*)
-          pathType: Prefix
-          service: api
-          port: 1337
+          service: kaneo
+          port: 5173
   tls:
     - secretName: kaneo-tls
       hosts:
@@ -287,9 +258,9 @@ If you prefer to use an external PostgreSQL database instead of the bundled one:
 postgresql:
   enabled: false
 
-api:
+kaneo:
   env:
-    jwtAccess: "your-secure-jwt-secret"
+    authSecret: "your-secure-auth-secret-at-least-32-characters"
     database:
       external:
         enabled: true
@@ -302,13 +273,15 @@ api:
 
 ### Using an Existing Secret for Sensitive Data
 
-For production environments, it's recommended to store sensitive data like the JWT access token and database credentials in Kubernetes Secrets:
+For production environments, it's recommended to store sensitive data like the auth secret and database credentials in Kubernetes Secrets:
+
+When `postgresql.auth.existingSecret` is used with bundled PostgreSQL, the password is expanded by Kubernetes into `DATABASE_URL` at runtime and must be URL-safe. If your password contains reserved URI characters such as `@`, `:`, `/`, `#`, `%`, or spaces, use an external database and provide the complete connection URI through `kaneo.env.database.external.existingSecret`.
 
 ```bash
 # Create a Secret for sensitive data
 kubectl create secret generic kaneo-secrets \
   --namespace kaneo \
-  --from-literal=jwt-access="your-secure-jwt-secret" \
+  --from-literal=auth-secret="your-secure-auth-secret-at-least-32-characters" \
   --from-literal=postgres-password="your-secure-db-password"
 ```
 
@@ -322,12 +295,12 @@ postgresql:
     secretKeys:
       userPasswordKey: "postgres-password"
 
-api:
+kaneo:
   env:
     existingSecret:
       enabled: true
       name: "kaneo-secrets"
-      key: "jwt-access"
+      key: "auth-secret"
 ```
 
 ## Database Management
@@ -339,6 +312,17 @@ The chart deploys PostgreSQL 16 (Alpine) by default with the following configura
 - Username: `kaneo_user`
 - Default password: `kaneo_password` (change this in production!)
 - Persistent storage: 8Gi (configurable)
+
+The bundled PostgreSQL deployment is intended for development, trials, and small self-hosted installs. For production environments, use an external managed PostgreSQL database by setting `postgresql.enabled=false` and configuring `kaneo.env.database.external`.
+
+Bundled PostgreSQL credentials are only applied when PostgreSQL initializes an empty data directory. If a PVC already exists, changing `postgresql.auth.password` or `postgresql.auth.existingSecret` updates the Pod environment but does not rotate the password inside the existing database. For local retesting with a new password, uninstall the release and delete the test PVC before reinstalling:
+
+```bash
+helm uninstall kaneo -n kaneo-test
+kubectl delete pvc kaneo-postgresql-data -n kaneo-test --ignore-not-found
+```
+
+To preserve data, rotate the password inside PostgreSQL first, then update the Helm values to match.
 
 ### Backup and Recovery
 
@@ -362,17 +346,16 @@ Contact the Kaneo community on [Discord](https://discord.gg/rU4tSyhXXU) for migr
 
 This chart deploys the following components:
 
-1. **API Backend**: Handles all business logic and database operations
-2. **Web Frontend**: Serves the user interface
-3. **PostgreSQL Database**: Stores all application data with proper relational integrity
+1. **Kaneo application**: Serves the web UI and API from the combined Kaneo image
+2. **PostgreSQL Database**: Stores all application data with proper relational integrity
 
-The API and Web components are deployed in the same pod for simplified connectivity, while PostgreSQL runs in a separate pod for better resource isolation and management.
+The Kaneo application and PostgreSQL run in separate pods for resource isolation and simpler database lifecycle management.
 
 ## Production Environment
 
 For production deployments, you should:
 
-1. Set secure passwords for JWT and PostgreSQL
+1. Set secure values for `AUTH_SECRET` and PostgreSQL passwords
 2. Use an Ingress controller to expose the application
 3. Configure TLS for secure access
 4. Set appropriate resource limits and requests
@@ -386,18 +369,13 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
   hosts:
     - host: your-domain.com
       paths:
-        - path: /?(.*)
+        - path: /
           pathType: Prefix
-          service: web
-          port: 80
-        - path: /api/?(.*)
-          pathType: Prefix
-          service: api
-          port: 1337
+          service: kaneo
+          port: 5173
   tls:
     - secretName: kaneo-tls
       hosts:
@@ -420,18 +398,17 @@ gateway:
     - kaneo.example.com
 ```
 
-By default the chart creates two Gateway API rules:
+By default the chart creates one Gateway API rule:
 
-1. `/api` goes to the API service and rewrites the prefix to `/`
-2. `/` goes to the web service
+1. `/` goes to the Kaneo service
 
-If you need custom matching or multiple backend references, override `gateway.rules` directly. Each `backendRefs` entry follows the same pattern as ingress and uses the chart-specific `service` field (`api` or `web`), which is expanded to the release-specific Service name.
+If you need custom matching or multiple backend references, override `gateway.rules` directly. Each `backendRefs` entry follows the same pattern as ingress and uses the chart-specific `service` field (`kaneo`), which is expanded to the release-specific Service name.
 
 ## Security
 
 For production deployments, consider the following security recommendations:
 
-1. Use secure JWT_ACCESS and PostgreSQL passwords, preferably stored in Kubernetes Secrets
+1. Use secure `AUTH_SECRET` and PostgreSQL passwords, preferably stored in Kubernetes Secrets
 2. Enable TLS for ingress or Gateway API
 3. Enable and set resource limits to prevent resource exhaustion
 4. Use a dedicated storage class for the PostgreSQL database
@@ -443,7 +420,7 @@ For production deployments, consider the following security recommendations:
 By default, user registration is enabled. To disable new user registration:
 
 ```yaml
-api:
+kaneo:
   env:
     disableRegistration: true
 ```

--- a/charts/kaneo/templates/NOTES.txt
+++ b/charts/kaneo/templates/NOTES.txt
@@ -51,7 +51,7 @@ NOTES:
    {{- end }}
 
 2. Important environment variables:
-   - AUTH_SECRET: Secret key for Better Auth (currently set to: {{ .Values.kaneo.env.authSecret }})
+   - AUTH_SECRET: Secret key for Better Auth
    - KANEO_CLIENT_URL: Public URL of this instance (currently set to: "{{ .Values.kaneo.env.clientUrl }}")
    - DATABASE_URL: Derived from postgresql.auth values unless kaneo.env.database.external.enabled=true
 

--- a/charts/kaneo/templates/_helpers.tpl
+++ b/charts/kaneo/templates/_helpers.tpl
@@ -62,6 +62,14 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+URL-encode credentials for URI userinfo. Sprig urlquery uses form escaping,
+so spaces become +; in userinfo they must be %20 to preserve credentials.
+*/}}
+{{- define "kaneo.urlencodeUserinfo" -}}
+{{- . | urlquery | replace "+" "%20" -}}
+{{- end }}
+
+{{/*
 API component common labels
 */}}
 {{- define "kaneo.api.labels" -}}

--- a/charts/kaneo/templates/deployment.yaml
+++ b/charts/kaneo/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       {{- end }}
       labels:
         {{- include "kaneo.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: kaneo
     spec:
       serviceAccountName: {{ include "kaneo.serviceAccountName" . }}
       securityContext:
@@ -64,11 +65,22 @@ spec:
                   name: {{ .Values.kaneo.env.database.external.existingSecret.name }}
                   key: {{ .Values.kaneo.env.database.external.existingSecret.passwordKey }}
               {{- else }}
-              value: "postgresql://{{ .Values.kaneo.env.database.external.username }}:{{ .Values.kaneo.env.database.external.password }}@{{ .Values.kaneo.env.database.external.host }}:{{ .Values.kaneo.env.database.external.port }}/{{ .Values.kaneo.env.database.external.database }}"
+              value: "postgresql://{{ .Values.kaneo.env.database.external.username | urlquery }}:{{ .Values.kaneo.env.database.external.password | urlquery }}@{{ .Values.kaneo.env.database.external.host }}:{{ .Values.kaneo.env.database.external.port }}/{{ .Values.kaneo.env.database.external.database }}"
               {{- end }}
               {{- else }}
-              value: "postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ include "kaneo.fullname" . }}-postgresql:{{ .Values.postgresql.service.port }}/{{ .Values.postgresql.auth.database }}"
+              {{- if .Values.postgresql.auth.existingSecret }}
+              value: "postgresql://{{ .Values.postgresql.auth.username | urlquery }}:$(KANEO_POSTGRES_PASSWORD)@{{ include "kaneo.fullname" . }}-postgresql:{{ .Values.postgresql.service.port }}/{{ .Values.postgresql.auth.database }}"
+              {{- else }}
+              value: "postgresql://{{ .Values.postgresql.auth.username | urlquery }}:{{ .Values.postgresql.auth.password | urlquery }}@{{ include "kaneo.fullname" . }}-postgresql:{{ .Values.postgresql.service.port }}/{{ .Values.postgresql.auth.database }}"
               {{- end }}
+              {{- end }}
+            {{- if and (not .Values.kaneo.env.database.external.enabled) .Values.postgresql.auth.existingSecret }}
+            - name: KANEO_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.auth.existingSecret }}
+                  key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
+            {{- end }}
             - name: DISABLE_REGISTRATION
               value: {{ .Values.kaneo.env.disableRegistration | quote }}
             - name: DISABLE_PASSWORD_REGISTRATION

--- a/charts/kaneo/templates/deployment.yaml
+++ b/charts/kaneo/templates/deployment.yaml
@@ -65,13 +65,13 @@ spec:
                   name: {{ .Values.kaneo.env.database.external.existingSecret.name }}
                   key: {{ .Values.kaneo.env.database.external.existingSecret.passwordKey }}
               {{- else }}
-              value: "postgresql://{{ .Values.kaneo.env.database.external.username | urlquery }}:{{ .Values.kaneo.env.database.external.password | urlquery }}@{{ .Values.kaneo.env.database.external.host }}:{{ .Values.kaneo.env.database.external.port }}/{{ .Values.kaneo.env.database.external.database }}"
+              value: "postgresql://{{ include "kaneo.urlencodeUserinfo" .Values.kaneo.env.database.external.username }}:{{ include "kaneo.urlencodeUserinfo" .Values.kaneo.env.database.external.password }}@{{ .Values.kaneo.env.database.external.host }}:{{ .Values.kaneo.env.database.external.port }}/{{ .Values.kaneo.env.database.external.database }}"
               {{- end }}
               {{- else }}
               {{- if .Values.postgresql.auth.existingSecret }}
-              value: "postgresql://{{ .Values.postgresql.auth.username | urlquery }}:$(KANEO_POSTGRES_PASSWORD)@{{ include "kaneo.fullname" . }}-postgresql:{{ .Values.postgresql.service.port }}/{{ .Values.postgresql.auth.database }}"
+              value: "postgresql://{{ include "kaneo.urlencodeUserinfo" .Values.postgresql.auth.username }}:$(KANEO_POSTGRES_PASSWORD)@{{ include "kaneo.fullname" . }}-postgresql:{{ .Values.postgresql.service.port }}/{{ .Values.postgresql.auth.database }}"
               {{- else }}
-              value: "postgresql://{{ .Values.postgresql.auth.username | urlquery }}:{{ .Values.postgresql.auth.password | urlquery }}@{{ include "kaneo.fullname" . }}-postgresql:{{ .Values.postgresql.service.port }}/{{ .Values.postgresql.auth.database }}"
+              value: "postgresql://{{ include "kaneo.urlencodeUserinfo" .Values.postgresql.auth.username }}:{{ include "kaneo.urlencodeUserinfo" .Values.postgresql.auth.password }}@{{ include "kaneo.fullname" . }}-postgresql:{{ .Values.postgresql.service.port }}/{{ .Values.postgresql.auth.database }}"
               {{- end }}
               {{- end }}
             {{- if and (not .Values.kaneo.env.database.external.enabled) .Values.postgresql.auth.existingSecret }}

--- a/charts/kaneo/templates/services.yaml
+++ b/charts/kaneo/templates/services.yaml
@@ -15,6 +15,7 @@ spec:
       name: http
   selector:
     {{- include "kaneo.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: kaneo
 
 {{- if .Values.postgresql.enabled }}
 ---

--- a/charts/kaneo/templates/validations.yaml
+++ b/charts/kaneo/templates/validations.yaml
@@ -1,0 +1,10 @@
+{{- $publicExposureEnabled := or .Values.ingress.enabled .Values.gateway.enabled -}}
+{{- if and $publicExposureEnabled (not .Values.kaneo.env.existingSecret.enabled) (eq .Values.kaneo.env.authSecret "change_me_to_at_least_32_characters_long_string") -}}
+{{- fail "kaneo.env.authSecret must be changed or provided via kaneo.env.existingSecret before enabling ingress or gateway" -}}
+{{- end -}}
+{{- if and $publicExposureEnabled .Values.postgresql.enabled (not .Values.postgresql.auth.existingSecret) (eq .Values.postgresql.auth.password "kaneo_password") -}}
+{{- fail "postgresql.auth.password must be changed or provided via postgresql.auth.existingSecret before enabling ingress or gateway" -}}
+{{- end -}}
+{{- if and .Values.autoscaling.enabled .Values.autoscaling.targetCPUUtilizationPercentage (not (dig "requests" "cpu" "" .Values.kaneo.resources)) -}}
+{{- fail "kaneo.resources.requests.cpu must be set when autoscaling CPU utilization is enabled" -}}
+{{- end -}}

--- a/charts/kaneo/templates/validations.yaml
+++ b/charts/kaneo/templates/validations.yaml
@@ -2,6 +2,9 @@
 {{- if and $publicExposureEnabled (not .Values.kaneo.env.existingSecret.enabled) (eq .Values.kaneo.env.authSecret "change_me_to_at_least_32_characters_long_string") -}}
 {{- fail "kaneo.env.authSecret must be changed or provided via kaneo.env.existingSecret before enabling ingress or gateway" -}}
 {{- end -}}
+{{- if and $publicExposureEnabled (not .Values.kaneo.env.existingSecret.enabled) (lt (len (.Values.kaneo.env.authSecret | toString)) 32) -}}
+{{- fail "kaneo.env.authSecret must be at least 32 characters or provided via kaneo.env.existingSecret before enabling ingress or gateway" -}}
+{{- end -}}
 {{- if and $publicExposureEnabled .Values.postgresql.enabled (not .Values.postgresql.auth.existingSecret) (eq .Values.postgresql.auth.password "kaneo_password") -}}
 {{- fail "postgresql.auth.password must be changed or provided via postgresql.auth.existingSecret before enabling ingress or gateway" -}}
 {{- end -}}

--- a/charts/kaneo/values.yaml
+++ b/charts/kaneo/values.yaml
@@ -61,7 +61,8 @@ postgresql:
 kaneo:
   image:
     repository: ghcr.io/usekaneo/kaneo
-    tag: latest
+    # Defaults to Chart.appVersion when empty.
+    tag: ""
     pullPolicy: IfNotPresent
   securityContext: {}
   service:


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->

This PR prepares the Kaneo Helm chart for GHCR OCI publishing.

I added a chart publishing workflow, tightened the chart defaults, and fixed a few issues that showed up while testing local installs. The chart now renders a pinned app image version instead of `latest`, publishes as `oci://ghcr.io/usekaneo/charts/kaneo`, and has validation for unsafe public deployments.

It also fixes the Kaneo Service selector so it only targets Kaneo pods, not PostgreSQL pods.

## Related Issue(s)
<!-- Link to the related issue(s) this PR addresses -->
Fixes #1235

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Other (please describe): Helm linting. templateing, packaging, and local cluster install. Soon as this is published, its going into my talos-prod cluster!

## Screenshots (if applicable)

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any other context about the PR here -->

Bundled PostgreSQL credentials only apply when PostgreSQL initializes an empty data directory. I documented this because changing `postgresql.auth.password` with an existing PVC does not rotate the database password.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to validate and publish the Helm chart, ensuring chart templates are linted and rendered across common configurations.
  * For non-PR updates, packaged charts are published to the registry only when a new chart version is detected, reducing duplicate releases and streamlining releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->