### PR TITLE
feat(comments): allow users to delete their own comments

### DIFF
--- a/apps/web/src/components/activity/comment-card.tsx
+++ b/apps/web/src/components/activity/comment-card.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { ExternalLink, Github, Pencil } from "lucide-react";
+import { ExternalLink, Github, Pencil, Trash2 } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import CommentEditor from "@/components/activity/comment-editor";
@@ -17,6 +17,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import useDeleteComment from "@/hooks/mutations/comment/use-delete-comment";
 import useUpdateComment from "@/hooks/mutations/comment/use-update-comment";
 import { formatDateTime, formatRelativeTime } from "@/lib/format";
 import { toast } from "@/lib/toast";
@@ -50,6 +51,8 @@ export default function CommentCard({
   const [isEditing, setIsEditing] = useState(false);
   const [editedContent, setEditedContent] = useState(content);
   const { mutateAsync: updateComment, isPending } = useUpdateComment();
+  const { mutate: deleteComment, isPending: isDeleting } =
+    useDeleteComment(taskId);
   const queryClient = useQueryClient();
 
   const canEdit = currentUser?.id === user?.id;
@@ -197,21 +200,39 @@ export default function CommentCard({
         </div>
 
         {canEdit && !isEditing && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleEdit}
-                className="absolute top-2 right-2 h-6 w-6 rounded-md p-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground"
-              >
-                <Pencil className="size-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p className="text-xs">{t("activity:comment.edit")}</p>
-            </TooltipContent>
-          </Tooltip>
+          <div className="absolute top-2 right-2 flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleEdit}
+                  className="h-6 w-6 rounded-md p-0 text-muted-foreground hover:text-foreground"
+                >
+                  <Pencil className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="text-xs">{t("activity:comment.edit")}</p>
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => deleteComment(commentId)}
+                  disabled={isDeleting}
+                  className="h-6 w-6 rounded-md p-0 text-muted-foreground hover:text-destructive"
+                >
+                  <Trash2 className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="text-xs">{t("common:actions.delete")}</p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
         )}
 
         <div className="pt-0.5">

--- a/apps/web/src/components/activity/comment-card.tsx
+++ b/apps/web/src/components/activity/comment-card.tsx
@@ -221,7 +221,7 @@ export default function CommentCard({
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => deleteComment(commentId)}
+                  onClick={() => deleteComment({ activityId: commentId })}
                   disabled={isDeleting}
                   className="h-6 w-6 rounded-md p-0 text-muted-foreground hover:text-destructive"
                 >


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Allow comment authors to delete their own comments
<code>✨ Enhancement</code> <code>🐞 Bug fix</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary

Adds a delete button to comments, visible on hover for the comment author only. This mirrors the existing edit (pencil) button pattern — both appear together in the top-right corner of the comment card when hovered.

- Only the comment author sees the delete button (same `canEdit` guard used by the edit button)
- Trash icon appears alongside the pencil on hover, with a red tint on hover to signal destructive action
- Calls the existing `DELETE /activity/comment` endpoint with `{ activityId }` in the request body
- Invalidates the activity query on success so the comment disappears immediately
- Also fixes a bug where `deleteComment(commentId)` was passing a bare string instead of `{ activityId: commentId }`, causing the endpoint to return 400

## Test plan

- [ ] Hover a comment you authored — pencil and trash icons appear
- [ ] Click trash — comment is deleted immediately
- [ ] Hover a comment authored by someone else — no icons appear
- [ ] Verify `DELETE /activity/comment` returns 200 (not 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Show edit + delete actions on comment hover for the comment author only.
• Wire delete button to the existing delete-comment mutation and disable while deleting.
• Fix delete mutation call shape by passing <b><i>{ activityId }</i></b> instead of a string.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["CommentCard"] --> B["useDeleteComment"] --> C["deleteComment fetcher"] --> D{{"DELETE /activity/comment"}}
  B --> E[("React Query cache: activities")]
  subgraph Legend
    direction LR
    _ui["UI Component"] ~~~ _hook["Hook"] ~~~ _cache[("Cache")] ~~~ _api{{"API"}}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Add a confirmation dialog (or undo toast) before deletion</b></summary>

- ➕ Reduces accidental deletions, especially with a one-click destructive icon
- ➕ Clearer UX for destructive actions
- ➖ Adds extra UI/state handling and slows down the “quick delete” flow
- ➖ Requires design decisions (modal vs toast/undo)

</details>

<details>
<summary><b>2. Optimistically remove the comment from cache instead of invalidating</b></summary>

- ➕ Instant UI feedback without waiting for refetch
- ➕ Less network traffic than full query invalidation
- ➖ More complex cache manipulation and rollback on failure
- ➖ Risk of cache inconsistency if other activity fields also change server-side

</details>

**Recommendation:** Current approach (call existing mutation and invalidate the activities query) is a good consistency-first baseline with minimal complexity. If accidental deletes become a concern or activity payloads are large, consider a follow-up to add confirmation/undo and/or optimistic cache removal.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>comment-card.tsx</strong> <code>Add author-only hover delete action alongside edit</code> <code>+37/-16</code></summary>

<br/>

>Add author-only hover delete action alongside edit
>
><pre>
>• Adds a trash-icon delete button next to the existing edit pencil, shown only when the current user authored the comment and the card is hovered. Wires the button to &#x27;useDeleteComment(taskId)&#x27; and correctly calls &#x27;deleteComment({ activityId: commentId })&#x27;, disabling the control while the mutation is pending.
></pre>
>
><a href='https://github.com/usekaneo/kaneo/pull/1322/files#diff-839c45763c455930c49dbf9b080a5a2541242721e8e636d1a9c1ce3a1baea2ff'>apps/web/src/components/activity/comment-card.tsx</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to delete comments. Comments now include a delete button alongside the existing edit option for improved content management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->