### PR TITLE
fix(deps): allow @hono/node-server v2 so the #1292 upgrade takes effect

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "pnpm": {
     "overrides": {
       "@isaacs/brace-expansion": "5.0.1",
-      "@hono/node-server": ">=1.19.13 <2.0.0",
+      "@hono/node-server": ">=1.19.13",
       "ajv": "8.18.0",
       "diff": "8.0.3",
       "esbuild": "0.27.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@isaacs/brace-expansion': 5.0.1
-  '@hono/node-server': '>=1.19.13 <2.0.0'
+  '@hono/node-server': '>=1.19.13'
   ajv: 8.18.0
   diff: 8.0.3
   esbuild: 0.27.3
@@ -77,11 +77,11 @@ importers:
         specifier: ^1.6.11
         version: 1.6.11(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)(typescript@5.9.3)))
       '@hono/node-server':
-        specifier: '>=1.19.13 <2.0.0'
-        version: 1.19.13(hono@4.12.19)
+        specifier: '>=1.19.13'
+        version: 2.0.4(hono@4.12.19)
       '@hono/node-ws':
         specifier: ^1.3.1
-        version: 1.3.1(@hono/node-server@1.19.13(hono@4.12.19))(hono@4.12.19)
+        version: 1.3.1(@hono/node-server@2.0.4(hono@4.12.19))(hono@4.12.19)
       '@hono/standard-validator':
         specifier: ^0.2.2
         version: 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.19)
@@ -1624,15 +1624,9 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  '@hono/node-server@1.19.13':
-    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: '>=4.12.19'
-
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.4':
+    resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: '>=4.12.19'
 
@@ -1640,7 +1634,7 @@ packages:
     resolution: {integrity: sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      '@hono/node-server': '>=1.19.13 <2.0.0'
+      '@hono/node-server': '>=1.19.13'
       hono: '>=4.12.19'
 
   '@hono/standard-validator@0.2.2':
@@ -9477,18 +9471,18 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@hono/node-server@1.19.13(hono@4.12.19)':
+  '@hono/node-server@2.0.4(hono@4.12.19)':
     dependencies:
       hono: 4.12.19
 
-  '@hono/node-server@1.19.14(hono@4.12.23)':
+  '@hono/node-server@2.0.4(hono@4.12.23)':
     dependencies:
       hono: 4.12.23
     optional: true
 
-  '@hono/node-ws@1.3.1(@hono/node-server@1.19.13(hono@4.12.19))(hono@4.12.19)':
+  '@hono/node-ws@1.3.1(@hono/node-server@2.0.4(hono@4.12.19))(hono@4.12.19)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.19)
+      '@hono/node-server': 2.0.4(hono@4.12.19)
       hono: 4.12.19
       ws: 8.17.1
     transitivePeerDependencies:
@@ -9736,7 +9730,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.19)
+      '@hono/node-server': 2.0.4(hono@4.12.19)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -9758,7 +9752,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.19)
+      '@hono/node-server': 2.0.4(hono@4.12.19)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -10072,7 +10066,7 @@ snapshots:
       '@electric-sql/pglite': 0.3.15
       '@electric-sql/pglite-socket': 0.0.20(@electric-sql/pglite@0.3.15)
       '@electric-sql/pglite-tools': 0.2.20(@electric-sql/pglite@0.3.15)
-      '@hono/node-server': 1.19.14(hono@4.12.23)
+      '@hono/node-server': 2.0.4(hono@4.12.23)
       '@mrleebo/prisma-ast': 0.13.1
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
@@ -10095,7 +10089,7 @@ snapshots:
       '@electric-sql/pglite': 0.3.15
       '@electric-sql/pglite-socket': 0.0.20(@electric-sql/pglite@0.3.15)
       '@electric-sql/pglite-tools': 0.2.20(@electric-sql/pglite@0.3.15)
-      '@hono/node-server': 1.19.14(hono@4.12.23)
+      '@hono/node-server': 2.0.4(hono@4.12.23)
       '@mrleebo/prisma-ast': 0.13.1
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0


### PR DESCRIPTION
## Description

Follow-up to #1292.

#1292 bumped `apps/api` to `@hono/node-server: ^2.0.3`, but the root `pnpm.overrides` still pinned `@hono/node-server` to `>=1.19.13 <2.0.0`. pnpm overrides win, so the lockfile kept resolving **1.19.13** — v2 was never actually installed, and #1292's CI ran against 1.x.

### Fix
Drop the `<2.0.0` cap while keeping the `>=1.19.13` security floor (it originated from a node-server security advisory, #1271). `apps/api` now resolves `@hono/node-server@2.0.4`, and that's the only node-server version left in the lockfile.

### Validation (local)
- `@hono/node-ws@1.3.1` resolves against `@hono/node-server@2.0.4` — peer-compatible, no conflict.
- API esbuild build passes.
- All **151 API unit tests** pass.
- `serve()` usage in `src/index.ts` typechecks clean against v2.

(Integration tests run in CI — they need PostgreSQL.)

## Type of Change
- [x] Bug fix (dependency / build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->