### PR TITLE
ci: add nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -90,6 +92,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,123 @@
+name: Nightly
+
+on:
+  schedule:
+    # Runs at 02:17 UTC to avoid the busiest top-of-hour scheduler window.
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-main
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  verify:
+    name: Verify nightly build
+    runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: kaneo_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d kaneo_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      NODE_ENV: test
+      AUTH_SECRET: test-secret-with-at-least-32-chars
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/kaneo_test
+      KANEO_API_URL: http://localhost:1337
+      KANEO_CLIENT_URL: http://localhost:5173
+      DISABLE_GUEST_ACCESS: "false"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.20.2
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Biome
+        run: pnpm exec biome ci .
+
+      - name: Run unit tests
+        run: pnpm test
+
+      - name: Run API integration tests
+        run: pnpm test:integration
+
+      - name: Build monorepo
+        run: pnpm build
+
+  publish-images:
+    name: Publish nightly images
+    needs: verify
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: ./Dockerfile.kaneo
+            image: ghcr.io/${{ github.repository_owner }}/kaneo
+          - dockerfile: ./apps/web/Dockerfile
+            image: ghcr.io/${{ github.repository_owner }}/web
+          - dockerfile: ./apps/api/Dockerfile
+            image: ghcr.io/${{ github.repository_owner }}/api
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=raw,value=nightly
+            type=schedule,pattern=nightly-{{date 'YYYYMMDD'}}
+            type=sha,prefix=nightly-
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,11 +12,11 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   verify:
     name: Verify nightly build
+    if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     runs-on: ubuntu-24.04
     services:
       postgres:
@@ -41,7 +41,7 @@ jobs:
       DISABLE_GUEST_ACCESS: "false"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -72,7 +72,11 @@ jobs:
   publish-images:
     name: Publish nightly images
     needs: verify
+    if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -85,7 +89,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/api
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -107,7 +111,7 @@ jobs:
           images: ${{ matrix.image }}
           tags: |
             type=raw,value=nightly
-            type=schedule,pattern=nightly-{{date 'YYYYMMDD'}}
+            type=raw,value=nightly-{{date 'YYYYMMDD'}}
             type=sha,prefix=nightly-
 
       - name: Build and push


### PR DESCRIPTION
## Description
Adds a nightly GitHub Actions workflow that verifies the default branch and publishes nightly container images to GHCR.

The workflow runs on a daily schedule and can also be triggered manually. It runs Biome, unit tests, API integration tests, and the monorepo build before publishing `kaneo`, `web`, and `api` images with nightly-specific tags.

## Related Issue(s)
Fixes #

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [x] Other (please describe): CI workflow addition

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other (please describe): YAML parsing, actionlint validation, pre-commit Biome check, and full monorepo build

## Screenshots (if applicable)

N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
Nightly images are tagged as `nightly`, `nightly-YYYYMMDD`, and `nightly-<sha>`. The workflow does not publish latest, create releases, or modify package versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Nightly automation workflow that runs daily and can also be triggered manually.
  * The workflow performs verification (linting, unit tests, and API integration tests) and completes a full monorepo build prior to publishing.
  * Nightly Docker images are published to a container registry for multiple CPU architectures, with tags for the date and the specific commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->