### PR TITLE
fix: add enabled guard to useGetTask

### DIFF
--- a/apps/web/src/hooks/queries/task/use-get-task.ts
+++ b/apps/web/src/hooks/queries/task/use-get-task.ts
@@ -5,6 +5,7 @@ function useGetTask(taskId: string) {
   return useQuery({
     queryKey: ["task", taskId],
     queryFn: () => getTask(taskId),
+    enabled: Boolean(taskId),
     refetchOnMount: "always",
     staleTime: 0,
   });


### PR DESCRIPTION
Prevent `/api/task` from firing with undefined taskId by adding an `enabled` guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task loading by preventing unnecessary API requests when no task is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->