### PR TITLE
fix(auth): fall back for custom OAuth profile names

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -38,6 +38,7 @@ import db, { schema } from "./database";
 import { publishEvent } from "./events";
 import { checkRegistrationAllowed } from "./utils/check-registration-allowed";
 import { checkWorkspaceName } from "./utils/check-workspace-name";
+import { mapCustomOAuthProfileToUser } from "./utils/custom-oauth-profile";
 import { generateDemoName } from "./utils/generate-demo-name";
 import { getGithubSsoOAuthCredentials } from "./utils/github-sso-env";
 import { isCloud } from "./utils/is-cloud";
@@ -428,6 +429,7 @@ export const auth = betterAuth({
           responseType: process.env.CUSTOM_OAUTH_RESPONSE_TYPE || "code",
           discoveryUrl: process.env.CUSTOM_OAUTH_DISCOVERY_URL || "",
           pkce: process.env.CUSTOM_AUTH_PKCE !== "false",
+          mapProfileToUser: mapCustomOAuthProfileToUser,
         },
       ],
     }),

--- a/apps/api/src/utils/custom-oauth-profile.ts
+++ b/apps/api/src/utils/custom-oauth-profile.ts
@@ -1,0 +1,22 @@
+function stringOrEmpty(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function mapCustomOAuthProfileToUser(profile: Record<string, unknown>) {
+  const email = stringOrEmpty(profile.email);
+  const nameFromParts = [
+    stringOrEmpty(profile.given_name),
+    stringOrEmpty(profile.family_name),
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const fallbackName = [
+    stringOrEmpty(profile.name),
+    nameFromParts,
+    stringOrEmpty(profile.preferred_username),
+    email ? email.split("@")[0] : "",
+  ].find(Boolean);
+
+  return fallbackName ? { name: fallbackName } : {};
+}

--- a/tests/api/utils/custom-oauth-profile.test.ts
+++ b/tests/api/utils/custom-oauth-profile.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { mapCustomOAuthProfileToUser } from "../../../apps/api/src/utils/custom-oauth-profile";
+
+describe("mapCustomOAuthProfileToUser", () => {
+  it("uses the provider name when present", () => {
+    expect(
+      mapCustomOAuthProfileToUser({
+        name: "Jane Doe",
+        preferred_username: "jdoe",
+        email: "jane@example.com",
+      }),
+    ).toEqual({ name: "Jane Doe" });
+  });
+
+  it("falls back to given and family name parts", () => {
+    expect(
+      mapCustomOAuthProfileToUser({
+        given_name: "Jane",
+        family_name: "Doe",
+        preferred_username: "jdoe",
+        email: "jane@example.com",
+      }),
+    ).toEqual({ name: "Jane Doe" });
+  });
+
+  it("falls back to preferred_username when name is missing", () => {
+    expect(
+      mapCustomOAuthProfileToUser({
+        sub: "keycloak-user-id",
+        email_verified: true,
+        preferred_username: "jdoe",
+        email: "jane@example.com",
+      }),
+    ).toEqual({ name: "jdoe" });
+  });
+
+  it("falls back to the email local part when no profile name is available", () => {
+    expect(
+      mapCustomOAuthProfileToUser({
+        email: "jane@example.com",
+      }),
+    ).toEqual({ name: "jane" });
+  });
+
+  it("returns an empty mapping when no usable display value exists", () => {
+    expect(mapCustomOAuthProfileToUser({ email: "" })).toEqual({});
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved sign-in profile handling for the custom OAuth provider, making user names more likely to appear correctly during authentication.
  - Added better name fallback behavior so profiles can display a name even when some fields are missing.

- **Tests**
  - Added coverage for multiple profile scenarios to ensure name selection works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->