### PR TITLE
fix(helm): define KANEO_POSTGRES_PASSWORD before DATABASE_URL

### DIFF
--- a/charts/kaneo/templates/deployment.yaml
+++ b/charts/kaneo/templates/deployment.yaml
@@ -57,6 +57,13 @@ spec:
               {{- else }}
               value: "{{ .Values.kaneo.env.authSecret }}"
               {{- end }}
+            {{- if and (not .Values.kaneo.env.database.external.enabled) .Values.postgresql.auth.existingSecret }}
+            - name: KANEO_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.auth.existingSecret }}
+                  key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
+            {{- end }}
             - name: DATABASE_URL
               {{- if .Values.kaneo.env.database.external.enabled }}
               {{- if .Values.kaneo.env.database.external.existingSecret.enabled }}
@@ -74,13 +81,6 @@ spec:
               value: "postgresql://{{ include "kaneo.urlencodeUserinfo" .Values.postgresql.auth.username }}:{{ include "kaneo.urlencodeUserinfo" .Values.postgresql.auth.password }}@{{ include "kaneo.fullname" . }}-postgresql:{{ .Values.postgresql.service.port }}/{{ .Values.postgresql.auth.database }}"
               {{- end }}
               {{- end }}
-            {{- if and (not .Values.kaneo.env.database.external.enabled) .Values.postgresql.auth.existingSecret }}
-            - name: KANEO_POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.postgresql.auth.existingSecret }}
-                  key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
-            {{- end }}
             - name: DISABLE_REGISTRATION
               value: {{ .Values.kaneo.env.disableRegistration | quote }}
             - name: DISABLE_PASSWORD_REGISTRATION


### PR DESCRIPTION
## Description

Follow-up to #1306.

In the bundled-PostgreSQL + `postgresql.auth.existingSecret` path, `DATABASE_URL` references `$(KANEO_POSTGRES_PASSWORD)`, but that env var was declared **after** `DATABASE_URL` in the container's env list.

Kubernetes only substitutes `$(VAR)` references to env vars defined **earlier** in the same container's env list. A forward reference is left as the literal string, so `DATABASE_URL` ended up containing the literal `$(KANEO_POSTGRES_PASSWORD)` and the database connection failed.

This moves the secret-backed `KANEO_POSTGRES_PASSWORD` entry above `DATABASE_URL` so the reference resolves at runtime. `helm template` doesn't perform `$(VAR)` substitution (that happens at pod runtime), which is why the CI render matrix didn't catch it.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)