### PR TITLE
fix(bug): fix for s3 files using old api URL

### DIFF
--- a/apps/api/src/task/index.ts
+++ b/apps/api/src/task/index.ts
@@ -804,7 +804,7 @@ const task = new Hono<{
             });
 
       const apiBaseUrl = normalizeApiServerUrl(
-        process.env.KANEO_API_URL || "http://localhost:1337",
+        process.env.KANEO_API_URL || new URL(c.req.url).origin,
       );
       return c.json({
         id: asset.id,

--- a/apps/api/src/task/index.ts
+++ b/apps/api/src/task/index.ts
@@ -17,6 +17,7 @@ import {
   isImageContentType,
   validateTaskAssetUploadInput,
 } from "../storage/s3";
+import { normalizeApiServerUrl } from "../utils/openapi-spec";
 import { requireWorkspacePermission } from "../utils/require-workspace-permission";
 import { workspaceAccess } from "../utils/workspace-access-middleware";
 import bulkUpdateTasks from "./controllers/bulk-update-tasks";
@@ -802,9 +803,12 @@ const task = new Hono<{
               id: assetTable.id,
             });
 
+      const apiBaseUrl = normalizeApiServerUrl(
+        process.env.KANEO_API_URL || "http://localhost:1337",
+      );
       return c.json({
         id: asset.id,
-        url: new URL(`/api/asset/${asset.id}`, c.req.url).toString(),
+        url: `${apiBaseUrl}/asset/${asset.id}`,
       });
     },
   )

--- a/tests/api-integration/task-image-upload.test.ts
+++ b/tests/api-integration/task-image-upload.test.ts
@@ -1,0 +1,433 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import db, { schema } from "../../apps/api/src/database";
+import { createApp } from "../../apps/api/src/index";
+import { mockAnonymousSession, mockAuthenticatedSession } from "./helpers/auth";
+import { resetTestDatabase } from "./helpers/database";
+import {
+  createProjectFixture,
+  createWorkspaceMember,
+} from "./helpers/fixtures";
+
+describe("API integration: task image upload finalize", () => {
+  beforeEach(async () => {
+    await resetTestDatabase();
+
+    process.env.S3_ENDPOINT = "https://storage.example.test";
+    process.env.S3_BUCKET = "test-bucket";
+    process.env.S3_ACCESS_KEY_ID = "test-access-key";
+    process.env.S3_SECRET_ACCESS_KEY = "test-secret-key";
+    delete process.env.S3_KEY_PREFIX;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a URL using KANEO_API_URL", async () => {
+    process.env.KANEO_API_URL = "http://kaneo.test:1337";
+
+    const member = await createWorkspaceMember();
+    const { project, columns } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    const [task] = await db
+      .insert(schema.taskTable)
+      .values({
+        projectId: project.id,
+        userId: member.user.id,
+        title: "URL test task",
+        status: "to-do",
+        columnId: columns.todo.id,
+        priority: "medium",
+        number: 1,
+        position: 1,
+      })
+      .returning();
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const key = `workspace/${member.workspace.id}/project/${project.id}/task/${task.id}/descriptions/test-image.png`;
+
+    const response = await app.request(
+      `/api/task/image-upload/${task.id}/finalize`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          key,
+          filename: "test-image.png",
+          contentType: "image/png",
+          size: 12345,
+          surface: "description",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { id: string; url: string };
+    expect(payload).toHaveProperty("id");
+    expect(payload).toHaveProperty("url");
+    expect(payload.url).toBe(`http://kaneo.test:1337/api/asset/${payload.id}`);
+    expect(payload.url).not.toContain("localhost");
+  });
+
+  it("updates the URL when KANEO_API_URL changes", async () => {
+    process.env.KANEO_API_URL = "https://proxy.kaneo.internal";
+
+    const member = await createWorkspaceMember();
+    const { project, columns } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    const [task] = await db
+      .insert(schema.taskTable)
+      .values({
+        projectId: project.id,
+        userId: member.user.id,
+        title: "Proxy test",
+        status: "to-do",
+        columnId: columns.todo.id,
+        priority: "medium",
+        number: 1,
+        position: 1,
+      })
+      .returning();
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const key = `workspace/${member.workspace.id}/project/${project.id}/task/${task.id}/descriptions/proxy-image.png`;
+
+    const response = await app.request(
+      `/api/task/image-upload/${task.id}/finalize`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          key,
+          filename: "proxy-image.png",
+          contentType: "image/png",
+          size: 99999,
+          surface: "description",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { id: string; url: string };
+    expect(payload.url).toBe(
+      `https://proxy.kaneo.internal/api/asset/${payload.id}`,
+    );
+    expect(payload.url).not.toContain("localhost");
+  });
+
+  it("falls back when KANEO_API_URL is not set", async () => {
+    delete process.env.KANEO_API_URL;
+
+    const member = await createWorkspaceMember();
+    const { project, columns } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    const [task] = await db
+      .insert(schema.taskTable)
+      .values({
+        projectId: project.id,
+        userId: member.user.id,
+        title: "Fallback test",
+        status: "to-do",
+        columnId: columns.todo.id,
+        priority: "medium",
+        number: 1,
+        position: 1,
+      })
+      .returning();
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const key = `workspace/${member.workspace.id}/project/${project.id}/task/${task.id}/descriptions/fallback-image.png`;
+
+    const response = await app.request(
+      `/api/task/image-upload/${task.id}/finalize`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          key,
+          filename: "fallback-image.png",
+          contentType: "image/png",
+          size: 12345,
+          surface: "description",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { id: string; url: string };
+    expect(payload.url).toBe(`http://localhost:1337/api/asset/${payload.id}`);
+  });
+
+  it("persists a new asset record with correct metadata", async () => {
+    process.env.KANEO_API_URL = "http://localhost:1337";
+
+    const member = await createWorkspaceMember();
+    const { project, columns } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    const [task] = await db
+      .insert(schema.taskTable)
+      .values({
+        projectId: project.id,
+        userId: member.user.id,
+        title: "Persist test",
+        status: "to-do",
+        columnId: columns.todo.id,
+        priority: "medium",
+        number: 1,
+        position: 1,
+      })
+      .returning();
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const key = `workspace/${member.workspace.id}/project/${project.id}/task/${task.id}/descriptions/persist-asset.png`;
+
+    const response = await app.request(
+      `/api/task/image-upload/${task.id}/finalize`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          key,
+          filename: "persist-asset.png",
+          contentType: "image/png",
+          size: 45678,
+          surface: "description",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { id: string; url: string };
+
+    const asset = await db.query.assetTable.findFirst({
+      where: (t, { eq }) => eq(t.id, payload.id),
+    });
+
+    expect(asset).toBeDefined();
+    expect(asset?.id).toBe(payload.id);
+    expect(asset?.objectKey).toBe(key);
+    expect(asset?.filename).toBe("persist-asset.png");
+    expect(asset?.mimeType).toBe("image/png");
+    expect(asset?.size).toBe(45678);
+    expect(asset?.kind).toBe("image");
+    expect(asset?.surface).toBe("description");
+    expect(asset?.workspaceId).toBe(member.workspace.id);
+    expect(asset?.projectId).toBe(project.id);
+    expect(asset?.taskId).toBe(task.id);
+    expect(asset?.createdBy).toBe(member.user.id);
+  });
+
+  it("creates attachment records for non-image content types", async () => {
+    process.env.KANEO_API_URL = "http://localhost:1337";
+
+    const member = await createWorkspaceMember();
+    const { project, columns } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    const [task] = await db
+      .insert(schema.taskTable)
+      .values({
+        projectId: project.id,
+        userId: member.user.id,
+        title: "Attachment test",
+        status: "to-do",
+        columnId: columns.todo.id,
+        priority: "medium",
+        number: 1,
+        position: 1,
+      })
+      .returning();
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const key = `workspace/${member.workspace.id}/project/${project.id}/task/${task.id}/descriptions/report.pdf`;
+
+    const response = await app.request(
+      `/api/task/image-upload/${task.id}/finalize`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          key,
+          filename: "report.pdf",
+          contentType: "application/pdf",
+          size: 102400,
+          surface: "description",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { id: string; url: string };
+
+    const asset = await db.query.assetTable.findFirst({
+      where: (t, { eq }) => eq(t.id, payload.id),
+    });
+    expect(asset?.kind).toBe("attachment");
+  });
+
+  it("rejects key that does not match the task context", async () => {
+    process.env.KANEO_API_URL = "http://localhost:1337";
+
+    const member = await createWorkspaceMember();
+    const { project, columns } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    const [task] = await db
+      .insert(schema.taskTable)
+      .values({
+        projectId: project.id,
+        userId: member.user.id,
+        title: "Bad key test",
+        status: "to-do",
+        columnId: columns.todo.id,
+        priority: "medium",
+        number: 1,
+        position: 1,
+      })
+      .returning();
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request(
+      `/api/task/image-upload/${task.id}/finalize`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          key: "totally/wrong/path/image.png",
+          filename: "test.png",
+          contentType: "image/png",
+          size: 100,
+          surface: "description",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(400);
+    const text = await response.text();
+    expect(text).toBe("Image upload key does not match the task context.");
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    process.env.KANEO_API_URL = "http://localhost:1337";
+
+    const member = await createWorkspaceMember();
+    const { project, columns } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    const [task] = await db
+      .insert(schema.taskTable)
+      .values({
+        projectId: project.id,
+        userId: member.user.id,
+        title: "Auth test",
+        status: "to-do",
+        columnId: columns.todo.id,
+        priority: "medium",
+        number: 1,
+        position: 1,
+      })
+      .returning();
+
+    mockAnonymousSession();
+    const { app } = createApp();
+
+    const response = await app.request(
+      `/api/task/image-upload/${task.id}/finalize`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          key: "some/key.png",
+          filename: "test.png",
+          contentType: "image/png",
+          size: 100,
+          surface: "description",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects requests from users outside the workspace", async () => {
+    process.env.KANEO_API_URL = "http://localhost:1337";
+
+    const member = await createWorkspaceMember();
+    const outsiderId = `user-${randomUUID()}`;
+
+    const [outsider] = await db
+      .insert(schema.userTable)
+      .values({
+        id: outsiderId,
+        email: `${outsiderId}@example.com`,
+        emailVerified: true,
+        name: "Outsider",
+      })
+      .returning();
+
+    const { project, columns } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    const [task] = await db
+      .insert(schema.taskTable)
+      .values({
+        projectId: project.id,
+        userId: member.user.id,
+        title: "RBAC test",
+        status: "to-do",
+        columnId: columns.todo.id,
+        priority: "medium",
+        number: 1,
+        position: 1,
+      })
+      .returning();
+
+    mockAuthenticatedSession(outsider);
+    const { app } = createApp();
+
+    const response = await app.request(
+      `/api/task/image-upload/${task.id}/finalize`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          key: `workspace/${member.workspace.id}/project/${project.id}/task/${task.id}/descriptions/rbac-test.png`,
+          filename: "rbac-test.png",
+          contentType: "image/png",
+          size: 100,
+          surface: "description",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toBe(
+      "You don't have access to this workspace",
+    );
+  });
+});

--- a/tests/api-integration/task-image-upload.test.ts
+++ b/tests/api-integration/task-image-upload.test.ts
@@ -124,7 +124,7 @@ describe("API integration: task image upload finalize", () => {
     expect(payload.url).not.toContain("localhost");
   });
 
-  it("falls back when KANEO_API_URL is not set", async () => {
+  it("falls back to deriving URL from the request when KANEO_API_URL is not set", async () => {
     delete process.env.KANEO_API_URL;
 
     const member = await createWorkspaceMember();
@@ -152,7 +152,7 @@ describe("API integration: task image upload finalize", () => {
     const key = `workspace/${member.workspace.id}/project/${project.id}/task/${task.id}/descriptions/fallback-image.png`;
 
     const response = await app.request(
-      `/api/task/image-upload/${task.id}/finalize`,
+      `https://app.kaneo.test/api/task/image-upload/${task.id}/finalize`,
       {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -168,7 +168,8 @@ describe("API integration: task image upload finalize", () => {
 
     expect(response.status).toBe(200);
     const payload = (await response.json()) as { id: string; url: string };
-    expect(payload.url).toBe(`http://localhost:1337/api/asset/${payload.id}`);
+    expect(payload.url).toBe(`https://app.kaneo.test/api/asset/${payload.id}`);
+    expect(payload.url).not.toContain("localhost");
   });
 
   it("persists a new asset record with correct metadata", async () => {


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->

The following PR fixes #1270 . Asset URLs from `POST /api/task/image-upload/{taskId}/finalize` used `new URL(path, c.req.url)` which resolves to `localhost:1337` when the API runs behind a reverse proxy. Changed to use `KANEO_API_URL` env var instead, so the returned URL matches the public-facing host.



## Related Issue(s)
<!-- Link to the related issue(s) this PR addresses -->
Fixes #1270 

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):
- 8 new tests covering URL construction, env var fallback, DB persistence, key validation, auth, and RBAC

## Screenshots (if applicable)

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any other context about the PR here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the finalized asset URL generation for task image uploads to use consistent environment-based API configuration, with a sensible fallback to the incoming request origin.

* **Tests**
  * Added integration coverage for image upload finalization, including URL behavior, authentication/authorization enforcement, validation errors, and correct asset/attachment persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->