### PR TITLE
fix: use custom column names in webhook status reports

### DIFF
--- a/apps/api/src/plugins/discord/client.ts
+++ b/apps/api/src/plugins/discord/client.ts
@@ -22,6 +22,17 @@ type DiscordMessage = {
 
 const DISCORD_TIMEOUT_MS = 10_000;
 
+export function sanitizeDiscordContent(value: string): string {
+  return value
+    .replace(/@everyone/g, "@\u200beveryone")
+    .replace(/@here/g, "@\u200bhere")
+    .replace(/<@&/g, "<@\u200b&")
+    .replace(/<@!?\d+>/g, (match) => `<@\u200b${match.slice(2)}`)
+    .replace(/<#\d+>/g, (match) => `<#\u200b${match.slice(2)}`)
+    .replace(/<:\w+:\d+>/g, (match) => `<:\u200b${match.slice(2)}`)
+    .replace(/<a:\w+:\d+>/g, (match) => `<a:\u200b${match.slice(3)}`);
+}
+
 export async function postToDiscord(
   webhookUrl: string,
   message: DiscordMessage,

--- a/apps/api/src/plugins/discord/events.ts
+++ b/apps/api/src/plugins/discord/events.ts
@@ -26,7 +26,8 @@ type DiscordEventData = {
   projectName: string;
   taskUrl: string | null;
   actorName: string | null;
-  status: string | null;
+  statusSlug: string;
+  columnName: string | null;
   priority: string | null;
 };
 
@@ -114,7 +115,8 @@ async function getDiscordEventData(
     projectName: taskRow.projectName,
     taskUrl,
     actorName: user?.name ?? null,
-    status: taskRow.columnName ?? taskRow.status,
+    statusSlug: taskRow.status,
+    columnName: taskRow.columnName,
     priority: taskRow.priority,
   };
 }
@@ -132,7 +134,9 @@ async function sendDiscordMessage(
   const safeBody = sanitizeDiscordContent(body);
   const safeTaskLabel = sanitizeDiscordContent(taskLabel);
   const safeProjectName = sanitizeDiscordContent(data.projectName);
-  const safeStatus = sanitizeDiscordContent(toSentenceCase(data.status));
+  const safeStatus = sanitizeDiscordContent(
+    data.columnName ?? toSentenceCase(data.statusSlug),
+  );
   const safePriority = sanitizeDiscordContent(toSentenceCase(data.priority));
   const safeActor = data.actorName
     ? sanitizeDiscordContent(data.actorName)

--- a/apps/api/src/plugins/discord/events.ts
+++ b/apps/api/src/plugins/discord/events.ts
@@ -81,7 +81,13 @@ async function getDiscordEventData(
     .from(taskTable)
     .innerJoin(projectTable, eq(taskTable.projectId, projectTable.id))
     .innerJoin(workspaceTable, eq(projectTable.workspaceId, workspaceTable.id))
-    .leftJoin(columnTable, eq(taskTable.columnId, columnTable.id))
+    .leftJoin(
+      columnTable,
+      and(
+        eq(taskTable.columnId, columnTable.id),
+        eq(columnTable.projectId, projectTable.id),
+      ),
+    )
     .where(and(eq(taskTable.id, taskId), eq(projectTable.id, projectId)))
     .limit(1);
 

--- a/apps/api/src/plugins/discord/events.ts
+++ b/apps/api/src/plugins/discord/events.ts
@@ -16,7 +16,7 @@ import type {
   TaskStatusChangedEvent,
   TaskTitleChangedEvent,
 } from "../types";
-import { postToDiscord } from "./client";
+import { postToDiscord, sanitizeDiscordContent } from "./client";
 import type { DiscordConfig, DiscordEventKey } from "./config";
 import { normalizeDiscordConfig } from "./config";
 
@@ -122,43 +122,52 @@ async function sendDiscordMessage(
   const issueKey =
     data.taskNumber !== null ? `#${data.taskNumber}` : "Task update";
   const taskLabel = `${issueKey} ${data.taskTitle}`;
+  const safeTitle = sanitizeDiscordContent(title);
+  const safeBody = sanitizeDiscordContent(body);
+  const safeTaskLabel = sanitizeDiscordContent(taskLabel);
+  const safeProjectName = sanitizeDiscordContent(data.projectName);
+  const safeStatus = sanitizeDiscordContent(toSentenceCase(data.status));
+  const safePriority = sanitizeDiscordContent(toSentenceCase(data.priority));
+  const safeActor = data.actorName
+    ? sanitizeDiscordContent(data.actorName)
+    : null;
 
   try {
     await postToDiscord(config.webhookUrl, {
-      content: `${title}: ${data.taskTitle}`,
+      content: `${safeTitle}: ${safeTaskLabel}`,
       embeds: [
         {
-          title,
-          description: body,
+          title: safeTitle,
+          description: safeBody,
           url: data.taskUrl ?? undefined,
           color: 0x5865f2,
           fields: [
             {
               name: "Task",
               value: data.taskUrl
-                ? `[${taskLabel}](${data.taskUrl})`
-                : taskLabel,
+                ? `[${safeTaskLabel}](${data.taskUrl})`
+                : safeTaskLabel,
               inline: true,
             },
             {
               name: "Project",
-              value: data.projectName,
+              value: safeProjectName,
               inline: true,
             },
             {
               name: "Status",
-              value: toSentenceCase(data.status),
+              value: safeStatus,
               inline: true,
             },
             {
               name: "Priority",
-              value: toSentenceCase(data.priority),
+              value: safePriority,
               inline: true,
             },
           ],
           footer: {
-            text: data.actorName
-              ? `Triggered by ${data.actorName}`
+            text: safeActor
+              ? `Triggered by ${safeActor}`
               : "Triggered by Kaneo",
           },
         },

--- a/apps/api/src/plugins/discord/events.ts
+++ b/apps/api/src/plugins/discord/events.ts
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import db from "../../database";
 import {
+  columnTable,
   projectTable,
   taskTable,
   userTable,
@@ -72,6 +73,7 @@ async function getDiscordEventData(
       number: taskTable.number,
       status: taskTable.status,
       priority: taskTable.priority,
+      columnName: columnTable.name,
       projectName: projectTable.name,
       projectId: projectTable.id,
       workspaceId: workspaceTable.id,
@@ -79,6 +81,7 @@ async function getDiscordEventData(
     .from(taskTable)
     .innerJoin(projectTable, eq(taskTable.projectId, projectTable.id))
     .innerJoin(workspaceTable, eq(projectTable.workspaceId, workspaceTable.id))
+    .leftJoin(columnTable, eq(taskTable.columnId, columnTable.id))
     .where(and(eq(taskTable.id, taskId), eq(projectTable.id, projectId)))
     .limit(1);
 
@@ -105,7 +108,7 @@ async function getDiscordEventData(
     projectName: taskRow.projectName,
     taskUrl,
     actorName: user?.name ?? null,
-    status: taskRow.status,
+    status: taskRow.columnName ?? taskRow.status,
     priority: taskRow.priority,
   };
 }

--- a/apps/api/src/plugins/generic-webhook/events.ts
+++ b/apps/api/src/plugins/generic-webhook/events.ts
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import db from "../../database";
 import {
+  columnTable,
   integrationTable,
   projectTable,
   taskTable,
@@ -50,6 +51,7 @@ async function getTaskData(
       number: taskTable.number,
       status: taskTable.status,
       priority: taskTable.priority,
+      columnName: columnTable.name,
       projectId: projectTable.id,
       projectName: projectTable.name,
       workspaceId: workspaceTable.id,
@@ -57,6 +59,7 @@ async function getTaskData(
     .from(taskTable)
     .innerJoin(projectTable, eq(taskTable.projectId, projectTable.id))
     .innerJoin(workspaceTable, eq(projectTable.workspaceId, workspaceTable.id))
+    .leftJoin(columnTable, eq(taskTable.columnId, columnTable.id))
     .where(and(eq(taskTable.id, taskId), eq(projectTable.id, projectId)))
     .limit(1);
 
@@ -68,6 +71,7 @@ async function getTaskData(
 
   return {
     ...taskRow,
+    status: taskRow.columnName ?? taskRow.status,
     taskUrl: `${clientUrl}/dashboard/workspace/${taskRow.workspaceId}/project/${taskRow.projectId}/task/${taskId}`,
   };
 }

--- a/apps/api/src/plugins/generic-webhook/events.ts
+++ b/apps/api/src/plugins/generic-webhook/events.ts
@@ -59,7 +59,13 @@ async function getTaskData(
     .from(taskTable)
     .innerJoin(projectTable, eq(taskTable.projectId, projectTable.id))
     .innerJoin(workspaceTable, eq(projectTable.workspaceId, workspaceTable.id))
-    .leftJoin(columnTable, eq(taskTable.columnId, columnTable.id))
+    .leftJoin(
+      columnTable,
+      and(
+        eq(taskTable.columnId, columnTable.id),
+        eq(columnTable.projectId, projectTable.id),
+      ),
+    )
     .where(and(eq(taskTable.id, taskId), eq(projectTable.id, projectId)))
     .limit(1);
 

--- a/apps/api/src/plugins/generic-webhook/events.ts
+++ b/apps/api/src/plugins/generic-webhook/events.ts
@@ -26,6 +26,7 @@ type GenericWebhookTaskData = {
   title: string;
   number: number | null;
   status: string | null;
+  statusName: string | null;
   priority: string | null;
   projectId: string;
   projectName: string;
@@ -77,7 +78,8 @@ async function getTaskData(
 
   return {
     ...taskRow,
-    status: taskRow.columnName ?? taskRow.status,
+    status: taskRow.status,
+    statusName: taskRow.columnName ?? taskRow.status,
     taskUrl: `${clientUrl}/dashboard/workspace/${taskRow.workspaceId}/project/${taskRow.projectId}/task/${taskId}`,
   };
 }
@@ -178,6 +180,7 @@ async function sendEvent(
           number: task.number,
           title: task.title,
           status: task.status,
+          statusName: task.statusName,
           priority: task.priority,
           url: task.taskUrl,
         },


### PR DESCRIPTION
## Problem #1326 

Discord and generic webhooks report the wrong status name when a project uses custom column names. The webhook sends the default slug (e.g. `to-do`, `in-progress`) instead of the actual column name the user configured.

**Steps to reproduce:**
1. Create a project with custom column names
2. Set up a Discord webhook
3. Move a task between columns
4. The webhook embed shows the default status name, not the custom one

## Root cause

Both `plugins/discord/events.ts` and `plugins/generic-webhook/events.ts` read `taskTable.status` directly in their data-fetching queries. The `status` column stores the default slug, while the actual display name lives in `columnTable.name`.

## Fix

Left join with `columnTable` on `taskTable.columnId` and prefer `columnName` over the default slug. Falls back to `taskTable.status` when no custom column is assigned.

Changes in:
- `apps/api/src/plugins/discord/events.ts` -- `getDiscordEventData` now resolves the column name
- `apps/api/src/plugins/generic-webhook/events.ts` -- `getTaskData` now resolves the column name


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Task-related webhook and Discord notifications now prefer the task’s column name (when available) for status text, improving displayed status in outgoing messages.

* **New Features**
  * Generic webhook payloads now include a `statusName` field derived from the task’s column name when present.
  * Added a reusable Discord content sanitization helper that prevents accidental mentions/formatting issues in notification titles, bodies, and embed fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->