### PR TITLE
fix(docs): resolves bug 1346

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ volumes:
   postgres_data:
 ```
 
-Save this as `compose.yml`, create a `.env` file with `KANEO_CLIENT_URL=http://localhost:5173`, `POSTGRES_PASSWORD=<password>`, and `AUTH_SECRET=<output of openssl rand -hex 32>`, run `docker compose up -d`, and open [http://localhost:5173](http://localhost:5173).
+Save this as `compose.yml`, copy `.env.sample` to `.env` and set `POSTGRES_PASSWORD=<password>` and `AUTH_SECRET=<output of openssl rand -hex 32>`, run `docker compose up -d`, and open [http://localhost:5173](http://localhost:5173).
 
 In Docker Compose, the bundled Kaneo container reaches PostgreSQL at the service hostname `postgres`.
 If you run the API on your host instead of inside Compose, use `localhost` or set `DATABASE_URL` explicitly.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ volumes:
   postgres_data:
 ```
 
-Save this as `compose.yml`, copy `.env.sample` to `.env` and set `POSTGRES_PASSWORD=<password>` and `AUTH_SECRET=<output of openssl rand -hex 32>`, run `docker compose up -d`, and open [http://localhost:5173](http://localhost:5173).
+Save this as `compose.yml`, copy `.env.sample` to `.env`, uncomment `KANEO_CLIENT_URL=http://localhost:5173`, and set `POSTGRES_PASSWORD=<password>` and `AUTH_SECRET=<output of openssl rand -hex 32>`, run `docker compose up -d`, and open [http://localhost:5173](http://localhost:5173).
 
 In Docker Compose, the bundled Kaneo container reaches PostgreSQL at the service hostname `postgres`.
 If you run the API on your host instead of inside Compose, use `localhost` or set `DATABASE_URL` explicitly.

--- a/apps/docs/core/installation/docker-compose.mdx
+++ b/apps/docs/core/installation/docker-compose.mdx
@@ -58,7 +58,7 @@ Additionally, the following volumes are used:
 
 ## Required URL configuration
 
-Copy `.env.sample` to `.env`, then set these values:
+Copy `.env.sample` to `.env` and uncomment or set these values:
 
 ```env
 KANEO_CLIENT_URL=http://localhost:5173

--- a/apps/docs/core/installation/docker-compose.mdx
+++ b/apps/docs/core/installation/docker-compose.mdx
@@ -58,15 +58,17 @@ Additionally, the following volumes are used:
 
 ## Required URL configuration
 
-For the combined image, only `KANEO_CLIENT_URL` is required — `KANEO_API_URL` is derived automatically as `KANEO_CLIENT_URL/api`:
+Copy `.env.sample` to `.env`, then set these values:
 
 ```env
 KANEO_CLIENT_URL=http://localhost:5173
+POSTGRES_DB=kaneo
+POSTGRES_USER=kaneo
 POSTGRES_PASSWORD=changeme
 AUTH_SECRET=                             # generate: openssl rand -hex 32
 ```
 
-Set `KANEO_API_URL` explicitly only if you need to override the default (e.g. a reverse proxy changes the path).
+`KANEO_API_URL` defaults to `KANEO_CLIENT_URL/api` — set it explicitly only if you need to override the default (e.g. a reverse proxy changes the path).
 
 This keeps the browser on one origin while the container proxies `/api` requests to the internal API process.
 


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->

Updated Docker Compose quick-start to reference .env.sample instead of listing vars inline.

Changes made are below:

- Replaced the "only KANEO_CLIENT_URL is required" note with a "copy .env.sample" instruction.
- Added POSTGRES_DB and POSTGRES_USER to the example .env block.
- Reworded the KANEO_API_URL line for clarity.
- 
## Related Issue(s)
<!-- Link to the related issue(s) this PR addresses -->
Fixes #1346 

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any other context about the PR here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the Docker Compose setup guide with clearer `.env` configuration steps.
  * Added an explicit `.env` example using the required variables (client URL, database credentials, and auth secret).
  * Clarified how `KANEO_API_URL` defaults from `KANEO_CLIENT_URL/api`, and when it should be overridden (e.g., reverse proxy/custom routing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->