### PR TITLE
chore(helm): bump chart to 0.4.2

### DIFF
--- a/charts/kaneo/Chart.yaml
+++ b/charts/kaneo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kaneo
 description: Kaneo - All you need. Nothing you don't. Open source project management that works for you.
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "2.7.7"
 keywords:
   - project-management


### PR DESCRIPTION
## Description

Bumps the Helm chart version `0.4.1` → `0.4.2`.

The publish workflow is idempotent and skips pushing when the chart version already exists in GHCR. The `0.4.1` artifact currently in `oci://ghcr.io/usekaneo/charts/kaneo` was packaged before the `KANEO_POSTGRES_PASSWORD` env-ordering fix (#1309) merged, so the published chart doesn't yet contain that fix. This version bump lets the publish job push an updated chart on merge to `main`.

No template or value changes — version metadata only. `appVersion` stays `2.7.7`.

## Type of Change
- [x] Other: chart release / version bump