### PR TITLE
feat: support AWS IAM roles for S3 storage

### DIFF
--- a/apps/api/src/storage/s3.ts
+++ b/apps/api/src/storage/s3.ts
@@ -92,17 +92,53 @@ export function parsePositiveInt(value: string | undefined, fallback: number) {
   return parsed;
 }
 
+/**
+ * Resolves static S3 credentials from the access key pair.
+ *
+ * Returns the explicit credentials only when BOTH the access key id and secret
+ * are provided. When neither is set, returns `undefined` so the AWS SDK falls
+ * back to its default credential provider chain (EC2 instance profile, ECS task
+ * role, EKS IRSA, environment variables, or shared config) — enabling
+ * IAM-role-based access without static keys.
+ *
+ * Throws when exactly one of the two is set, since that is almost always a
+ * misconfiguration rather than an intentional fallback.
+ */
+export function resolveS3Credentials(
+  accessKeyId: string,
+  secretAccessKey: string,
+): { accessKeyId: string; secretAccessKey: string } | undefined {
+  const hasAccessKeyId = Boolean(accessKeyId);
+  const hasSecretAccessKey = Boolean(secretAccessKey);
+
+  if (hasAccessKeyId !== hasSecretAccessKey) {
+    throw new Error(
+      "Incomplete S3 credentials. Set both S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY, or neither to use the default AWS credential provider chain (IAM role / IRSA / environment).",
+    );
+  }
+
+  if (hasAccessKeyId && hasSecretAccessKey) {
+    return { accessKeyId, secretAccessKey };
+  }
+
+  return undefined;
+}
+
 function getStorageConfig(): StorageConfig {
   const endpoint = env("S3_ENDPOINT");
   const bucket = env("S3_BUCKET");
   const accessKeyId = env("S3_ACCESS_KEY_ID");
   const secretAccessKey = env("S3_SECRET_ACCESS_KEY");
 
-  if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) {
+  if (!endpoint || !bucket) {
     throw new Error(
-      "S3 uploads are not configured. Set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY.",
+      "S3 uploads are not configured. Set S3_ENDPOINT and S3_BUCKET (and either both S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY, or neither to use the default AWS credential provider chain / IAM role).",
     );
   }
+
+  // Validate the access key pair early so misconfiguration surfaces here rather
+  // than as an opaque signing error later.
+  resolveS3Credentials(accessKeyId, secretAccessKey);
 
   return {
     endpoint,
@@ -151,11 +187,20 @@ function getClient(config: StorageConfig) {
     // Avoid auto-injecting checksum params for presigned PUT URLs. Some
     // S3-compatible providers (e.g. Garage/R2) reject mismatched hoisted CRCs.
     requestChecksumCalculation: "WHEN_REQUIRED",
-    credentials: {
-      accessKeyId: config.accessKeyId,
-      secretAccessKey: config.secretAccessKey,
-    },
   };
+
+  const credentials = resolveS3Credentials(
+    config.accessKeyId,
+    config.secretAccessKey,
+  );
+
+  // Only pin explicit credentials when both keys are provided. Otherwise leave
+  // `credentials` unset so the AWS SDK resolves them from its default provider
+  // chain (EC2 instance profile, ECS task role, EKS IRSA, env, shared config),
+  // which is how IAM-role-based access works.
+  if (credentials) {
+    clientConfig.credentials = credentials;
+  }
 
   const client = new S3Client(clientConfig);
   clientCache = { cacheKey, client };

--- a/apps/docs/core/installation/environment-variables.mdx
+++ b/apps/docs/core/installation/environment-variables.mdx
@@ -67,8 +67,8 @@ Name | Description | Default |
 --- | --- | --- |
 | `S3_ENDPOINT` | The S3-compatible API endpoint used by the Kaneo API for presigned uploads. Example: `http://minio:9000`. |  |
 | `S3_BUCKET` | The bucket Kaneo will use for uploaded files. |  |
-| `S3_ACCESS_KEY_ID` | Access key used by the Kaneo API to create presigned upload URLs. |  |
-| `S3_SECRET_ACCESS_KEY` | Secret key used by the Kaneo API to create presigned upload URLs. |  |
+| `S3_ACCESS_KEY_ID` | Access key used by the Kaneo API to create presigned upload URLs. Optional — leave unset (together with `S3_SECRET_ACCESS_KEY`) to use the default AWS credential provider chain (IAM role / IRSA / instance profile). |  |
+| `S3_SECRET_ACCESS_KEY` | Secret key used by the Kaneo API to create presigned upload URLs. Must be set together with `S3_ACCESS_KEY_ID`, or left unset for IAM-role-based access. |  |
 | `S3_REGION` | The storage region used for request signing. | `us-east-1` |
 | `S3_PUBLIC_BASE_URL` | Optional public base URL for uploaded assets. Kaneo does not require this for the current private asset flow. |  |
 | `S3_FORCE_PATH_STYLE` | Use path-style S3 URLs. This should usually be `true` for MinIO and `fs`. | `true` |

--- a/apps/docs/core/installation/object-storage-and-image-uploads.mdx
+++ b/apps/docs/core/installation/object-storage-and-image-uploads.mdx
@@ -136,8 +136,8 @@ Set these in your Kaneo deployment:
 | --- | --- |
 | `S3_ENDPOINT` | S3-compatible API endpoint used by Kaneo |
 | `S3_BUCKET` | Bucket used for uploaded files |
-| `S3_ACCESS_KEY_ID` | Access key used to create presigned upload URLs |
-| `S3_SECRET_ACCESS_KEY` | Secret key used to create presigned upload URLs |
+| `S3_ACCESS_KEY_ID` | Access key used to create presigned upload URLs. Optional when using an IAM role (see below) |
+| `S3_SECRET_ACCESS_KEY` | Secret key used to create presigned upload URLs. Optional when using an IAM role (see below) |
 | `S3_REGION` | Region used for signing |
 | `S3_FORCE_PATH_STYLE` | Usually `true` for MinIO and `fs` |
 
@@ -148,6 +148,40 @@ Optional:
 | `S3_PUBLIC_BASE_URL` | Optional public asset base URL. Kaneo does not require this for the current private asset flow. |
 | `S3_MAX_IMAGE_UPLOAD_BYTES` | Maximum allowed upload size in bytes for images and other uploaded files |
 | `S3_PRESIGN_TTL_SECONDS` | Presigned upload URL lifetime |
+
+## Using an IAM role (AWS S3) instead of static keys
+
+When Kaneo runs on AWS (EC2, ECS, or EKS), you can let it authenticate with an
+IAM role instead of long-lived access keys.
+
+Leave both `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY` unset. Kaneo then falls
+back to the AWS SDK's default credential provider chain, which automatically
+picks up credentials from:
+
+- an EC2 instance profile
+- an ECS task role
+- an EKS service account / IRSA (`AWS_WEB_IDENTITY_TOKEN_FILE`)
+- standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables
+- a shared `~/.aws/credentials` profile
+
+Example for AWS S3 with an attached IAM role:
+
+```env
+S3_ENDPOINT=https://s3.us-east-1.amazonaws.com
+S3_BUCKET=kaneo-uploads
+S3_REGION=us-east-1
+S3_FORCE_PATH_STYLE=false
+# S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY intentionally omitted
+```
+
+The IAM role must allow `s3:PutObject`, `s3:GetObject`, and `s3:DeleteObject`
+on the bucket.
+
+<Warning>
+  Set both keys or neither. Configuring only one of `S3_ACCESS_KEY_ID` /
+  `S3_SECRET_ACCESS_KEY` is treated as a misconfiguration and Kaneo will refuse
+  to start the storage client.
+</Warning>
 
 ## Testing uploads
 

--- a/apps/docs/core/installation/storage-backends.mdx
+++ b/apps/docs/core/installation/storage-backends.mdx
@@ -114,6 +114,24 @@ For another AWS region, adjust:
 
 - `S3_ENDPOINT`
 
+### Using an IAM role instead of an access key
+
+If Kaneo runs on AWS (EC2, ECS, or EKS), you can omit `S3_ACCESS_KEY_ID` and
+`S3_SECRET_ACCESS_KEY` entirely and let Kaneo authenticate with the instance's
+IAM role. Leave both unset and the AWS SDK resolves credentials from its default
+provider chain (instance profile, ECS task role, or EKS IRSA).
+
+```env
+S3_ENDPOINT=https://s3.us-east-1.amazonaws.com
+S3_BUCKET=kaneo-uploads
+S3_REGION=us-east-1
+S3_FORCE_PATH_STYLE=false
+# S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY omitted — the IAM role is used
+```
+
+Set both keys or neither: configuring only one is rejected. The role must allow
+`s3:PutObject`, `s3:GetObject`, and `s3:DeleteObject` on the bucket.
+
 Recommended S3 CORS policy:
 
 ```json

--- a/tests/api/storage/s3.test.ts
+++ b/tests/api/storage/s3.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   applyKeyPrefix,
+  assertStorageConfigured,
   assertTaskImageKeyMatchesContext,
   buildObjectKey,
   buildObjectKeyPrefix,
@@ -9,6 +10,7 @@ import {
   isImageContentType,
   parseBoolean,
   parsePositiveInt,
+  resolveS3Credentials,
   sanitizePathSegment,
   validateTaskAssetUploadInput,
 } from "../../../apps/api/src/storage/s3";
@@ -213,6 +215,125 @@ describe("S3 helpers", () => {
     const searchParams = new URL(upload.uploadUrl).searchParams;
     expect(searchParams.has("x-amz-checksum-crc32")).toBe(false);
     expect(searchParams.has("x-amz-sdk-checksum-algorithm")).toBe(false);
+  });
+
+  it("resolveS3Credentials returns explicit credentials when both keys are set", () => {
+    expect(resolveS3Credentials("AKIA", "secret")).toEqual({
+      accessKeyId: "AKIA",
+      secretAccessKey: "secret",
+    });
+  });
+
+  it("resolveS3Credentials returns undefined when both keys are absent (IAM role fallback)", () => {
+    expect(resolveS3Credentials("", "")).toBeUndefined();
+  });
+
+  it("resolveS3Credentials throws when only one key is set", () => {
+    expect(() => resolveS3Credentials("AKIA", "")).toThrow(
+      /both S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY/,
+    );
+    expect(() => resolveS3Credentials("", "secret")).toThrow(
+      /both S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY/,
+    );
+  });
+
+  it("assertStorageConfigured succeeds without static keys (IAM role mode)", () => {
+    process.env.S3_ENDPOINT = "https://s3.us-east-1.amazonaws.com";
+    process.env.S3_BUCKET = "kaneo";
+    delete process.env.S3_ACCESS_KEY_ID;
+    delete process.env.S3_SECRET_ACCESS_KEY;
+
+    const config = assertStorageConfigured();
+    expect(config.bucket).toBe("kaneo");
+    expect(config.accessKeyId).toBe("");
+    expect(config.secretAccessKey).toBe("");
+  });
+
+  it("assertStorageConfigured throws when only one credential key is set", () => {
+    process.env.S3_ENDPOINT = "https://s3.us-east-1.amazonaws.com";
+    process.env.S3_BUCKET = "kaneo";
+    process.env.S3_ACCESS_KEY_ID = "AKIA";
+    delete process.env.S3_SECRET_ACCESS_KEY;
+
+    expect(() => assertStorageConfigured()).toThrow(
+      /Incomplete S3 credentials/,
+    );
+  });
+
+  it("assertStorageConfigured throws when endpoint or bucket is missing", () => {
+    delete process.env.S3_ENDPOINT;
+    delete process.env.S3_BUCKET;
+
+    expect(() => assertStorageConfigured()).toThrow(
+      /S3 uploads are not configured/,
+    );
+  });
+});
+
+describe("S3 credential provider chain (IAM role)", () => {
+  const trackedKeys = [
+    "S3_ENDPOINT",
+    "S3_BUCKET",
+    "S3_ACCESS_KEY_ID",
+    "S3_SECRET_ACCESS_KEY",
+    "S3_REGION",
+    "S3_FORCE_PATH_STYLE",
+    "S3_KEY_PREFIX",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+  ] as const;
+
+  const original: Partial<Record<(typeof trackedKeys)[number], string>> = {};
+
+  beforeEach(() => {
+    for (const key of trackedKeys) {
+      original[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of trackedKeys) {
+      const value = original[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("signs presigned URLs using ambient credentials when S3 keys are unset", async () => {
+    // Non-sensitive, obviously-fake credentials generated at runtime so no
+    // credential-like literals are committed (avoids secret-scanning hits).
+    const ambientAccessKeyId = `test-ambient-key-${Date.now()}`;
+    const ambientSecretAccessKey = `test-ambient-secret-${Date.now()}`;
+
+    // Simulates an IAM role / IRSA / instance profile: no S3_ACCESS_KEY_ID is
+    // configured, but ambient AWS credentials are resolvable from the
+    // environment (the AWS SDK default provider chain reads AWS_* env vars).
+    process.env.S3_ENDPOINT = "https://s3.us-east-1.amazonaws.com";
+    process.env.S3_BUCKET = "kaneo";
+    process.env.S3_REGION = "us-east-1";
+    process.env.S3_FORCE_PATH_STYLE = "false";
+    process.env.AWS_ACCESS_KEY_ID = ambientAccessKeyId;
+    process.env.AWS_SECRET_ACCESS_KEY = ambientSecretAccessKey;
+
+    const upload = await createTaskImageUploadUrl({
+      workspaceId: "workspace-1",
+      projectId: "project-1",
+      taskId: "task-1",
+      surface: "description",
+      filename: "report.png",
+      contentType: "image/png",
+    });
+
+    const searchParams = new URL(upload.uploadUrl).searchParams;
+    // The signature must be derived from the ambient credentials, proving the
+    // SDK default provider chain (used for IAM roles) was applied.
+    expect(searchParams.get("X-Amz-Credential")).toContain(ambientAccessKeyId);
+    expect(searchParams.has("X-Amz-Signature")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Description
Adds support for AWS IAM roles when accessing S3, so deployments on EC2, ECS, or EKS no longer need static access keys.

A new `resolveS3Credentials` helper accepts either a complete static key pair or no keys at all. When both `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY` are set, they're used as before; when neither is set, credentials are left unconfigured so the AWS SDK falls back to its default provider chain (instance profile, ECS task role, EKS IRSA, environment, or shared config). Setting exactly one of the two is rejected with a clear error instead of failing later at signing time.

`getStorageConfig` no longer requires the static keys (only `S3_ENDPOINT` and `S3_BUCKET`) and validates the key pair early, and `getClient` only pins explicit credentials when both keys are provided.

Backward compatible: existing static-key setups (MinIO, Cloudflare R2, AWS with keys) are unchanged — only the "no keys" path is new.

## Related Issue(s)
No existing issue — checked open issues, GitHub, and Discord; no one is working on this.

Fixes #

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
Docs updated in three places: `environment-variables.mdx`, `object-storage-and-image-uploads.mdx`, and `storage-backends.mdx` (new "Using an IAM role" guidance with an AWS example and the required `s3:PutObject`/`s3:GetObject`/`s3:DeleteObject` permissions).

Out of scope: `S3_ENDPOINT` is still required, so AWS users set it to the regional endpoint (e.g. `https://s3.us-east-1.amazonaws.com`). Happy to make the endpoint optional in a follow-up if maintainers prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3 uploads can now use AWS’s default credential provider chain (e.g., IAM role/IRSA/instance profile) when static S3 access keys are left unset.
  * S3 configuration now requires access key pairs to be set together; providing only one key is rejected.

* **Documentation**
  * Updated environment variable and S3 storage documentation to clarify IAM role usage, required permissions, and the “both keys or neither” rule.

* **Tests**
  * Expanded S3 tests to cover explicit-key mode, IAM-role/default credential behavior, validation failures, and presigned upload URL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->