### PR TITLE
feat(notifications): notification inbox with real-time WebSocket updates

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -547,6 +547,57 @@ export function createApp() {
     ),
   );
 
+  // User-scoped WebSocket endpoint — MUST be registered before /ws/:projectId
+  // so the literal path "user" isn't consumed by the param route.
+  api.get(
+    "/ws/user",
+    upgradeWebSocket(async (c) => {
+      try {
+        await authenticateApiRequest(c);
+      } catch (error) {
+        if (error instanceof HTTPException) {
+          throw error;
+        }
+        console.error("API authentication failed:", error);
+        throw new HTTPException(500, { message: "Internal Server Error" });
+      }
+
+      const userId = c.get("userId");
+      let conn: ReturnType<typeof addUserConnection> | null = null;
+
+      return {
+        onOpen(_evt, ws) {
+          if (userId) {
+            conn = addUserConnection(userId, ws);
+          }
+        },
+        onMessage(evt) {
+          try {
+            const raw =
+              typeof evt.data === "string"
+                ? evt.data
+                : Buffer.isBuffer(evt.data)
+                  ? evt.data.toString()
+                  : null;
+            if (raw) {
+              const msg = JSON.parse(raw) as { type?: string };
+              if (msg?.type === "ping") {
+                // keepalive — no-op
+              }
+            }
+          } catch {
+            // Ignore malformed messages
+          }
+        },
+        onClose() {
+          if (conn && userId) {
+            removeUserConnection(userId, conn);
+          }
+        },
+      };
+    }),
+  );
+
   api.get(
     "/ws/:projectId",
     upgradeWebSocket(async (c) => {
@@ -591,56 +642,6 @@ export function createApp() {
         onClose() {
           if (conn && projectId) {
             removeConnection(projectId, conn);
-          }
-        },
-      };
-    }),
-  );
-
-  // User-scoped WebSocket endpoint for user-targeted events (e.g. NOTIFICATION_CREATED)
-  api.get(
-    "/ws/user",
-    upgradeWebSocket(async (c) => {
-      try {
-        await authenticateApiRequest(c);
-      } catch (error) {
-        if (error instanceof HTTPException) {
-          throw error;
-        }
-        console.error("API authentication failed:", error);
-        throw new HTTPException(500, { message: "Internal Server Error" });
-      }
-
-      const userId = c.get("userId");
-      let conn: ReturnType<typeof addUserConnection> | null = null;
-
-      return {
-        onOpen(_evt, ws) {
-          if (userId) {
-            conn = addUserConnection(userId, ws);
-          }
-        },
-        onMessage(evt) {
-          try {
-            const raw =
-              typeof evt.data === "string"
-                ? evt.data
-                : Buffer.isBuffer(evt.data)
-                  ? evt.data.toString()
-                  : null;
-            if (raw) {
-              const msg = JSON.parse(raw) as { type?: string };
-              if (msg?.type === "ping") {
-                // keepalive — no-op
-              }
-            }
-          } catch {
-            // Ignore malformed messages
-          }
-        },
-        onClose() {
-          if (conn && userId) {
-            removeUserConnection(userId, conn);
           }
         },
       };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -77,8 +77,10 @@ import workflowRule from "./workflow-rule";
 import workspace from "./workspace";
 import {
   addConnection,
+  addUserConnection,
   initializeWebSocketAdapter,
   removeConnection,
+  removeUserConnection,
   shutdownWebSocketAdapter,
 } from "./ws";
 
@@ -589,6 +591,56 @@ export function createApp() {
         onClose() {
           if (conn && projectId) {
             removeConnection(projectId, conn);
+          }
+        },
+      };
+    }),
+  );
+
+  // User-scoped WebSocket endpoint for user-targeted events (e.g. NOTIFICATION_CREATED)
+  api.get(
+    "/ws/user",
+    upgradeWebSocket(async (c) => {
+      try {
+        await authenticateApiRequest(c);
+      } catch (error) {
+        if (error instanceof HTTPException) {
+          throw error;
+        }
+        console.error("API authentication failed:", error);
+        throw new HTTPException(500, { message: "Internal Server Error" });
+      }
+
+      const userId = c.get("userId");
+      let conn: ReturnType<typeof addUserConnection> | null = null;
+
+      return {
+        onOpen(_evt, ws) {
+          if (userId) {
+            conn = addUserConnection(userId, ws);
+          }
+        },
+        onMessage(evt) {
+          try {
+            const raw =
+              typeof evt.data === "string"
+                ? evt.data
+                : Buffer.isBuffer(evt.data)
+                  ? evt.data.toString()
+                  : null;
+            if (raw) {
+              const msg = JSON.parse(raw) as { type?: string };
+              if (msg?.type === "ping") {
+                // keepalive — no-op
+              }
+            }
+          } catch {
+            // Ignore malformed messages
+          }
+        },
+        onClose() {
+          if (conn && userId) {
+            removeUserConnection(userId, conn);
           }
         },
       };

--- a/apps/api/src/notification/controllers/get-notifications.ts
+++ b/apps/api/src/notification/controllers/get-notifications.ts
@@ -1,16 +1,54 @@
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import db from "../../database";
-import { notificationTable } from "../../database/schema";
+import {
+  notificationTable,
+  projectTable,
+  taskTable,
+  workspaceTable,
+} from "../../database/schema";
 
 async function getNotifications(userId: string) {
-  const notifications = await db
-    .select()
+  const rows = await db
+    .select({
+      notification: notificationTable,
+      projectId: projectTable.id,
+      workspaceId: workspaceTable.id,
+    })
     .from(notificationTable)
+    .leftJoin(
+      taskTable,
+      and(
+        eq(notificationTable.resourceId, taskTable.id),
+        eq(notificationTable.resourceType, "task"),
+      ),
+    )
+    .leftJoin(projectTable, eq(taskTable.projectId, projectTable.id))
+    .leftJoin(workspaceTable, eq(projectTable.workspaceId, workspaceTable.id))
     .where(eq(notificationTable.userId, userId))
     .orderBy(desc(notificationTable.createdAt))
     .limit(50);
 
-  return notifications;
+  return rows.map(({ notification, projectId, workspaceId }) => {
+    if (!projectId && !workspaceId) {
+      return notification;
+    }
+
+    const existing =
+      notification.eventData &&
+      typeof notification.eventData === "object" &&
+      !Array.isArray(notification.eventData)
+        ? (notification.eventData as Record<string, unknown>)
+        : {};
+
+    return {
+      ...notification,
+      eventData: {
+        ...existing,
+        projectId: projectId ?? existing.projectId ?? null,
+        workspaceId: workspaceId ?? existing.workspaceId ?? null,
+      },
+    };
+  });
 }
 
 export default getNotifications;

--- a/apps/api/src/notification/index.ts
+++ b/apps/api/src/notification/index.ts
@@ -1,6 +1,9 @@
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import * as v from "valibot";
+import db from "../database";
+import { projectTable, taskTable } from "../database/schema";
 import { subscribeToEvent } from "../events";
 import { notificationSchema } from "../schemas";
 import clearNotifications from "./controllers/clear-notifications";
@@ -163,11 +166,19 @@ subscribeToEvent<{
   projectId: string;
 }>("task.created", async (data) => {
   if (data.userId) {
+    const [project] = await db
+      .select({ workspaceId: projectTable.workspaceId })
+      .from(projectTable)
+      .where(eq(projectTable.id, data.projectId))
+      .limit(1);
+
     await createNotification({
       userId: data.userId,
       type: "task_created",
       eventData: {
         taskTitle: data.title,
+        projectId: data.projectId,
+        workspaceId: project?.workspaceId ?? null,
       },
       resourceId: data.taskId,
       resourceType: "task",
@@ -203,6 +214,20 @@ subscribeToEvent<{
   assigneeId?: string;
 }>("task.status_changed", async (data) => {
   if (data.assigneeId && data.assigneeId !== data.userId) {
+    const [task] = await db
+      .select({ projectId: taskTable.projectId })
+      .from(taskTable)
+      .where(eq(taskTable.id, data.taskId))
+      .limit(1);
+
+    const [project] = task
+      ? await db
+          .select({ workspaceId: projectTable.workspaceId })
+          .from(projectTable)
+          .where(eq(projectTable.id, task.projectId))
+          .limit(1)
+      : [];
+
     await createNotification({
       userId: data.assigneeId,
       type: "task_status_changed",
@@ -210,6 +235,8 @@ subscribeToEvent<{
         taskTitle: data.title,
         oldStatus: data.oldStatus,
         newStatus: data.newStatus,
+        projectId: task?.projectId ?? null,
+        workspaceId: project?.workspaceId ?? null,
       },
       resourceId: data.taskId,
       resourceType: "task",
@@ -226,11 +253,27 @@ subscribeToEvent<{
   title: string;
 }>("task.assignee_changed", async (data) => {
   if (data.newAssigneeId) {
+    const [task] = await db
+      .select({ projectId: taskTable.projectId })
+      .from(taskTable)
+      .where(eq(taskTable.id, data.taskId))
+      .limit(1);
+
+    const [project] = task
+      ? await db
+          .select({ workspaceId: projectTable.workspaceId })
+          .from(projectTable)
+          .where(eq(projectTable.id, task.projectId))
+          .limit(1)
+      : [];
+
     await createNotification({
       userId: data.newAssigneeId,
       type: "task_assignee_changed",
       eventData: {
         taskTitle: data.title,
+        projectId: task?.projectId ?? null,
+        workspaceId: project?.workspaceId ?? null,
       },
       resourceId: data.taskId,
       resourceType: "task",
@@ -246,11 +289,27 @@ subscribeToEvent<{
   taskTitle?: string;
 }>("time-entry.created", async (data) => {
   if (data.taskOwnerId && data.taskOwnerId !== data.userId) {
+    const [task] = await db
+      .select({ projectId: taskTable.projectId })
+      .from(taskTable)
+      .where(eq(taskTable.id, data.taskId))
+      .limit(1);
+
+    const [project] = task
+      ? await db
+          .select({ workspaceId: projectTable.workspaceId })
+          .from(projectTable)
+          .where(eq(projectTable.id, task.projectId))
+          .limit(1)
+      : [];
+
     await createNotification({
       userId: data.taskOwnerId,
       type: "time_entry_created",
       eventData: {
         taskTitle: data.taskTitle ?? null,
+        projectId: task?.projectId ?? null,
+        workspaceId: project?.workspaceId ?? null,
       },
       resourceId: data.taskId,
       resourceType: "task",

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -93,6 +93,7 @@ export const notificationSchema = v.object({
     "time_entry_created",
     "due_date_reminder",
     "task_overdue",
+    "task_mention",
   ] as const),
   eventData: v.nullable(v.record(v.string(), v.unknown())),
   isRead: v.optional(v.boolean()),

--- a/apps/api/src/ws/index.ts
+++ b/apps/api/src/ws/index.ts
@@ -15,6 +15,55 @@ type ProjectConnection = {
   initiatorId: string;
 };
 
+type UserConnection = {
+  ws: WSContext;
+};
+
+/**
+ * User-scoped connections — tracks WebSocket connections keyed by userId.
+ * Used for delivering user-targeted events like NOTIFICATION_CREATED.
+ */
+const userConnections = new Map<string, Set<UserConnection>>();
+
+export function addUserConnection(userId: string, ws: WSContext) {
+  if (!userConnections.has(userId)) {
+    userConnections.set(userId, new Set());
+  }
+  const conn: UserConnection = { ws };
+  userConnections.get(userId)?.add(conn);
+  return conn;
+}
+
+export function removeUserConnection(userId: string, conn: UserConnection) {
+  const connections = userConnections.get(userId);
+  if (connections) {
+    connections.delete(conn);
+    if (connections.size === 0) {
+      userConnections.delete(userId);
+    }
+  }
+}
+
+export function broadcastToUser(
+  userId: string,
+  message: { type: string; [key: string]: unknown },
+) {
+  const connections = userConnections.get(userId);
+  if (!connections) return;
+
+  const payload = JSON.stringify(message);
+  for (const conn of connections) {
+    try {
+      conn.ws.send(payload);
+    } catch {
+      connections.delete(conn);
+    }
+  }
+  if (connections.size === 0) {
+    userConnections.delete(userId);
+  }
+}
+
 /**
  * Local connections — Each instance tracks only its own WebSocket connections.
  */
@@ -260,6 +309,15 @@ subscribeToEvent<{
     initiatorId,
   );
 });
+
+subscribeToEvent<{ notificationId: string; userId: string }>(
+  "notification.created",
+  async (data) => {
+    if (data.userId) {
+      broadcastToUser(data.userId, { type: "NOTIFICATION_CREATED" });
+    }
+  },
+);
 
 for (const eventName of taskUpdateEvents) {
   subscribeToEvent<TaskEvent>(eventName, async (data) => {

--- a/apps/web/src/components/notification/notification-dropdown.tsx
+++ b/apps/web/src/components/notification/notification-dropdown.tsx
@@ -1,5 +1,6 @@
+import { useNavigate } from "@tanstack/react-router";
 import { Bell } from "lucide-react";
-import { forwardRef, useImperativeHandle, useState } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AlertDialog,
@@ -27,6 +28,7 @@ import {
 import { shortcuts } from "@/constants/shortcuts";
 import useClearNotifications from "@/hooks/mutations/notification/use-clear-notifications";
 import useMarkAllNotificationsAsRead from "@/hooks/mutations/notification/use-mark-all-notifications-as-read";
+import useMarkNotificationAsRead from "@/hooks/mutations/notification/use-mark-notification-as-read";
 import useGetNotifications from "@/hooks/queries/notification/use-get-notifications";
 import { useRegisterShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { cn } from "@/lib/cn";
@@ -148,12 +150,43 @@ function getNotificationContent(
 const NotificationDropdown = forwardRef<NotificationDropdownRef>(
   (_props, ref) => {
     const { t } = useTranslation();
+    const navigate = useNavigate();
     const { data: notifications } = useGetNotifications();
     const [isOpen, setIsOpen] = useState(false);
     const [showClearDialog, setShowClearDialog] = useState(false);
 
     const { mutate: markAllAsRead } = useMarkAllNotificationsAsRead();
     const { mutate: clearAll } = useClearNotifications();
+    const { mutate: markAsRead } = useMarkNotificationAsRead();
+
+    const handleNotificationClick = useCallback(
+      (notification: Notification) => {
+        if (!notification.isRead) {
+          markAsRead(notification.id);
+        }
+
+        const ed = getEventDataRecord(notification.eventData);
+        const workspaceId =
+          typeof ed?.workspaceId === "string" ? ed.workspaceId : null;
+        const projectId =
+          typeof ed?.projectId === "string" ? ed.projectId : null;
+        const taskId = notification.resourceId ?? null;
+
+        if (
+          notification.resourceType === "task" &&
+          workspaceId &&
+          projectId &&
+          taskId
+        ) {
+          setIsOpen(false);
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId",
+            params: { workspaceId, projectId, taskId },
+          });
+        }
+      },
+      [markAsRead, navigate],
+    );
 
     const unreadNotifications = notifications?.filter((n) => !n.isRead) || [];
     const hasNotifications = notifications && notifications.length > 0;
@@ -240,10 +273,12 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
                 </div>
               ) : (
                 notifications.map((notification) => (
-                  <div
+                  <button
                     key={notification.id}
+                    type="button"
+                    onClick={() => handleNotificationClick(notification)}
                     className={cn(
-                      "px-3 py-3 border-b border-border/50 hover:bg-accent/50 transition-colors",
+                      "w-full text-left px-3 py-3 border-b border-border/50 hover:bg-accent/50 transition-colors cursor-pointer",
                       !notification.isRead && "bg-accent/20",
                     )}
                   >
@@ -267,7 +302,7 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
                         </p>
                       </div>
                     </div>
-                  </div>
+                  </button>
                 ))
               )}
             </div>

--- a/apps/web/src/components/notification/notification-dropdown.tsx
+++ b/apps/web/src/components/notification/notification-dropdown.tsx
@@ -80,6 +80,11 @@ function getNotificationTitle(
           ...eventData,
           defaultValue: notification.title ?? notification.type,
         });
+      case "task_mention":
+        return t("notifications:events.task_mention.title", {
+          ...eventData,
+          defaultValue: notification.title ?? notification.type,
+        });
       default:
         break;
     }
@@ -127,6 +132,11 @@ function getNotificationContent(
               ...eventData,
               defaultValue: notification.content ?? "",
             });
+      case "task_mention":
+        return t("notifications:events.task_mention.content", {
+          ...eventData,
+          defaultValue: notification.content ?? "",
+        });
       default:
         break;
     }
@@ -179,7 +189,11 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
                   >
                     <Bell className="h-4 w-4" />
                     {unreadNotifications.length > 0 && (
-                      <span className="absolute top-0 right-0 h-2 w-2 rounded-full bg-destructive" />
+                      <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-0.5 text-[10px] font-bold leading-none text-destructive-foreground">
+                        {unreadNotifications.length > 99
+                          ? "99+"
+                          : unreadNotifications.length}
+                      </span>
                     )}
                     <span className="sr-only">
                       {t("navigation:notifications")}
@@ -207,21 +221,11 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
                 {t("notifications:title")}
               </h3>
               {unreadNotifications.length > 0 && (
-                <div className="flex items-center gap-2">
-                  <Badge variant="secondary" className="text-xs">
-                    {t("notifications:newCount", {
-                      count: unreadNotifications.length,
-                    })}
-                  </Badge>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => markAllAsRead()}
-                    className="text-xs h-6 px-2"
-                  >
-                    {t("common:actions.markAllRead")}
-                  </Button>
-                </div>
+                <Badge variant="secondary" className="text-xs">
+                  {t("notifications:newCount", {
+                    count: unreadNotifications.length,
+                  })}
+                </Badge>
               )}
             </div>
 
@@ -268,12 +272,21 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
               )}
             </div>
             {hasNotifications && (
-              <div className="border-t border-border p-2">
+              <div className="border-t border-border p-2 flex gap-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => markAllAsRead()}
+                  disabled={unreadNotifications.length === 0}
+                  className="flex-1 text-xs"
+                >
+                  {t("common:actions.markAllRead")}
+                </Button>
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={() => setShowClearDialog(true)}
-                  className="w-full text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
+                  className="flex-1 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
                 >
                   {t("notifications:clearAll")}
                 </Button>

--- a/apps/web/src/components/notification/notification-dropdown.tsx
+++ b/apps/web/src/components/notification/notification-dropdown.tsx
@@ -222,7 +222,7 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
                   >
                     <Bell className="h-4 w-4" />
                     {unreadNotifications.length > 0 && (
-                      <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-0.5 text-[10px] font-bold leading-none text-destructive-foreground">
+                      <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-0.5 text-[10px] font-bold leading-none text-white">
                         {unreadNotifications.length > 99
                           ? "99+"
                           : unreadNotifications.length}
@@ -250,7 +250,7 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
 
           <DropdownMenuContent align="end" className="w-80 p-0">
             <div className="flex items-center justify-between px-3 py-2 border-b">
-              <h3 className="font-medium text-sm text-white">
+              <h3 className="font-medium text-sm">
                 {t("notifications:title")}
               </h3>
               {unreadNotifications.length > 0 && (
@@ -264,11 +264,9 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
 
             <div className="relative max-h-96 overflow-y-auto">
               {!hasNotifications ? (
-                <div className="p-6 text-center text-sm text-white/60">
-                  <Bell className="mx-auto h-12 w-12 opacity-40 mb-2" />
-                  <p className="text-white/80">
-                    {t("notifications:emptyTitle")}
-                  </p>
+                <div className="p-6 text-center text-sm text-muted-foreground">
+                  <Bell className="mx-auto h-12 w-12 opacity-50 mb-2" />
+                  <p>{t("notifications:emptyTitle")}</p>
                   <p className="text-xs mt-1">
                     {t("notifications:emptySubtitle")}
                   </p>
@@ -287,7 +285,7 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
                     <div className="flex items-start gap-3">
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 mb-1">
-                          <h4 className="text-sm font-medium text-white">
+                          <h4 className="text-sm font-medium text-foreground">
                             {getNotificationTitle(notification, t)}
                           </h4>
                           {!notification.isRead && (
@@ -295,11 +293,11 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
                           )}
                         </div>
                         {getNotificationContent(notification, t) && (
-                          <p className="text-xs text-white/70 line-clamp-2">
+                          <p className="text-xs text-muted-foreground line-clamp-2">
                             {getNotificationContent(notification, t)}
                           </p>
                         )}
-                        <p className="text-xs text-white/40 mt-2">
+                        <p className="text-xs text-muted-foreground mt-2">
                           {formatRelativeTime(notification.createdAt)}
                         </p>
                       </div>

--- a/apps/web/src/components/notification/notification-dropdown.tsx
+++ b/apps/web/src/components/notification/notification-dropdown.tsx
@@ -250,7 +250,7 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
 
           <DropdownMenuContent align="end" className="w-80 p-0">
             <div className="flex items-center justify-between px-3 py-2 border-b">
-              <h3 className="font-medium text-sm">
+              <h3 className="font-medium text-sm text-white">
                 {t("notifications:title")}
               </h3>
               {unreadNotifications.length > 0 && (
@@ -264,9 +264,11 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
 
             <div className="relative max-h-96 overflow-y-auto">
               {!hasNotifications ? (
-                <div className="p-6 text-center text-sm text-muted-foreground">
-                  <Bell className="mx-auto h-12 w-12 opacity-50 mb-2" />
-                  <p>{t("notifications:emptyTitle")}</p>
+                <div className="p-6 text-center text-sm text-white/60">
+                  <Bell className="mx-auto h-12 w-12 opacity-40 mb-2" />
+                  <p className="text-white/80">
+                    {t("notifications:emptyTitle")}
+                  </p>
                   <p className="text-xs mt-1">
                     {t("notifications:emptySubtitle")}
                   </p>
@@ -285,7 +287,7 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
                     <div className="flex items-start gap-3">
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 mb-1">
-                          <h4 className="text-sm font-medium text-foreground">
+                          <h4 className="text-sm font-medium text-white">
                             {getNotificationTitle(notification, t)}
                           </h4>
                           {!notification.isRead && (
@@ -293,11 +295,11 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
                           )}
                         </div>
                         {getNotificationContent(notification, t) && (
-                          <p className="text-xs text-muted-foreground line-clamp-2">
+                          <p className="text-xs text-white/70 line-clamp-2">
                             {getNotificationContent(notification, t)}
                           </p>
                         )}
-                        <p className="text-xs text-muted-foreground mt-2">
+                        <p className="text-xs text-white/40 mt-2">
                           {formatRelativeTime(notification.createdAt)}
                         </p>
                       </div>

--- a/apps/web/src/components/notification/notification-dropdown.tsx
+++ b/apps/web/src/components/notification/notification-dropdown.tsx
@@ -17,6 +17,7 @@ import { KbdSequence } from "@/components/ui/kbd";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/menu";
 import {
@@ -178,7 +179,6 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
           projectId &&
           taskId
         ) {
-          setIsOpen(false);
           navigate({
             to: "/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId",
             params: { workspaceId, projectId, taskId },
@@ -273,12 +273,11 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
                 </div>
               ) : (
                 notifications.map((notification) => (
-                  <button
+                  <DropdownMenuItem
                     key={notification.id}
-                    type="button"
-                    onClick={() => handleNotificationClick(notification)}
+                    onSelect={() => handleNotificationClick(notification)}
                     className={cn(
-                      "w-full text-left px-3 py-3 border-b border-border/50 hover:bg-accent/50 transition-colors cursor-pointer",
+                      "px-3 py-3 border-b border-border/50 rounded-none cursor-pointer",
                       !notification.isRead && "bg-accent/20",
                     )}
                   >
@@ -302,7 +301,7 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
                         </p>
                       </div>
                     </div>
-                  </button>
+                  </DropdownMenuItem>
                 ))
               )}
             </div>

--- a/apps/web/src/components/notification/notification-dropdown.tsx
+++ b/apps/web/src/components/notification/notification-dropdown.tsx
@@ -275,7 +275,7 @@ const NotificationDropdown = forwardRef<NotificationDropdownRef>(
                 notifications.map((notification) => (
                   <DropdownMenuItem
                     key={notification.id}
-                    onSelect={() => handleNotificationClick(notification)}
+                    onClick={() => handleNotificationClick(notification)}
                     className={cn(
                       "px-3 py-3 border-b border-border/50 rounded-none cursor-pointer",
                       !notification.isRead && "bg-accent/20",

--- a/apps/web/src/components/workspace-switcher.tsx
+++ b/apps/web/src/components/workspace-switcher.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { ChevronDown } from "lucide-react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-
+import NotificationDropdown from "@/components/notification/notification-dropdown";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -183,8 +183,11 @@ export function WorkspaceSwitcher() {
           </SidebarMenuItem>
         </SidebarMenu>
 
-        <div className="h-7 w-7 shrink-0">
-          <UserAvatar />
+        <div className="flex items-center gap-1">
+          <NotificationDropdown />
+          <div className="h-7 w-7 shrink-0">
+            <UserAvatar />
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/components/workspace-switcher.tsx
+++ b/apps/web/src/components/workspace-switcher.tsx
@@ -26,6 +26,7 @@ import {
   getModifierKeyText,
   useRegisterShortcuts,
 } from "@/hooks/use-keyboard-shortcuts";
+import { useUserWebSocket } from "@/hooks/use-user-websocket";
 import { authClient } from "@/lib/auth-client";
 import type { Workspace } from "@/types/workspace";
 import CreateWorkspaceModal from "./shared/modals/create-workspace-modal";
@@ -33,6 +34,9 @@ import CreateWorkspaceModal from "./shared/modals/create-workspace-modal";
 export function WorkspaceSwitcher() {
   const { t } = useTranslation();
   const { data: workspace } = useActiveWorkspace();
+
+  // User-scoped WebSocket for real-time events (e.g. NOTIFICATION_CREATED)
+  useUserWebSocket();
   const { data: workspaces } = useGetWorkspaces();
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = React.useState(false);

--- a/apps/web/src/hooks/use-user-websocket.ts
+++ b/apps/web/src/hooks/use-user-websocket.ts
@@ -1,0 +1,93 @@
+import { windowId } from "@kaneo/libs";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+import { getApiUrl } from "@/fetchers/get-api-url";
+import { authClient } from "@/lib/auth-client";
+
+export function getUserWsUrl() {
+  const base = getApiUrl("ws");
+  const wsBase = base.replace(/^http/, "ws");
+  return `${wsBase}/user?windowId=${encodeURIComponent(windowId)}`;
+}
+
+const MAX_RETRIES = 5;
+const BASE_DELAY = 1000;
+const WS_PING_INTERVAL_MS = 30_000;
+
+/**
+ * Maintains a user-scoped WebSocket connection for receiving user-targeted
+ * real-time events (e.g. NOTIFICATION_CREATED). Invalidates TanStack Query
+ * caches as needed — no polling required.
+ */
+export function useUserWebSocket() {
+  const queryClient = useQueryClient();
+  const { data: session } = authClient.useSession();
+  const wsRef = useRef<WebSocket | null>(null);
+  const retriesRef = useRef(0);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!session?.user?.id) return;
+
+    retriesRef.current = 0;
+
+    function clearPing() {
+      if (pingIntervalRef.current) {
+        clearInterval(pingIntervalRef.current);
+        pingIntervalRef.current = null;
+      }
+    }
+
+    function connect() {
+      const url = getUserWsUrl();
+      const ws = new WebSocket(url);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        retriesRef.current = 0;
+        clearPing();
+        pingIntervalRef.current = setInterval(() => {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ type: "ping" }));
+          }
+        }, WS_PING_INTERVAL_MS);
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const message = JSON.parse(event.data as string) as {
+            type?: string;
+          };
+          if (message.type === "NOTIFICATION_CREATED") {
+            queryClient.invalidateQueries({ queryKey: ["notifications"] });
+          }
+        } catch {
+          // Ignore malformed messages
+        }
+      };
+
+      ws.onclose = () => {
+        clearPing();
+        wsRef.current = null;
+
+        if (retriesRef.current < MAX_RETRIES) {
+          const delay = BASE_DELAY * 2 ** retriesRef.current;
+          retriesRef.current += 1;
+          timeoutRef.current = setTimeout(connect, delay);
+        }
+      };
+    }
+
+    connect();
+
+    return () => {
+      retriesRef.current = MAX_RETRIES; // prevent reconnect after unmount
+      clearPing();
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      wsRef.current?.close();
+    };
+  }, [session?.user?.id, queryClient]);
+}


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Notification inbox with unread badge and user-scoped WebSocket updates
<code>✨ Enhancement</code> <code>🐞 Bug fix</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary

Adds a notification inbox to the sidebar and wires it up to real-time updates via a user-scoped WebSocket connection.

### Notification inbox
- Bell icon in the sidebar (bottom of workspace switcher row) with an unread count badge
- Dropdown lists all notifications with sender name, message, and relative timestamp
- Clicking a notification navigates to the relevant task and marks it as read
- Notifications are fetched from the existing `/notification` API endpoints

### Real-time badge updates
- New `/ws/user` WebSocket endpoint — scoped to the authenticated user rather than a project
- Server fires a `NOTIFICATION_CREATED` event when a notification is created; the WS handler pushes `{ type: "NOTIFICATION_CREATED" }` to all of that user's connected tabs
- `useUserWebSocket` hook on the client subscribes and invalidates the `["notifications"]` TanStack Query cache on receipt — no polling
- Includes 30s keepalive pings and exponential backoff reconnect (max 5 retries)

### Route ordering fix
- `/ws/user` must be registered **before** `/ws/:projectId` in Hono, otherwise Hono captures the literal `"user"` as the `projectId` param and the DB lookup throws 401. Added a comment to document the constraint.

## Test plan

- [ ] Bell icon appears in sidebar; badge shows unread count
- [ ] Posting a comment that mentions a user → their badge updates in real time (no refresh)
- [ ] Clicking a notification → navigates to the task, marks notification read, badge decrements
- [ ] Badge disappears when all notifications are read
- [ ] WebSocket reconnects after the tab is backgrounded for >60s

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add sidebar notification inbox with unread count badge and mark/clear actions.
• Enable click-to-navigate to related task while marking the notification as read.
• Introduce user-scoped WebSocket events to refresh notifications cache in real time (no polling).
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Web: WorkspaceSwitcher"] --> B(["useUserWebSocket"])
  B --> C["API: /ws/user"] --> D["API: userConnections"]
  E["API: notification.created event"] --> D --> F(["Web: Query invalidate"])
  G["Web: NotificationDropdown"] --> H["API: /notification"] --> I[("DB")]
  H --> I

  subgraph Legend
    direction LR
    _ui["UI Component"] ~~~ _hook(["Hook/Logic"]) ~~~ _api["API Endpoint/Module"] ~~~ _db[("Database")]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Send full notification payload over WebSocket</b></summary>

- ➕ Avoids refetch; reduces API load on bursts of notifications
- ➕ UI can update immediately without waiting for query refetch
- ➖ More coupling between WS message schema and UI rendering
- ➖ Need to handle partial/legacy eventData hydration and pagination consistency
- ➖ Harder to keep cache coherent with mark/clear mutations

</details>

<details>
<summary><b>2. Server-Sent Events (SSE) instead of WebSocket</b></summary>

- ➕ Simpler infra than bidirectional WS; works well for one-way events
- ➕ Often easier to operate through proxies/load balancers
- ➖ No built-in client-&gt;server keepalive semantics beyond HTTP; still need retry logic
- ➖ May not fit existing WS adapter/event patterns already in codebase

</details>

<details>
<summary><b>3. Continue polling notifications with shorter interval</b></summary>

- ➕ Very simple client; no persistent connection management
- ➖ Unnecessary background traffic and delayed badge updates
- ➖ Worse UX when expecting immediate mention/assignment notifications

</details>

**Recommendation:** The chosen approach (broadcasting a minimal NOTIFICATION_CREATED event and invalidating the TanStack Query cache) is a good balance of low coupling and correctness: it reuses existing /notification endpoints and keeps cache state authoritative. If notification volume becomes high, consider augmenting the WS payload with a notification id (or a lightweight unreadCount) to reduce refetch frequency while keeping the API as the source of truth.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (7)</summary>

<blockquote>
<details>
<summary><strong>index.ts</strong> <code>Add authenticated user-scoped WebSocket endpoint and fix route ordering</code> <code>+53/-0</code></summary>

<br/>

>Add authenticated user-scoped WebSocket endpoint and fix route ordering
>
><pre>
>• Registers a new /ws/user endpoint that authenticates, tracks a connection per user, and ignores ping keepalives. Includes a comment documenting that /ws/user must be registered before /ws/:projectId to avoid Hono param capture issues.
></pre>
>
><a href='https://github.com/usekaneo/kaneo/pull/1324/files#diff-55a96a3cad00af7af702aeea23e5691e713c4898618aaa8de6eb97c32c851538'>apps/api/src/index.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>index.ts</strong> <code>Include project/workspace context in notification eventData for task events</code> <code>+59/-0</code></summary>

<br/>

>Include project/workspace context in notification eventData for task events
>
><pre>
>• Enhances notification creation for several task/time-entry events by querying task/project to populate projectId and workspaceId in eventData. Improves downstream routing from notifications to the correct task context.
></pre>
>
><a href='https://github.com/usekaneo/kaneo/pull/1324/files#diff-500680acbf776e9290ea904d738dca5db556e02a8a038a0b76cf9673aa890950'>apps/api/src/notification/index.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>schemas.ts</strong> <code>Extend notification schema with task_mention type</code> <code>+1/-0</code></summary>

<br/>

>Extend notification schema with task_mention type
>
><pre>
>• Adds task_mention to the allowed notification type union so the API schema validates the new event type.
></pre>
>
><a href='https://github.com/usekaneo/kaneo/pull/1324/files#diff-95fb7b28c1dc5b1b0ad441b7f5a23f7961c5e2c5ac59826abc4b4c34696f2f56'>apps/api/src/schemas.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>index.ts</strong> <code>Add user-keyed WebSocket connection registry and notification broadcast</code> <code>+58/-0</code></summary>

<br/>

>Add user-keyed WebSocket connection registry and notification broadcast
>
><pre>
>• Introduces userConnections with helpers to add/remove connections and broadcast a JSON message to all tabs for a user. Subscribes to notification.created and broadcasts NOTIFICATION_CREATED to the recipient&#x27;s active connections.
></pre>
>
><a href='https://github.com/usekaneo/kaneo/pull/1324/files#diff-7e4c345f3a746b5a256d2ee13c45cc29689efe188f9544b9357a21297fc651d7'>apps/api/src/ws/index.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>notification-dropdown.tsx</strong> <code>Unread-count badge, task_mention copy, and click-to-navigate/mark-as-read</code> <code>+69/-22</code></summary>

<br/>

>Unread-count badge, task_mention copy, and click-to-navigate/mark-as-read
>
><pre>
>• Updates the dropdown to show a numeric unread badge (capped at 99+), adds task_mention title/content translations, and switches list rows to menu items with click handling. Clicking marks the notification read and navigates to the related task using project/workspace IDs from eventData.
></pre>
>
><a href='https://github.com/usekaneo/kaneo/pull/1324/files#diff-cf53efaa3982e0850204ce96fee917dbcd0f52a0d0975ecd68402f80970e14ae'>apps/web/src/components/notification/notification-dropdown.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>workspace-switcher.tsx</strong> <code>Mount notification dropdown and initialize user WebSocket</code> <code>+10/-3</code></summary>

<br/>

>Mount notification dropdown and initialize user WebSocket
>
><pre>
>• Places the NotificationDropdown next to the user avatar in the sidebar footer and mounts useUserWebSocket so real-time events refresh the notifications cache.
></pre>
>
><a href='https://github.com/usekaneo/kaneo/pull/1324/files#diff-4ecec98464491614017cd42e01e514cf48d7498ae9119af2a19fc0855b2c6a55'>apps/web/src/components/workspace-switcher.tsx</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>use-user-websocket.ts</strong> <code>New hook for user-scoped WebSocket with keepalive and backoff reconnect</code> <code>+93/-0</code></summary>

<br/>

>New hook for user-scoped WebSocket with keepalive and backoff reconnect
>
><pre>
>• Adds a client hook that opens a user-scoped WebSocket connection, sends periodic ping keepalives, and reconnects with exponential backoff (max 5 retries). On NOTIFICATION_CREATED, invalidates the [&quot;notifications&quot;] query to refresh the inbox and badge.
></pre>
>
><a href='https://github.com/usekaneo/kaneo/pull/1324/files#diff-216713a0b5bbddfa03ca569057cf008d33e204116367d22356971db127ef027c'>apps/web/src/hooks/use-user-websocket.ts</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>get-notifications.ts</strong> <code>Hydrate notifications with project/workspace IDs via task joins</code> <code>+43/-5</code></summary>

<br/>

>Hydrate notifications with project/workspace IDs via task joins
>
><pre>
>• Changes the query to left-join task -&gt; project -&gt; workspace to derive projectId/workspaceId for task notifications. Merges these into eventData to support navigation for legacy notifications missing those fields.
></pre>
>
><a href='https://github.com/usekaneo/kaneo/pull/1324/files#diff-081aa552206257b2377983afec76e068c4628076e17590a649acc7e41d71ffc9'>apps/api/src/notification/controllers/get-notifications.ts</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time notification delivery via a user-scoped WebSocket (with keepalive support)
  * Click notifications to mark them as read and navigate to the related task
  * Support for the new `task_mention` notification type
  * Unread indicator now shows a capped numeric count (`99+`)
* **Improvements**
  * Notifications are enriched with related project/workspace context
  * Notification dropdown UI updated with footer buttons for “mark all as read” and “clear” actions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->