### PR TITLE
feat(i18n): add Indonesian locale

### DIFF
--- a/apps/web/src/routes/_layout/_authenticated/dashboard/settings/workspace/roles.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/settings/workspace/roles.tsx
@@ -2,6 +2,7 @@ import { DEFAULT_ROLE_NAMES, statement } from "@kaneo/permissions";
 import { createFileRoute } from "@tanstack/react-router";
 import { Plus, Shield, Trash2, X } from "lucide-react";
 import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import PageTitle from "@/components/page-title";
 import {
   Accordion,
@@ -69,13 +70,6 @@ const RESOURCE_LABELS: Record<string, string> = {
   label: "Labels",
   workspace: "Workspace",
 };
-
-function resourceLabel(resource: string): string {
-  return (
-    RESOURCE_LABELS[resource] ??
-    resource.charAt(0).toUpperCase() + resource.slice(1)
-  );
-}
 
 const PERMISSION_LABELS: Record<
   string,
@@ -199,6 +193,7 @@ function permissionCount(permissions: Record<string, string[] | undefined>) {
 }
 
 function RouteComponent() {
+  const { t } = useTranslation();
   const { workspace, isAdmin } = useWorkspacePermission();
   const workspaceId = workspace?.id ?? "";
   const {
@@ -231,12 +226,14 @@ function RouteComponent() {
   if (!isAdmin) {
     return (
       <>
-        <PageTitle title="Roles" />
+        <PageTitle title={t("settings:workspaceRoles.pageTitle")} />
         <div className="max-w-4xl mx-auto space-y-8">
           <div className="space-y-2">
-            <h1 className="text-2xl font-semibold">Roles</h1>
+            <h1 className="text-2xl font-semibold">
+              {t("settings:workspaceRoles.title")}
+            </h1>
             <p className="text-muted-foreground">
-              You need admin or owner permissions to manage workspace roles.
+              {t("settings:workspaceRoles.noAccess")}
             </p>
           </div>
         </div>
@@ -246,23 +243,28 @@ function RouteComponent() {
 
   return (
     <>
-      <PageTitle title="Roles" />
+      <PageTitle title={t("settings:workspaceRoles.pageTitle")} />
       <div className="max-w-4xl mx-auto space-y-8">
         <div className="space-y-2">
-          <h1 className="text-2xl font-semibold">Roles</h1>
+          <h1 className="text-2xl font-semibold">
+            {t("settings:workspaceRoles.title")}
+          </h1>
           <p className="text-muted-foreground">
-            Define which actions members can perform in{" "}
-            {workspace?.name ?? "this workspace"}.
+            {t("settings:workspaceRoles.subtitle", {
+              workspaceName:
+                workspace?.name ?? t("settings:workspaceRoles.thisWorkspace"),
+            })}
           </p>
         </div>
 
         <div className="space-y-6">
           <div className="flex items-start justify-between gap-4">
             <div className="space-y-1">
-              <h2 className="text-md font-medium">Workspace roles</h2>
+              <h2 className="text-md font-medium">
+                {t("settings:workspaceRoles.sectionTitle")}
+              </h2>
               <p className="text-xs text-muted-foreground">
-                Edit the default roles or add a tailored one. Members keep their
-                assigned role name across edits.
+                {t("settings:workspaceRoles.sectionSubtitle")}
               </p>
             </div>
             <Button
@@ -277,19 +279,19 @@ function RouteComponent() {
               disabled={draftActive}
             >
               <Plus className="w-3.5 h-3.5" />
-              New role
+              {t("settings:workspaceRoles.newRole")}
             </Button>
           </div>
           <div className="border border-border rounded-md bg-sidebar">
             {isLoading && !draftActive ? (
               <p className="text-xs text-muted-foreground px-4 py-6">
-                Loading…
+                {t("settings:workspaceRoles.loading")}
               </p>
             ) : customRolesError ? (
               <p className="text-xs text-destructive px-4 py-6">
                 {customRolesErrorValue instanceof Error
                   ? customRolesErrorValue.message
-                  : "Failed to load roles."}
+                  : t("settings:workspaceRoles.loadError")}
               </p>
             ) : sortedRoles.length === 0 && !draftActive ? (
               <Empty>
@@ -297,10 +299,11 @@ function RouteComponent() {
                   <EmptyMedia variant="icon">
                     <Shield />
                   </EmptyMedia>
-                  <EmptyTitle>No roles yet</EmptyTitle>
+                  <EmptyTitle>
+                    {t("settings:workspaceRoles.emptyTitle")}
+                  </EmptyTitle>
                   <EmptyDescription>
-                    Default roles will appear here once they're seeded for this
-                    workspace.
+                    {t("settings:workspaceRoles.emptyDescription")}
                   </EmptyDescription>
                 </EmptyHeader>
               </Empty>
@@ -320,7 +323,9 @@ function RouteComponent() {
                     <AccordionTrigger className="px-4">
                       <div className="flex items-center gap-3 min-w-0">
                         <Shield className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
-                        <p className="text-sm font-medium italic">New role</p>
+                        <p className="text-sm font-medium italic">
+                          {t("settings:workspaceRoles.newRole")}
+                        </p>
                       </div>
                     </AccordionTrigger>
                     <AccordionPanel className="px-0 pt-0 pb-0">
@@ -349,8 +354,19 @@ function RouteComponent() {
                 )}
                 {sortedRoles.map((role) => {
                   const isDefault = isDefaultRole(role.role);
+                  const roleLabel = isDefault
+                    ? t(`team:roles.${role.role}`, {
+                        defaultValue: role.role,
+                      })
+                    : role.role;
                   const description = isDefault
-                    ? DEFAULT_ROLE_DESCRIPTIONS[role.role]
+                    ? t(
+                        `settings:workspaceRoles.defaultRoleDescriptions.${role.role}`,
+                        {
+                          defaultValue:
+                            DEFAULT_ROLE_DESCRIPTIONS[role.role] ?? "",
+                        },
+                      )
                     : undefined;
                   return (
                     <AccordionItem
@@ -364,12 +380,16 @@ function RouteComponent() {
                             <Shield className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
                             <div className="min-w-0">
                               <div className="flex items-center gap-2">
-                                <p className="text-sm font-medium capitalize truncate">
-                                  {role.role}
+                                <p
+                                  className={`text-sm font-medium truncate ${
+                                    isDefault ? "" : "capitalize"
+                                  }`}
+                                >
+                                  {roleLabel}
                                 </p>
                                 {isDefault && (
                                   <span className="text-[10px] uppercase tracking-wide font-medium px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
-                                    Default
+                                    {t("settings:workspaceRoles.defaultBadge")}
                                   </span>
                                 )}
                               </div>
@@ -381,7 +401,9 @@ function RouteComponent() {
                             </div>
                           </div>
                           <p className="text-xs font-normal text-muted-foreground shrink-0">
-                            {permissionCount(role.permission)} permissions
+                            {t("settings:workspaceRoles.permissionCount", {
+                              count: permissionCount(role.permission),
+                            })}
                           </p>
                         </div>
                       </AccordionTrigger>
@@ -436,6 +458,7 @@ function PermissionList({
   readOnly?: boolean;
   disabled?: boolean;
 }) {
+  const { t } = useTranslation();
   const groups = useMemo(
     () =>
       CUSTOM_RESOURCES.map((resource) => ({
@@ -457,7 +480,11 @@ function PermissionList({
           {groupIndex > 0 && <Separator />}
           <div className="space-y-4 p-4">
             <p className="text-sm font-medium capitalize">
-              {resourceLabel(resource)}
+              {t(`settings:workspaceRoles.resources.${resource}`, {
+                defaultValue:
+                  RESOURCE_LABELS[resource] ??
+                  resource.charAt(0).toUpperCase() + resource.slice(1),
+              })}
             </p>
             <div className="space-y-4">
               {actions.map((action, idx) => {
@@ -465,17 +492,29 @@ function PermissionList({
                   label: `${action} ${resource}`,
                   description: "",
                 };
+                const labelKey = `${resource}.${action}.label`;
+                const descriptionKey = `${resource}.${action}.description`;
                 return (
                   <div key={`${resource}:${action}`}>
                     {idx > 0 && <Separator className="mb-4" />}
                     <div className="flex items-center justify-between gap-6">
                       <div className="space-y-0.5 flex-1 min-w-0">
                         <Label className="text-sm font-medium">
-                          {meta.label}
+                          {t(
+                            `settings:workspaceRoles.permissions.${labelKey}`,
+                            {
+                              defaultValue: meta.label,
+                            },
+                          )}
                         </Label>
                         {meta.description && (
                           <p className="text-xs text-muted-foreground">
-                            {meta.description}
+                            {t(
+                              `settings:workspaceRoles.permissions.${descriptionKey}`,
+                              {
+                                defaultValue: meta.description,
+                              },
+                            )}
                           </p>
                         )}
                       </div>
@@ -511,6 +550,7 @@ function DraftEditor({
   onCreated: (roleName: string) => void;
   onDiscard: () => void;
 }) {
+  const { t } = useTranslation();
   const [name, setName] = useState("");
   const [permissions, setPermissions] = useState<Record<string, Set<string>>>(
     {},
@@ -531,11 +571,11 @@ function DraftEditor({
   const handleCreate = async () => {
     const trimmed = name.trim().toLowerCase();
     if (!trimmed) {
-      toast.error("Name is required");
+      toast.error(t("settings:workspaceRoles.validation.nameRequired"));
       return;
     }
     if (existingNames.map((n) => n.toLowerCase()).includes(trimmed)) {
-      toast.error("A role with that name already exists");
+      toast.error(t("settings:workspaceRoles.validation.nameExists"));
       return;
     }
     const permission: Record<string, string[]> = {};
@@ -543,16 +583,18 @@ function DraftEditor({
       if (set.size > 0) permission[r] = Array.from(set);
     }
     if (Object.keys(permission).length === 0) {
-      toast.error("Select at least one permission");
+      toast.error(t("settings:workspaceRoles.validation.permissionRequired"));
       return;
     }
     try {
       await createRole({ workspaceId, role: trimmed, permission });
-      toast.success("Role created");
+      toast.success(t("settings:workspaceRoles.toast.created"));
       onCreated(trimmed);
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : "Failed to create role",
+        error instanceof Error
+          ? error.message
+          : t("settings:workspaceRoles.toast.createError"),
       );
     }
   };
@@ -562,15 +604,17 @@ function DraftEditor({
       <div className="border-t border-border">
         <div className="flex items-center justify-between gap-4 px-4 py-3">
           <div className="space-y-0.5">
-            <Label className="text-sm font-medium">Name</Label>
+            <Label className="text-sm font-medium">
+              {t("settings:workspaceRoles.nameLabel")}
+            </Label>
             <p className="text-xs text-muted-foreground">
-              Lowercase. Cannot be changed later.
+              {t("settings:workspaceRoles.nameHint")}
             </p>
           </div>
           <Input
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="e.g. reviewer"
+            placeholder={t("settings:workspaceRoles.namePlaceholder")}
             className="w-64"
             autoFocus
             disabled={isPending}
@@ -594,10 +638,10 @@ function DraftEditor({
           disabled={isPending}
         >
           <X className="w-4 h-4" />
-          Discard
+          {t("settings:workspaceRoles.discard")}
         </Button>
         <Button size="sm" onClick={handleCreate} disabled={isPending}>
-          Create role
+          {t("settings:workspaceRoles.createRole")}
         </Button>
       </div>
     </div>
@@ -615,6 +659,7 @@ function CustomRoleEditor({
   isDefault?: boolean;
   onDelete: () => void;
 }) {
+  const { t } = useTranslation();
   const [permissions, setPermissions] = useState<Record<string, Set<string>>>(
     () => {
       const out: Record<string, Set<string>> = {};
@@ -649,7 +694,7 @@ function CustomRoleEditor({
 
   const handleSave = async () => {
     if (Object.keys(currentPermissions).length === 0) {
-      toast.error("Select at least one permission");
+      toast.error(t("settings:workspaceRoles.validation.permissionRequired"));
       return;
     }
     try {
@@ -658,10 +703,12 @@ function CustomRoleEditor({
         roleName: role.role,
         permission: currentPermissions,
       });
-      toast.success("Role updated");
+      toast.success(t("settings:workspaceRoles.toast.updated"));
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : "Failed to update role",
+        error instanceof Error
+          ? error.message
+          : t("settings:workspaceRoles.toast.updateError"),
       );
     }
   };
@@ -685,7 +732,7 @@ function CustomRoleEditor({
       <div className="flex items-center justify-between gap-2 px-4 py-3 bg-sidebar">
         {isDefault ? (
           <span className="text-xs text-muted-foreground">
-            Default role — name is reserved and the row can't be deleted.
+            {t("settings:workspaceRoles.defaultRoleHelp")}
           </span>
         ) : (
           <Button
@@ -696,15 +743,17 @@ function CustomRoleEditor({
             disabled={isPending}
           >
             <Trash2 className="w-4 h-4" />
-            Delete role
+            {t("settings:workspaceRoles.deleteRole")}
           </Button>
         )}
         <div className="flex items-center gap-3">
           <p className="text-xs text-muted-foreground">
-            {dirty ? "You have unsaved changes" : "All changes saved"}
+            {dirty
+              ? t("settings:workspaceRoles.unsavedChanges")
+              : t("settings:workspaceRoles.allChangesSaved")}
           </p>
           <Button size="sm" onClick={handleSave} disabled={isPending || !dirty}>
-            Save changes
+            {t("settings:workspaceRoles.saveChanges")}
           </Button>
         </div>
       </div>
@@ -723,15 +772,20 @@ function DeleteRoleConfirm({
   onDeleted: () => void;
   onCancel: () => void;
 }) {
+  const { t } = useTranslation();
   const { mutateAsync: deleteRole, isPending } = useDeleteWorkspaceRole();
 
   return (
     <AlertDialogContent>
       <AlertDialogHeader>
-        <AlertDialogTitle>Delete role</AlertDialogTitle>
+        <AlertDialogTitle>
+          {t("settings:workspaceRoles.deleteDialog.title")}
+        </AlertDialogTitle>
         <AlertDialogDescription>
           {role
-            ? `This will permanently delete the role "${role.role}". Members assigned to this role will lose its permissions.`
+            ? t("settings:workspaceRoles.deleteDialog.description", {
+                role: role.role,
+              })
             : ""}
         </AlertDialogDescription>
       </AlertDialogHeader>
@@ -743,7 +797,7 @@ function DeleteRoleConfirm({
             disabled={isPending}
             onClick={onCancel}
           >
-            Cancel
+            {t("common:actions.cancel")}
           </Button>
         </AlertDialogClose>
         <Button
@@ -754,7 +808,7 @@ function DeleteRoleConfirm({
             if (!role) return;
             try {
               await deleteRole({ workspaceId, roleName: role.role });
-              toast.success("Role deleted");
+              toast.success(t("settings:workspaceRoles.toast.deleted"));
               // Caller closes the dialog after the mutation succeeds so a
               // failed delete leaves the confirmation visible.
               onDeleted();
@@ -762,13 +816,13 @@ function DeleteRoleConfirm({
               toast.error(
                 error instanceof Error
                   ? error.message
-                  : "Failed to delete role",
+                  : t("settings:workspaceRoles.toast.deleteError"),
               );
             }
           }}
         >
           <Trash2 className="w-4 h-4 mr-2" />
-          Delete
+          {t("common:actions.delete")}
         </Button>
       </AlertDialogFooter>
     </AlertDialogContent>

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -549,6 +549,143 @@
 				"nameShort": "Workspace name must be at least 2 characters"
 			}
 		},
+		"workspaceRoles": {
+			"pageTitle": "Roles",
+			"title": "Roles",
+			"subtitle": "Define which actions members can perform in {{workspaceName}}.",
+			"thisWorkspace": "this workspace",
+			"noAccess": "You need admin or owner permissions to manage workspace roles.",
+			"sectionTitle": "Workspace roles",
+			"sectionSubtitle": "Edit the default roles or add a tailored one. Members keep their assigned role name across edits.",
+			"newRole": "New role",
+			"loading": "Loading…",
+			"loadError": "Failed to load roles.",
+			"emptyTitle": "No roles yet",
+			"emptyDescription": "Default roles will appear here once they're seeded for this workspace.",
+			"defaultBadge": "Default",
+			"permissionCount_one": "{{count}} permission",
+			"permissionCount_other": "{{count}} permissions",
+			"nameLabel": "Name",
+			"nameHint": "Lowercase. Cannot be changed later.",
+			"namePlaceholder": "e.g. reviewer",
+			"discard": "Discard",
+			"createRole": "Create role",
+			"deleteRole": "Delete role",
+			"defaultRoleHelp": "Default role — name is reserved and the row can't be deleted.",
+			"unsavedChanges": "You have unsaved changes",
+			"allChangesSaved": "All changes saved",
+			"saveChanges": "Save changes",
+			"defaultRoleDescriptions": {
+				"viewer": "Read-only access to projects, tasks, and workspace.",
+				"member": "Can create and update projects and tasks.",
+				"admin": "Full project and task management plus workspace settings."
+			},
+			"resources": {
+				"project": "Projects",
+				"task": "Tasks",
+				"label": "Labels",
+				"workspace": "Workspace"
+			},
+			"permissions": {
+				"project": {
+					"create": {
+						"label": "Create projects",
+						"description": "Create new projects in this workspace."
+					},
+					"read": {
+						"label": "View projects",
+						"description": "View projects and their details."
+					},
+					"update": {
+						"label": "Edit projects",
+						"description": "Update project name, icon, description, and settings."
+					},
+					"delete": {
+						"label": "Delete projects",
+						"description": "Permanently delete projects in this workspace."
+					},
+					"share": {
+						"label": "Share projects",
+						"description": "Make projects publicly accessible via share links."
+					}
+				},
+				"task": {
+					"create": {
+						"label": "Create tasks",
+						"description": "Create new tasks in any project."
+					},
+					"read": {
+						"label": "View tasks",
+						"description": "View tasks across projects."
+					},
+					"update": {
+						"label": "Edit tasks",
+						"description": "Edit task content, status, priority, due date, and labels."
+					},
+					"delete": {
+						"label": "Delete tasks",
+						"description": "Permanently delete tasks."
+					},
+					"assign": {
+						"label": "Assign tasks",
+						"description": "Assign tasks to other workspace members."
+					}
+				},
+				"label": {
+					"create": {
+						"label": "Create labels",
+						"description": "Add new labels to tasks in this workspace."
+					},
+					"read": {
+						"label": "View labels",
+						"description": "View labels attached to tasks."
+					},
+					"update": {
+						"label": "Edit labels",
+						"description": "Rename, recolor, and reassign labels."
+					},
+					"delete": {
+						"label": "Delete labels",
+						"description": "Permanently delete labels from this workspace."
+					}
+				},
+				"workspace": {
+					"read": {
+						"label": "Access workspace",
+						"description": "Read workspace metadata and members."
+					},
+					"update": {
+						"label": "Edit workspace",
+						"description": "Edit workspace name and description."
+					},
+					"delete": {
+						"label": "Delete workspace",
+						"description": "Permanently delete this workspace."
+					},
+					"manage_settings": {
+						"label": "Manage settings",
+						"description": "Configure integrations, notification rules, and workspace preferences."
+					}
+				}
+			},
+			"validation": {
+				"nameRequired": "Name is required",
+				"nameExists": "A role with that name already exists",
+				"permissionRequired": "Select at least one permission"
+			},
+			"toast": {
+				"created": "Role created",
+				"createError": "Failed to create role",
+				"updated": "Role updated",
+				"updateError": "Failed to update role",
+				"deleted": "Role deleted",
+				"deleteError": "Failed to delete role"
+			},
+			"deleteDialog": {
+				"title": "Delete role",
+				"description": "This will permanently delete the role \"{{role}}\". Members assigned to this role will lose its permissions."
+			}
+		},
 		"projectGeneral": {
 			"pageTitle": "Project Settings",
 			"title": "General Settings",

--- a/i18n/id-ID.json
+++ b/i18n/id-ID.json
@@ -1,0 +1,1957 @@
+{
+	"common": {
+		"appName": "Kaneo",
+		"actions": {
+			"cancel": "Batal",
+			"close": "Tutup",
+			"clearAll": "Hapus semua",
+			"delete": "Hapus",
+			"deleting": "Menghapus...",
+			"markAllRead": "Tandai semua telah dibaca",
+			"remove": "Hapus",
+			"reset": "Atur ulang",
+			"filter": "Filter",
+			"clearAllFilters": "Hapus semua filter"
+		},
+		"a11y": {
+			"toggleSidebar": "Tampilkan/sembunyikan panel samping"
+		},
+		"sidebar": {
+			"title": "Bilah sisi",
+			"mobileDescription": "Menampilkan panel samping seluler."
+		},
+		"empty": {
+			"loading": "Memuat..."
+		},
+		"pagination": {
+			"label": "Paginasi",
+			"previous": "Sebelumnya",
+			"next": "Berikutnya",
+			"previousPage": "Buka halaman sebelumnya",
+			"nextPage": "Buka halaman berikutnya",
+			"morePages": "Halaman lainnya"
+		},
+		"breadcrumb": {
+			"label": "Jalur navigasi",
+			"more": "Lainnya"
+		},
+		"language": {
+			"english": "Inggris",
+			"german": "Jerman",
+			"greek": "Yunani",
+			"macedonian": "Makedonia",
+			"french": "Prancis",
+			"spanish": "Spanyol",
+			"dutch": "Belanda",
+			"korean": "Korea"
+		},
+		"people": {
+			"someone": "Seseorang",
+			"unknown": "Tidak diketahui"
+		},
+		"error": {
+			"title": "Terjadi kesalahan",
+			"troubleshooting": "Langkah pemecahan masalah:",
+			"tryAgain": "Coba lagi",
+			"viewDeploymentGuide": "Lihat panduan deployment",
+			"refreshPage": "Muat ulang halaman"
+		},
+		"formats": {
+			"never": "Tidak pernah"
+		},
+		"modals": {
+			"createProject": {
+				"title": "Buat proyek baru",
+				"breadcrumbNew": "Buat proyek baru",
+				"workspaceFallback": "RUANG KERJA",
+				"description": "Buat proyek baru di ruang kerja Anda dengan memberikan nama, key, dan memilih ikon.",
+				"pickIcon": "Pilih ikon",
+				"searchIcons": "Cari ikon...",
+				"projectName": "Nama proyek",
+				"keyLabel": "Key:",
+				"keyHint": "Digunakan untuk ID tiket (contoh, {{example}}-123)",
+				"createButton": "Buat Proyek",
+				"successToast": "Proyek berhasil dibuat",
+				"errorToast": "Gagal membuat proyek"
+			},
+			"createWorkspace": {
+				"breadcrumbKaneo": "KANEO",
+				"title": "Buat ruang kerja baru",
+				"description": "Buat ruang kerja baru dengan memberikan nama untuk ruang kerja Anda.",
+				"namePlaceholder": "Nama ruang kerja",
+				"descriptionPlaceholder": "Tambahkan deskripsi...",
+				"createButton": "Buat Ruang Kerja",
+				"successToast": "Ruang kerja berhasil dibuat",
+				"errorToast": "Gagal membuat ruang kerja"
+			},
+			"createTask": {
+				"breadcrumbTask": "TUGAS",
+				"title": "Tugas Baru",
+				"description": "Buat tugas baru dengan memberikan judul, deskripsi, dan detail lainnya.",
+				"taskTitlePlaceholder": "Judul tugas",
+				"descriptionPlaceholder": "Tambahkan deskripsi untuk tugas Anda...",
+				"chooseProjectForImages": "Pilih proyek sebelum mengunggah gambar.",
+				"prepareTaskError": "Gagal menyiapkan tugas",
+				"successCreated": "Tugas berhasil dibuat",
+				"successUpdated": "Tugas berhasil diperbarui",
+				"createError": "Gagal membuat tugas",
+				"priority": "Prioritas",
+				"statusFallback": "Sedang Berjalan",
+				"startDate": "Tanggal mulai",
+				"dueDate": "Tenggat",
+				"clearStartDate": "Hapus tanggal mulai",
+				"clearDueDate": "Hapus tenggat",
+				"assign": "Tugaskan",
+				"assignUnassigned": "Belum ditugaskan",
+				"assignUnassignedTitle": "Belum ditugaskan",
+				"labels": "Label",
+				"searchLabels": "Cari label...",
+				"noLabelsFound": "Label tidak ditemukan",
+				"createLabel": "Buat \"{{name}}\"",
+				"chooseColor": "Pilih warna",
+				"labelCreated": "Label dibuat",
+				"labelCreateError": "Gagal membuat label",
+				"createMore": "Buat lagi",
+				"createButton": "Buat Tugas",
+				"untitledTask": "Tugas tanpa judul",
+				"labelColors": {
+					"stone": "Abu Batu",
+					"slate": "Abu Kebiruan",
+					"lavender": "Lembayung",
+					"sage": "Hijau Kelabu",
+					"forest": "Hijau Hutan",
+					"amber": "Kuning Ambar",
+					"terracotta": "Merah Bata",
+					"rose": "Merah Mawar",
+					"crimson": "Merah Tua"
+				}
+			}
+		}
+	},
+	"auth": {
+		"signIn": {
+			"pageTitle": "Masuk",
+			"title": "Selamat datang kembali",
+			"subtitle": "Masukkan kredensial Anda untuk mengakses ruang kerja",
+			"invitationSubtitle": "Masuk untuk menerima undangan Anda",
+			"invitationAlert": "Setelah masuk, Anda dapat menerima undangan ruang kerja.",
+			"signingIn": "Masuk...",
+			"continueWithGoogle": "Lanjutkan dengan Google",
+			"continueWithGithub": "Lanjutkan dengan GitHub",
+			"continueWithDiscord": "Lanjutkan dengan Discord",
+			"continueWithOidc": "Lanjutkan dengan OIDC",
+			"lastUsed": "Terakhir digunakan",
+			"registrationDisabled": "Pendaftaran publik dinonaktifkan. Gunakan undangan untuk membuat akun.",
+			"passwordRegistrationDisabled": "Pendaftaran dengan kata sandi dinonaktifkan. Gunakan metode masuk sosial atau OIDC yang telah dikonfigurasi untuk membuat akun.",
+			"toggleMessage": "Belum punya akun?",
+			"toggleLink": "Buat akun",
+			"guestSuccess": "Masuk sebagai tamu",
+			"guestError": "Gagal masuk sebagai tamu",
+			"oidcError": "Gagal masuk dengan OIDC",
+			"googleError": "Gagal masuk dengan Google",
+			"githubError": "Gagal masuk dengan GitHub",
+			"discordError": "Gagal masuk dengan Discord",
+			"errors": {
+				"oauth_code_verification_failed": "Verifikasi OAuth gagal. Silakan coba lagi.",
+				"registration_is_currently_disabled_you_need_a_valid_invitation_to_create_an_account_": "Pendaftaran saat ini dinonaktifkan. Anda memerlukan undangan yang valid untuk membuat akun."
+			}
+		},
+		"providers": {
+			"google": "Google",
+			"discord": "Discord"
+		},
+		"forms": {
+			"or": "atau",
+			"email": "Email",
+			"password": "Kata sandi",
+			"emailPlaceholder": "saya@contoh.com",
+			"passwordPlaceholder": "••••••••",
+			"showPassword": "Tampilkan kata sandi",
+			"hidePassword": "Sembunyikan kata sandi"
+		},
+		"checkEmail": {
+			"pageTitle": "Periksa Email Anda",
+			"title": "Periksa email Anda",
+			"inboxMessage": "Kami telah mengirim tautan masuk sementara. Silakan periksa kotak masuk Anda di <email>{{email}}</email>.",
+			"emailFallback": "alamat email Anda",
+			"backToLogin": "Kembali ke masuk"
+		},
+		"signUp": {
+			"pageTitle": "Buat Akun",
+			"title": "Buat akun",
+			"subtitleInvitation": "Buat akun untuk menerima undangan Anda",
+			"subtitleRegistrationDisabled": "Pendaftaran memerlukan undangan",
+			"subtitlePasswordDisabled": "Gunakan masuk sosial atau OIDC untuk membuat akun",
+			"subtitleDefault": "Mulai dengan ruang kerja Anda",
+			"invitationAlert": "Setelah membuat akun, Anda dapat menerima undangan ruang kerja.",
+			"registrationDisabledAlert": "Pendaftaran saat ini dinonaktifkan. Jika Anda diundang, masukkan alamat email yang menerima undangan untuk membuat akun.",
+			"passwordDisabledAlert": "Pembuatan akun berbasis kata sandi dinonaktifkan. Gunakan metode masuk sosial atau OIDC yang telah dikonfigurasi dari halaman masuk.",
+			"signingIn": "Masuk...",
+			"continueAsGuest": "Lanjutkan sebagai tamu",
+			"toggleMessage": "Sudah punya akun?",
+			"toggleLink": "Masuk"
+		},
+		"verifyOtp": {
+			"pageTitle": "Verifikasi Kode",
+			"title": "Masukkan kode verifikasi",
+			"subtitle": "Gunakan kode 6 digit yang dikirim ke email Anda untuk melanjutkan",
+			"codeSentTo": "Kode dikirim ke {{email}}",
+			"verificationCodeLabel": "Kode Verifikasi",
+			"verifying": "Memverifikasi...",
+			"verifyAndSignIn": "Verifikasi & Masuk",
+			"changeEmail": "Ubah email",
+			"resend": "Kirim ulang",
+			"validation": {
+				"codeLength": "Kode harus 6 digit"
+			},
+			"toast": {
+				"invalidCode": "Kode verifikasi tidak valid",
+				"signedInSuccess": "Berhasil masuk!",
+				"verifyFailed": "Gagal memverifikasi kode",
+				"resendFailed": "Gagal mengirim ulang kode",
+				"resendSuccess": "Kode verifikasi baru dikirim!"
+			}
+		},
+		"otpSignIn": {
+			"sendFailed": "Gagal mengirim kode verifikasi",
+			"codeSent": "Kode verifikasi dikirim! Periksa email Anda.",
+			"sending": "Mengirim...",
+			"sendVerificationCode": "Kirim Kode Verifikasi"
+		},
+		"signInForm": {
+			"failedSignIn": "Gagal masuk",
+			"signedInSuccess": "Berhasil masuk",
+			"signingIn": "Masuk...",
+			"signIn": "Masuk"
+		},
+		"signUpForm": {
+			"fullName": "Nama Lengkap",
+			"namePlaceholder": "John Doe",
+			"failedSignUp": "Gagal mendaftar",
+			"accountCreated": "Akun berhasil dibuat",
+			"passwordTooShort": "Kata sandi terlalu pendek",
+			"creatingAccount": "Membuat Akun...",
+			"createAccount": "Buat Akun"
+		},
+		"invitation": {
+			"pageTitleAccept": "Terima Undangan",
+			"pageTitleError": "Kesalahan Undangan",
+			"pageTitleInvalid": "Undangan Tidak Valid",
+			"loadingTitle": "Memuat undangan...",
+			"errorTitle": "Kesalahan Undangan",
+			"invalidTitle": "Undangan Tidak Valid",
+			"invitationExpired": "Undangan Kedaluwarsa",
+			"errorLoadDescription": "Gagal memuat detail undangan. Undangan mungkin tidak valid atau sudah kedaluwarsa.",
+			"goToSignIn": "Buka Masuk",
+			"workspaceLabel": "Ruang kerja: {{workspaceName}}",
+			"joinWorkspace": "Gabung {{workspaceName}}",
+			"inviteBodySignedIn": "<inviter>{{inviterName}}</inviter> mengundang Anda untuk bergabung ke ruang kerjanya.",
+			"inviteBodySignedOut": "<inviter>{{inviterName}}</inviter> mengundang Anda untuk bergabung ke ruang kerjanya di Kaneo.",
+			"signInToAccept": "Masuk untuk menerima undangan ini.",
+			"accepting": "Menerima...",
+			"acceptInvitation": "Terima Undangan",
+			"goToDashboard": "Buka Dasbor",
+			"signedInAs": "Masuk sebagai <email>{{email}}</email>",
+			"youveBeenInvited": "Anda telah diundang!",
+			"invitationFor": "Undangan untuk: <email>{{email}}</email>",
+			"signIn": "Masuk",
+			"toast": {
+				"acceptFailed": "Gagal menerima undangan",
+				"acceptSuccess": "Undangan diterima! Selamat bergabung dengan tim."
+			}
+		},
+		"onboarding": {
+			"pageTitle": "Selamat datang di Kaneo",
+			"workspacePageTitle": "Buat Ruang Kerja",
+			"createWorkspaceTitle": "Buat ruang kerja",
+			"createWorkspaceSubtitle": "Siapkan ruang kerja Anda untuk mulai mengelola proyek",
+			"workspaceName": "Nama ruang kerja",
+			"workspaceNamePlaceholder": "contohnya: Acme Inc, Tim Saya",
+			"descriptionOptional": "Deskripsi (opsional)",
+			"descriptionPlaceholder": "Tim Anda mengerjakan apa?",
+			"creating": "Membuat...",
+			"createWorkspace": "Buat ruang kerja",
+			"workspaceCreatedTitle": "Ruang kerja dibuat",
+			"redirectingToWorkspace": "Mengarahkan Anda ke <name>{{name}}</name>...",
+			"toast": {
+				"workspaceCreated": "Ruang kerja berhasil dibuat",
+				"createFailed": "Gagal membuat ruang kerja"
+			},
+			"validation": {
+				"workspaceNameRequired": "Nama ruang kerja wajib diisi"
+			}
+		},
+		"profileSetup": {
+			"pageTitle": "Lengkapi Profil",
+			"completeTitle": "Lengkapi profil Anda",
+			"subtitle": "Masukkan nama Anda untuk memulai",
+			"yourName": "Nama Anda",
+			"namePlaceholder": "misalnya: John Doe",
+			"saving": "Menyimpan...",
+			"continue": "Lanjutkan",
+			"welcome": "Selamat datang, {{name}}!",
+			"redirecting": "Mengarahkan Anda ke dasbor...",
+			"toast": {
+				"updateSuccess": "Profil berhasil diperbarui",
+				"updateFailed": "Gagal memperbarui profil"
+			},
+			"validation": {
+				"nameRequired": "Nama wajib diisi",
+				"nameShort": "Nama harus minimal 2 karakter"
+			}
+		}
+	},
+	"settings": {
+		"account": "Akun",
+		"developer": "Pengembang",
+		"information": "Informasi",
+		"notifications": "Notifikasi",
+		"preferences": "Preferensi",
+		"apiKeys": "API Key",
+		"informationPage": {
+			"pageTitle": "Informasi Pribadi",
+			"title": "Informasi Pribadi",
+			"subtitle": "Kelola detail pribadi dan informasi akun Anda.",
+			"sectionTitle": "Informasi Akun",
+			"sectionSubtitle": "Kelola profil dan detail akun Anda.",
+			"profilePicture": "Foto profil",
+			"fullName": "Nama lengkap",
+			"fullNamePlaceholder": "Masukkan nama Anda",
+			"email": "Email",
+			"emailPlaceholder": "Masukkan email Anda",
+			"updateSuccess": "Profil berhasil diperbarui",
+			"updateError": "Gagal memperbarui profil",
+			"validation": {
+				"nameRequired": "Nama wajib diisi",
+				"nameShort": "Nama harus minimal 2 karakter",
+				"invalidEmail": "Alamat email tidak valid"
+			}
+		},
+		"notificationsPage": {
+			"pageTitle": "Notifikasi",
+			"title": "Notifikasi",
+			"subtitle": "Pilih cara Kaneo mengirim notifikasi akun Anda dan kanal yang digunakan.",
+			"statusConnected": "Terhubung",
+			"statusPaused": "Dijeda",
+			"emailTitle": "Email",
+			"emailDescription": "Gunakan email akun Anda sebagai tujuan notifikasi.",
+			"accountEmailLabel": "Email akun",
+			"accountEmailNoAddress": "Email akun tidak tersedia",
+			"accountEmailHint": "Pengiriman email selalu menuju email akun yang sedang masuk.",
+			"saveChanges": "Simpan perubahan",
+			"disconnect": "Putuskan",
+			"ntfyTitle": "ntfy",
+			"ntfyDescription": "Publikasikan notifikasi akun ke topik ntfy.",
+			"serverUrl": "URL server",
+			"topic": "Topik",
+			"token": "Token",
+			"ntfyServerPlaceholder": "https://ntfy.example.com",
+			"ntfyTopicPlaceholder": "team-alerts",
+			"ntfyTokenPlaceholder": "Token bearer opsional",
+			"ntfyTokenHintConfigured": "Token sudah dikonfigurasi ({{masked}}). Masukkan token baru untuk menggantinya.",
+			"ntfyTokenHintOptional": "Opsional. Berikan token jika server ntfy Anda memerlukan autentikasi.",
+			"connectNtfy": "Hubungkan ntfy",
+			"gotifyTitle": "Gotify",
+			"gotifyDescription": "Kirim notifikasi akun ke server Gotify Anda.",
+			"gotifyTokenLabel": "Token aplikasi",
+			"gotifyServerPlaceholder": "https://gotify.example.com",
+			"gotifyTokenPlaceholder": "Token aplikasi Gotify",
+			"gotifyTokenHintConfigured": "Token aplikasi sudah dikonfigurasi ({{masked}}). Masukkan token baru untuk menggantinya.",
+			"gotifyTokenHintRequired": "Wajib. Gunakan token aplikasi dari server Gotify Anda.",
+			"connectGotify": "Hubungkan Gotify",
+			"webhookTitle": "Webhook kustom",
+			"webhookDescription": "Kirim notifikasi akun ke endpoint Anda sendiri sebagai JSON.",
+			"endpointUrl": "URL endpoint",
+			"signingSecret": "Rahasia penandatanganan",
+			"webhookUrlPlaceholder": "https://example.com/webhooks/kaneo",
+			"webhookSecretPlaceholder": "Kunci rahasia bersama (opsional)",
+			"webhookSecretHintConfigured": "Signing secret sudah dikonfigurasi ({{masked}}). Masukkan yang baru untuk menggantinya.",
+			"webhookSecretHintOptional": "Opsional. Kaneo mendeteksi dan menandatangani isi request jika secret dikonfigurasi.",
+			"connectWebhook": "Hubungkan webhook",
+			"workspaceRulesTitle": "Aturan pengiriman ruang kerja",
+			"workspaceRulesDescription": "Gunakan ulang kanal global Anda, lalu tentukan ruang kerja dan proyek mana yang boleh mengirim notifikasi akun.",
+			"workspaceCardHint": "Pilih kanal yang dapat digunakan ruang kerja ini untuk notifikasi akun.",
+			"workspaceCardLabelEmail": "Email",
+			"workspaceCardLabelNtfy": "ntfy",
+			"workspaceCardLabelGotify": "Gotify",
+			"workspaceCardLabelWebhook": "Webhook kustom",
+			"emailChannelHintEnabled": "Kirim notifikasi ruang kerja yang sesuai melalui email.",
+			"emailChannelHintDisabled": "Konfigurasikan dan aktifkan email secara global terlebih dahulu.",
+			"ntfyChannelHintEnabled": "Kirim notifikasi ruang kerja yang sesuai ke ntfy.",
+			"ntfyChannelHintDisabled": "Konfigurasikan dan aktifkan ntfy secara global terlebih dahulu.",
+			"gotifyChannelHintEnabled": "Kirim notifikasi ruang kerja yang sesuai ke Gotify.",
+			"gotifyChannelHintDisabled": "Konfigurasikan dan aktifkan Gotify secara global terlebih dahulu.",
+			"webhookChannelHintEnabled": "Kirim notifikasi ruang kerja yang sesuai ke webhook Anda.",
+			"webhookChannelHintDisabled": "Konfigurasikan dan aktifkan webhook secara global terlebih dahulu.",
+			"projectScope": "Cakupan proyek",
+			"projectScopeDescription": "Semua proyek disertakan secara default. Persempit jika ruang kerja ini hanya boleh mengirim notifikasi dari proyek tertentu.",
+			"allProjects": "Semua proyek",
+			"allProjectsDescription": "Kirim notifikasi dari setiap proyek di ruang kerja ini.",
+			"selectedProjects": "Proyek terpilih",
+			"selectedProjectsDescription": "Hanya kirim notifikasi dari proyek yang dipilih.",
+			"noProjectsInWorkspace": "Belum ada proyek yang tersedia untuk ruang kerja ini.",
+			"createRule": "Buat aturan",
+			"removeRule": "Hapus aturan",
+			"toastEmailSaved": "Pengaturan notifikasi email disimpan",
+			"toastEmailSaveFailed": "Gagal menyimpan pengaturan email",
+			"toastNtfySaved": "Pengaturan ntfy disimpan",
+			"toastNtfySaveFailed": "Gagal menyimpan pengaturan ntfy",
+			"toastNtfyDisconnected": "ntfy diputuskan",
+			"toastNtfyDisconnectFailed": "Gagal memutuskan ntfy",
+			"toastGotifySaved": "Pengaturan Gotify disimpan",
+			"toastGotifySaveFailed": "Gagal menyimpan pengaturan Gotify",
+			"toastGotifyDisconnected": "Gotify diputuskan",
+			"toastGotifyDisconnectFailed": "Gagal memutuskan Gotify",
+			"toastWebhookSaved": "Pengaturan webhook disimpan",
+			"toastWebhookSaveFailed": "Gagal menyimpan pengaturan webhook",
+			"toastWebhookDisconnected": "Webhook diputuskan",
+			"toastWebhookDisconnectFailed": "Gagal memutuskan webhook",
+			"toastRuleSaved": "Aturan notifikasi untuk {{workspaceName}} disimpan",
+			"toastRuleSaveFailed": "Gagal menyimpan aturan notifikasi ruang kerja",
+			"toastRuleRemoved": "Aturan notifikasi untuk {{workspaceName}} dihapus",
+			"toastRuleRemoveFailed": "Gagal menghapus aturan notifikasi ruang kerja",
+			"toastPreferencesSaved": "Preferensi notifikasi disimpan",
+			"toastPreferencesSaveFailed": "Gagal menyimpan preferensi notifikasi",
+			"toastRuleSavedGeneric": "Aturan notifikasi ruang kerja disimpan",
+			"toastRuleRemovedGeneric": "Aturan notifikasi ruang kerja dihapus"
+		},
+		"preferencesPage": {
+			"title": "Preferensi",
+			"subtitle": "Sesuaikan pengalaman Kaneo Anda.",
+			"appearanceTitle": "Tampilan",
+			"appearanceSubtitle": "Pengaturan visual dan preferensi tata letak.",
+			"theme": "Tema",
+			"themeDescription": "Pilih skema warna yang Anda inginkan",
+			"selectTheme": "Pilih tema",
+			"themeLight": "Terang",
+			"themeDark": "Gelap",
+			"themeSystem": "Sistem",
+			"language": "Bahasa",
+			"languageDescription": "Pilih bahasa antarmuka yang Anda inginkan",
+			"selectLanguage": "Pilih bahasa",
+			"firstDayOfWeek": "Hari Pertama Minggu",
+			"firstDayOfWeekDescription": "Pilih apakah kalender dan rentang mingguan dimulai pada Minggu atau Senin",
+			"selectFirstDayOfWeek": "Pilih hari pertama",
+			"weekStartsOnSunday": "Minggu",
+			"weekStartsOnMonday": "Senin",
+			"defaultView": "Tampilan Default",
+			"defaultViewDescription": "Pilih mode tampilan tugas yang Anda inginkan",
+			"selectViewMode": "Pilih mode tampilan",
+			"board": "Papan",
+			"list": "Daftar",
+			"gantt": "Gantt",
+			"sidebarDefault": "Default panel samping",
+			"sidebarDefaultDescription": "Biarkan sanel samping terbuka saat mulai",
+			"displayOptions": "Opsi tampilan",
+			"displayOptionsDescription": "Pilih informasi yang ditampilkan di tampilan tugas",
+			"taskNumbers": "Nomor Tugas",
+			"taskNumbersDescription": "Tampilkan ID dan nomor tugas",
+			"assignees": "Penanggung Jawab",
+			"assigneesDescription": "Tampilkan siapa yang ditugaskan ke tugas",
+			"dueDates": "Tenggat",
+			"dueDatesDescription": "Tampilkan tenggat tugas",
+			"labels": "Label",
+			"labelsDescription": "Tampilkan label dan tag tugas",
+			"priority": "Prioritas",
+			"priorityDescription": "Tampilkan indikator prioritas"
+		},
+		"developerPage": {
+			"pageTitle": "Pengaturan Pengembang",
+			"title": "Pengaturan Pengembang",
+			"subtitle": "Kelola API key dan sumber daya pengembang Anda.",
+			"apiKeysCardTitle": "API Key",
+			"apiKeysCardDescription": "Buat dan kelola API key untuk akses terprogram ke Kaneo.",
+			"createApiKey": "Buat API Key",
+			"unnamedKey": "Key Tanpa Nama"
+		},
+		"apiKey": {
+			"createdModal": {
+				"title": "API Key Dibuat",
+				"description": "API key \"{{keyName}}\" berhasil dibuat.",
+				"yourApiKey": "API Key Anda",
+				"copy": "Salin",
+				"copied": "Disalin",
+				"toastCopied": "API key disalin ke papan klip",
+				"alertTitle": "Berhasil! API key Anda telah dibuat",
+				"alertDescription": "Salin key ini sekarang. Anda tidak akan dapat melihatnya lagi.",
+				"done": "Selesai",
+				"copyToContinue": "Salin key untuk melanjutkan"
+			},
+			"table": {
+				"loading": "Memuat API key...",
+				"empty": "Belum ada API key. Buat satu untuk memulai.",
+				"columnName": "Nama",
+				"columnKey": "Key",
+				"columnCreated": "Dibuat",
+				"columnExpires": "Kedaluwarsa",
+				"columnActions": "Aksi",
+				"unnamedKey": "Key Tanpa Nama",
+				"expiredBadge": "Kedaluwarsa {{label}}",
+				"deleteConfirmTitle": "Hapus API key?",
+				"deleteConfirmDescription": "Tindakan ini tidak dapat dibatalkan. Ini akan menghapus {{name}} secara permanen.",
+				"deleteFallbackName": "API key ini",
+				"delete": "Hapus",
+				"deleting": "Menghapus...",
+				"deleteAria": "Hapus {{name}}",
+				"deleteAriaFallback": "API key",
+				"toastDeleted": "API key berhasil dihapus",
+				"toastDeleteError": "Gagal menghapus API key"
+			},
+			"createDialog": {
+				"title": "Buat API Key",
+				"description": "Buat API key baru untuk mengakses API Kaneo secara terprogram.",
+				"nameLabel": "Nama",
+				"namePlaceholder": "API Key Saya",
+				"nameDescription": "Nama deskriptif untuk API key ini",
+				"expirationLabel": "Masa berlaku",
+				"expirationPlaceholder": "Pilih masa berlaku",
+				"expirationDescription": "Pilih berapa lama API key ini tetap valid. Tidak pernah akan membuat key tanpa kedaluwarsa otomatis.",
+				"expiration1d": "1 hari",
+				"expiration7d": "7 hari",
+				"expiration30d": "30 hari",
+				"expiration90d": "90 hari",
+				"expirationNever": "Tidak pernah",
+				"create": "Buat",
+				"creating": "Membuat...",
+				"failedCreate": "Gagal membuat API key",
+				"validation": {
+					"nameRequired": "Nama wajib diisi",
+					"nameShort": "Nama harus minimal 3 karakter",
+					"expirationRequired": "Masa berlaku wajib diisi"
+				}
+			}
+		},
+		"workspaceGeneral": {
+			"pageTitle": "Pengaturan Umum",
+			"title": "Pengaturan Umum",
+			"subtitle": "Kelola nama dan deskripsi ruang kerja Anda.",
+			"workspaceInfoTitle": "Informasi Ruang Kerja",
+			"workspaceInfoSubtitle": "Konfigurasikan detail dan preferensi ruang kerja Anda.",
+			"nameLabel": "Nama ruang kerja",
+			"nameHint": "Nama ruang kerja Anda",
+			"namePlaceholder": "Masukkan nama ruang kerja",
+			"descriptionLabel": "Deskripsi",
+			"descriptionHint": "Deskripsi singkat ruang kerja Anda",
+			"descriptionPlaceholder": "Masukkan deskripsi ruang kerja",
+			"dangerZone": "Zona berbahaya",
+			"dangerZoneSubtitle": "Tindakan destruktif dan tidak dapat dibatalkan.",
+			"deleteWorkspace": "Hapus ruang kerja",
+			"deleteWorkspaceDescription": "Jadwalkan ruang kerja untuk dihapus permanen",
+			"deleteModalTitle": "Hapus Ruang Kerja?",
+			"deleteModalDescription": "Ini akan menghapus ruang kerja \"{{name}}\" dan semua datanya secara permanen. Tindakan ini tidak dapat dibatalkan.",
+			"deleteModalConfirm": "Hapus Ruang Kerja",
+			"toastUpdated": "Ruang kerja berhasil diperbarui",
+			"toastUpdateError": "Gagal memperbarui ruang kerja",
+			"toastDeleted": "Ruang kerja berhasil dihapus",
+			"toastDeleteError": "Gagal menghapus ruang kerja",
+			"validation": {
+				"nameRequired": "Nama ruang kerja wajib diisi",
+				"nameShort": "Nama ruang kerja harus minimal 2 karakter"
+			}
+		},
+		"projectGeneral": {
+			"pageTitle": "Pengaturan Proyek",
+			"title": "Pengaturan Umum",
+			"subtitle": "Kelola nama, key, ikon, dan deskripsi proyek Anda.",
+			"projectInfoTitle": "Informasi Proyek",
+			"projectInfoSubtitle": "Konfigurasikan detail dan preferensi proyek Anda.",
+			"iconLabel": "Ikon",
+			"iconHint": "Ditampilkan di panel samping dan halaman proyek.",
+			"pickIconTitle": "Pilih ikon",
+			"searchIconsPlaceholder": "Cari ikon...",
+			"projectNameLabel": "Nama proyek",
+			"projectNameHint": "Nama proyek Anda",
+			"projectNamePlaceholder": "Masukkan nama proyek",
+			"keyLabel": "Key",
+			"keyHint": "Digunakan untuk ID tiket (misalnya, {{slug}}-123)",
+			"keyPlaceholder": "PRO",
+			"descriptionLabel": "Deskripsi",
+			"descriptionHint": "Deskripsi singkat proyek Anda",
+			"descriptionPlaceholder": "Masukkan deskripsi proyek",
+			"dangerZone": "Zona berbahaya",
+			"dangerZoneSubtitle": "Tindakan destruktif dan tidak dapat dibatalkan.",
+			"deleteProject": "Hapus proyek",
+			"deleteProjectDescription": "Jadwalkan proyek untuk dihapus permanen",
+			"deleteModalTitle": "Hapus Proyek?",
+			"deleteModalDescription": "Ini akan menghapus proyek \"{{name}}\" dan semua datanya secara permanen. Tindakan ini tidak dapat dibatalkan.",
+			"deleteModalConfirm": "Hapus Proyek",
+			"toastUpdated": "Proyek berhasil diperbarui",
+			"toastUpdateError": "Gagal memperbarui proyek",
+			"toastDeleted": "Proyek berhasil dihapus",
+			"toastDeleteError": "Gagal menghapus proyek",
+			"validation": {
+				"nameRequired": "Nama proyek wajib diisi",
+				"nameShort": "Nama proyek harus minimal 2 karakter",
+				"keyRequired": "Key wajib diisi",
+				"keyShort": "Key harus minimal 2 karakter",
+				"keyMax": "Key maksimal 8 karakter",
+				"iconRequired": "Ikon wajib diisi"
+			},
+			"importExportTasks": "Impor/Ekspor",
+			"importExportTasksDescription": "Impor dan ekspor tugas."
+		},
+		"projectIntegrations": {
+			"pageTitle": "Integrasi Proyek",
+			"title": "Integrasi Proyek",
+			"subtitle": "Hubungkan proyek Anda dengan alat dan layanan eksternal untuk memperlancar alur kerja.",
+			"githubSectionTitle": "Integrasi GitHub",
+			"githubSectionSubtitle": "Sinkronkan tugas dengan issue GitHub dan aktifkan sinkronisasi dua arah.",
+			"giteaSectionTitle": "Integrasi Gitea",
+			"giteaSectionSubtitle": "Sinkronkan tugas dengan instance Gitea self-hosted (issue, PR, webhook).",
+			"discordSectionTitle": "Integrasi Discord",
+			"discordSectionSubtitle": "Kirim pembaruan tugas proyek ke kanal Discord dengan webhook.",
+			"genericWebhookSectionTitle": "Webhook Generik",
+			"genericWebhookSectionSubtitle": "Kirim event tugas proyek ke endpoint HTTP apa pun sebagai JSON.",
+			"slackSectionTitle": "Integrasi Slack",
+			"slackSectionSubtitle": "Kirim pembaruan tugas proyek ke kanal Slack dengan incoming webhook.",
+			"telegramSectionTitle": "Integrasi Telegram",
+			"telegramSectionSubtitle": "Kirim pembaruan tugas proyek ke chat atau topik Telegram dengan bot."
+		},
+		"projectVisibility": {
+			"pageTitle": "Visibilitas Proyek",
+			"title": "Visibilitas",
+			"subtitle": "Kontrol siapa yang dapat melihat dan mengakses proyek Anda.",
+			"sectionTitle": "Visibilitas",
+			"sectionSubtitle": "Aktifkan akses publik dan bagikan URL publik.",
+			"publicAccess": "Akses publik",
+			"publicAccessHint": "Izinkan siapa pun dengan URL untuk melihat proyek ini",
+			"publicUrl": "URL publik",
+			"publicUrlHint": "Bagikan tautan ini jika proyek bersifat publik",
+			"copy": "Salin",
+			"copiedToast": "Disalin",
+			"toastUpdated": "Visibilitas diperbarui",
+			"toastUpdateError": "Gagal memperbarui visibilitas"
+		},
+		"projectWorkflow": {
+			"pageTitle": "Pengaturan Alur Kerja",
+			"title": "Alur Kerja",
+			"subtitle": "Konfigurasikan kolom papan dan aturan otomatisasi untuk proyek ini.",
+			"columnsTitle": "Kolom",
+			"columnsDescription": "Kelola kolom yang muncul di papan Anda. Seret untuk mengurutkan ulang. Aktifkan \"Kolom selesai\" untuk tahap yang mewakili pekerjaan selesai.",
+			"automationTitle": "Aturan Otomatisasi",
+			"automationDescription": "Petakan event integrasi ke kolom. Saat event terjadi, tugas tertaut berpindah ke kolom yang ditentukan."
+		},
+		"projectSwitcher": {
+			"selectProject": "Pilih proyek",
+			"noProjects": "Tidak ada proyek"
+		},
+		"columnEditor": {
+			"toastCreated": "Kolom dibuat",
+			"toastCreateError": "Gagal membuat kolom",
+			"toastRenamed": "Kolom diganti nama",
+			"toastRenameError": "Gagal memperbarui kolom",
+			"toastFinalOn": "Kolom ditandai sebagai final",
+			"toastFinalOff": "Tanda final pada kolom dihapus",
+			"toastUpdateError": "Gagal memperbarui kolom",
+			"toastIconUpdated": "Ikon kolom diperbarui",
+			"toastDeleted": "Kolom dihapus",
+			"toastDeleteError": "Gagal menghapus kolom",
+			"loading": "Memuat kolom...",
+			"pickIconTitle": "Pilih ikon kolom",
+			"searchIconsPlaceholder": "Cari ikon...",
+			"doneColumnTooltip": "Perlakukan ini sebagai kolom selesai",
+			"doneColumn": "Kolom selesai",
+			"markDoneAria": "Tandai {{name}} sebagai kolom selesai",
+			"on": "Aktif",
+			"off": "Nonaktif",
+			"newColumnPlaceholder": "Nama kolom baru...",
+			"add": "Tambah"
+		},
+		"githubIntegration": {
+			"validation": {
+				"ownerRequired": "Pemilik repositori wajib diisi",
+				"ownerInvalid": "Format pemilik repositori tidak valid",
+				"nameRequired": "Nama repositori wajib diisi",
+				"nameInvalid": "Format nama repositori tidak valid"
+			},
+			"toast": {
+				"installedOk": "GitHub App terpasang dengan benar!",
+				"installedMissingPerms": "GitHub App terpasang tetapi izin yang diperlukan kurang",
+				"needsInstallOnRepo": "GitHub App perlu dipasang pada repositori ini",
+				"repoNotFound": "Repositori tidak ditemukan atau tidak dapat diakses",
+				"verifyError": "Gagal memverifikasi pemasangan GitHub",
+				"installAppFirst": "Pasang GitHub App pada repositori ini terlebih dahulu",
+				"missingPermsDetail": "GitHub App kekurangan izin yang diperlukan: {{list}}. Perbarui izin aplikasi.",
+				"updated": "Integrasi GitHub berhasil diperbarui",
+				"updateError": "Gagal memperbarui integrasi GitHub",
+				"removed": "Integrasi GitHub berhasil dihapus",
+				"removeError": "Gagal menghapus integrasi GitHub",
+				"issuesImported": "Issue berhasil diimpor",
+				"importError": "Gagal mengimpor issue",
+				"commentOnEnabled": "Kaneo akan berkomentar dengan tautan tugas pada issue baru",
+				"commentOnDisabled": "Komentar tautan tugas pada issue baru dimatikan",
+				"settingsUpdateError": "Gagal memperbarui integrasi GitHub"
+			},
+			"connectionStatus": "Status Koneksi",
+			"connectedActive": "Repositori terhubung dan aktif",
+			"notConnectedHint": "Tidak ada repositori terhubung",
+			"badgeConnected": "Terhubung",
+			"badgeNotConnected": "Tidak Terhubung",
+			"repository": "Repositori",
+			"repositoryHint": "Repositori GitHub terhubung",
+			"commentTaskLinkTitle": "Komentari tautan Kaneo pada issue baru",
+			"commentTaskLinkHint": "Saat diaktifkan, Kaneo memposting komentar pada setiap issue GitHub baru dengan tautan ke tugas.",
+			"appStatusTitle": "Status GitHub App",
+			"appStatusHint": "Status pemasangan dan izin",
+			"statusProperlyConfigured": "Dikonfigurasi dengan benar",
+			"statusMissingPermissions": "Izin kurang",
+			"statusNotInstalled": "Belum terpasang",
+			"ownerLabel": "Pemilik Repositori",
+			"ownerHint": "Username atau organisasi GitHub",
+			"ownerPlaceholder": "misalnya, octocat",
+			"repoNameLabel": "Nama Repositori",
+			"repoNameHint": "Nama repositori",
+			"repoNamePlaceholder": "misalnya, my-project",
+			"actionsTitle": "Aksi",
+			"actionsHint": "Kelola koneksi repositori Anda",
+			"browse": "Jelajahi",
+			"verify": "Verifikasi",
+			"update": "Perbarui",
+			"connect": "Hubungkan",
+			"disconnect": "Putuskan",
+			"missingPermissionsLabel": "Izin yang kurang:",
+			"updatePermissions": "Perbarui Izin",
+			"installGithubApp": "Pasang GitHub App",
+			"importSectionTitle": "Impor Issue GitHub",
+			"importSectionHint": "Impor issue yang ada dari repositori GitHub Anda sebagai tugas",
+			"importing": "Mengimpor...",
+			"importIssues": "Impor Issue",
+			"importDisabledHint": "Lengkapi konfigurasi repositori di atas untuk mengaktifkan impor"
+		},
+		"giteaIntegration": {
+			"validation": {
+				"baseUrlRequired": "URL dasar Gitea wajib diisi",
+				"baseUrlInvalid": "Masukkan URL yang valid (mis. https://gitea.example.com)",
+				"ownerRequired": "Pemilik repositori wajib diisi",
+				"ownerInvalid": "Format pemilik repositori tidak valid",
+				"nameRequired": "Nama repositori wajib diisi",
+				"nameInvalid": "Format nama repositori tidak valid"
+			},
+			"toast": {
+				"verifyOk": "Token Gitea dapat mengakses repositori ini",
+				"verifyWarning": "Periksa izin token atau akses repositori",
+				"repoNotFound": "Repositori tidak ditemukan atau tidak dapat diakses",
+				"verifyError": "Gagal memverifikasi akses Gitea",
+				"tokenRequired": "Token akses pribadi wajib diisi",
+				"tokenRequiredVerify": "Masukkan token untuk memverifikasi",
+				"verifyFirst": "Verifikasi akses gagal — periksa URL, token, dan repositori",
+				"updated": "Integrasi Gitea disimpan",
+				"updateError": "Gagal menyimpan integrasi Gitea",
+				"removed": "Integrasi Gitea dihapus",
+				"removeError": "Gagal menghapus integrasi Gitea",
+				"issuesImported": "Issue berhasil diimpor",
+				"importError": "Gagal mengimpor issue",
+				"commentOnEnabled": "Kaneo akan berkomentar dengan tautan tugas pada issue baru",
+				"commentOnDisabled": "Komentar tautan tugas pada issue baru dimatikan",
+				"settingsUpdateError": "Gagal memperbarui integrasi Gitea",
+				"secretCopied": "Disalin",
+				"unableToCopySecret": "Tidak dapat menyalin rahasia"
+			},
+			"webhookShow": "Tampilkan",
+			"webhookHide": "Sembunyikan",
+			"webhookCopy": "Salin",
+			"connectionStatus": "Status koneksi",
+			"connectedActive": "Repositori terhubung dan aktif",
+			"notConnectedHint": "Tidak ada repositori Gitea terhubung",
+			"badgeConnected": "Terhubung",
+			"badgeNotConnected": "Tidak terhubung",
+			"repository": "Repositori",
+			"repositoryHint": "Repositori Gitea tertaut",
+			"commentTaskLinkTitle": "Komentari tautan Kaneo pada issue baru",
+			"commentTaskLinkHint": "Saat diaktifkan, Kaneo memposting komentar pada setiap issue baru dengan tautan ke tugas.",
+			"webhookTitle": "Webhook",
+			"webhookHint": "Di repositori Gitea Anda, tambahkan webhook dengan URL dan rahasia ini. Aktifkan push, pull request, issue, komentar issue, dan create (untuk label).",
+			"webhookSecretLabel": "Rahasia (harus sama dengan rahasia webhook di Gitea)",
+			"baseUrlLabel": "URL Gitea",
+			"baseUrlHint": "URL root instance Gitea Anda",
+			"tokenLabel": "Token akses pribadi",
+			"tokenHint": "Token dengan akses repo dan issue",
+			"tokenPlaceholder": "Tempel token",
+			"tokenPlaceholderUpdate": "Tempel token baru untuk rotasi",
+			"currentToken": "tersimpan",
+			"ownerLabel": "Pemilik",
+			"ownerHint": "Nama pengguna atau organisasi",
+			"repoNameLabel": "Nama repositori",
+			"repoNameHint": "Nama repositori saja (tanpa pemilik)",
+			"actionsTitle": "Aksi",
+			"actionsHint": "Verifikasi akses dan hubungkan",
+			"browse": "Jelajahi",
+			"verify": "Verifikasi",
+			"update": "Perbarui",
+			"connect": "Hubungkan",
+			"disconnect": "Putuskan",
+			"importSectionTitle": "Impor issue Gitea",
+			"importSectionHint": "Impor issue terbuka dan pull request dari repositori",
+			"importing": "Mengimpor…",
+			"importIssues": "Impor issue",
+			"importDisabledHint": "Verifikasi repositori di atas untuk mengaktifkan impor",
+			"browseModalTitle": "Repositori Anda",
+			"browseModalHint": "Repositori yang dapat diakses token Anda",
+			"searchRepos": "Cari…",
+			"browseNeedsCredentials": "Masukkan URL dan token Gitea untuk menjelajah",
+			"loadingRepos": "Memuat repositori…",
+			"retry": "Coba lagi"
+		},
+		"slackIntegration": {
+			"validation": {
+				"webhookInvalid": "Masukkan URL webhook Slack yang valid"
+			},
+			"toast": {
+				"saved": "Integrasi Slack berhasil disimpan",
+				"saveError": "Gagal menyimpan integrasi Slack",
+				"enabled": "Notifikasi Slack diaktifkan",
+				"disabled": "Notifikasi Slack dijeda",
+				"updateError": "Gagal memperbarui integrasi Slack",
+				"removed": "Integrasi Slack berhasil dihapus",
+				"removeError": "Gagal menghapus integrasi Slack"
+			},
+			"connectionTitle": "Koneksi webhook Slack",
+			"connectionHint": "Tempel URL incoming webhook Slack dan pilih event tugas yang harus diposting.",
+			"connected": "Terhubung",
+			"paused": "Dijeda",
+			"webhookLabel": "URL incoming webhook",
+			"webhookPlaceholder": "https://hooks.slack.com/services/...",
+			"webhookHint": "Buat Incoming Webhook di Slack dan tempel URL yang dihasilkan di sini.",
+			"channelLabel": "Nama kanal",
+			"channelPlaceholder": "#team-updates",
+			"channelHint": "Label opsional untuk referensi Anda. Slack mengontrol kanal tujuan sebenarnya dari pengaturan webhook.",
+			"eventsTitle": "Notifikasi event",
+			"eventsHint": "Pilih perubahan proyek yang harus diposting ke Slack.",
+			"events": {
+				"taskCreated": "Tugas baru",
+				"taskStatusChanged": "Perubahan status",
+				"taskPriorityChanged": "Perubahan prioritas",
+				"taskTitleChanged": "Perubahan judul",
+				"taskDescriptionChanged": "Perubahan deskripsi",
+				"taskCommentCreated": "Komentar baru"
+			},
+			"connect": "Hubungkan Slack",
+			"saveChanges": "Simpan perubahan",
+			"update": "Perbarui Slack",
+			"disconnect": "Putuskan"
+		},
+		"discordIntegration": {
+			"validation": {
+				"webhookInvalid": "Masukkan URL webhook Discord yang valid"
+			},
+			"toast": {
+				"saved": "Integrasi Discord berhasil disimpan",
+				"saveError": "Gagal menyimpan integrasi Discord",
+				"enabled": "Notifikasi Discord diaktifkan",
+				"disabled": "Notifikasi Discord dijeda",
+				"updateError": "Gagal memperbarui integrasi Discord",
+				"removed": "Integrasi Discord berhasil dihapus",
+				"removeError": "Gagal menghapus integrasi Discord"
+			},
+			"connectionTitle": "Koneksi webhook Discord",
+			"connectionHint": "Tempel URL webhook Discord dan pilih event tugas yang harus diposting.",
+			"connected": "Terhubung",
+			"paused": "Dijeda",
+			"webhookLabel": "URL webhook",
+			"webhookPlaceholder": "https://discord.com/api/webhooks/...",
+			"webhookHint": "Buat webhook kanal Discord dan tempel URL yang dihasilkan di sini.",
+			"channelLabel": "Nama kanal",
+			"channelPlaceholder": "#team-updates",
+			"channelHint": "Label opsional untuk referensi Anda. Discord mengontrol kanal tujuan sebenarnya dari pengaturan webhook.",
+			"eventsTitle": "Notifikasi event",
+			"eventsHint": "Pilih perubahan proyek yang harus diposting ke Discord.",
+			"events": {
+				"taskCreated": "Tugas baru",
+				"taskStatusChanged": "Perubahan status",
+				"taskPriorityChanged": "Perubahan prioritas",
+				"taskTitleChanged": "Perubahan judul",
+				"taskDescriptionChanged": "Perubahan deskripsi",
+				"taskCommentCreated": "Komentar baru"
+			},
+			"connect": "Hubungkan Discord",
+			"saveChanges": "Simpan perubahan",
+			"update": "Perbarui Discord",
+			"disconnect": "Putuskan"
+		},
+		"genericWebhookIntegration": {
+			"validation": {
+				"webhookInvalid": "Masukkan URL webhook yang valid"
+			},
+			"toast": {
+				"saved": "Integrasi webhook generik berhasil disimpan",
+				"saveError": "Gagal menyimpan integrasi webhook generik",
+				"enabled": "Notifikasi webhook generik diaktifkan",
+				"disabled": "Notifikasi webhook generik dijeda",
+				"updateError": "Gagal memperbarui integrasi webhook generik",
+				"removed": "Integrasi webhook generik berhasil dihapus",
+				"removeError": "Gagal menghapus integrasi webhook generik"
+			},
+			"connectionTitle": "Koneksi webhook keluar",
+			"connectionHint": "Kirim event tugas ke endpoint Anda sendiri sebagai JSON. Header X-Kaneo-Signature yang ditandatangani disertakan saat rahasia dikonfigurasi.",
+			"connected": "Terhubung",
+			"paused": "Dijeda",
+			"webhookLabel": "URL endpoint",
+			"webhookPlaceholder": "https://example.com/webhooks/kaneo",
+			"webhookHint": "Kaneo mengirim request POST dengan payload JSON untuk setiap event yang diaktifkan.",
+			"secretLabel": "Rahasia penandatanganan",
+			"secretPlaceholder": "Rahasia bersama opsional",
+			"secretHint": "Opsional. Jika diberikan, Kaneo menandatangani body request dan mengirim digest hex di header X-Kaneo-Signature.",
+			"secretHintConfigured": "Rahasia penandatanganan sudah dikonfigurasi ({{secret}}). Masukkan yang baru untuk menggantinya.",
+			"eventsTitle": "Notifikasi event",
+			"eventsHint": "Pilih perubahan proyek yang harus memicu webhook keluar.",
+			"events": {
+				"taskCreated": "Tugas baru",
+				"taskStatusChanged": "Perubahan status",
+				"taskPriorityChanged": "Perubahan prioritas",
+				"taskTitleChanged": "Perubahan judul",
+				"taskDescriptionChanged": "Perubahan deskripsi",
+				"taskCommentCreated": "Komentar baru"
+			},
+			"connect": "Hubungkan webhook",
+			"saveChanges": "Simpan perubahan",
+			"disconnect": "Putuskan"
+		},
+		"telegramIntegration": {
+			"validation": {
+				"botTokenInvalid": "Masukkan token bot Telegram yang valid",
+				"chatIdRequired": "Chat ID wajib diisi",
+				"threadIdInvalid": "Masukkan ID thread topik Telegram yang valid"
+			},
+			"toast": {
+				"saved": "Integrasi Telegram berhasil disimpan",
+				"saveError": "Gagal menyimpan integrasi Telegram",
+				"enabled": "Notifikasi Telegram diaktifkan",
+				"disabled": "Notifikasi Telegram dijeda",
+				"updateError": "Gagal memperbarui integrasi Telegram",
+				"removed": "Integrasi Telegram berhasil dihapus",
+				"removeError": "Gagal menghapus integrasi Telegram"
+			},
+			"connectionTitle": "Koneksi bot Telegram",
+			"connectionHint": "Gunakan token bot Telegram dan chat ID untuk mengirim pembaruan tugas proyek ke chat atau topik.",
+			"connected": "Terhubung",
+			"paused": "Dijeda",
+			"botTokenLabel": "Token bot",
+			"botTokenPlaceholder": "123456789:AAExampleBotToken",
+			"botTokenHint": "Buat bot dengan BotFather dan tempel tokennya di sini.",
+			"botTokenHintConfigured": "Token bot sudah dikonfigurasi ({{token}}). Masukkan yang baru untuk menggantinya.",
+			"chatIdLabel": "Chat ID",
+			"chatIdPlaceholder": "-1001234567890 atau @team_updates",
+			"chatIdHint": "Masukkan chat ID Telegram atau username kanal tempat pembaruan akan diposting.",
+			"threadIdLabel": "ID thread topik",
+			"threadIdPlaceholder": "ID topik opsional",
+			"threadIdHint": "Opsional. Gunakan ini untuk topik forum di dalam grup Telegram.",
+			"chatLabelLabel": "Label chat",
+			"chatLabelPlaceholder": "Engineering Updates",
+			"chatLabelHint": "Label opsional untuk referensi Anda di Kaneo.",
+			"eventsTitle": "Notifikasi event",
+			"eventsHint": "Pilih perubahan proyek yang harus diposting ke Telegram.",
+			"events": {
+				"taskCreated": "Tugas baru",
+				"taskStatusChanged": "Perubahan status",
+				"taskPriorityChanged": "Perubahan prioritas",
+				"taskTitleChanged": "Perubahan judul",
+				"taskDescriptionChanged": "Perubahan deskripsi",
+				"taskCommentCreated": "Komentar baru"
+			},
+			"connect": "Hubungkan Telegram",
+			"saveChanges": "Simpan perubahan",
+			"disconnect": "Putuskan"
+		},
+		"repositoryBrowser": {
+			"title": "Pilih Repositori",
+			"description": "Pilih repositori tempat GitHub App Anda terpasang untuk mengaktifkan sinkronisasi issue.",
+			"searchPlaceholder": "Cari repositori...",
+			"loadError": "Gagal memuat repositori",
+			"tryAgain": "Coba Lagi",
+			"emptyTitle": "Repositori tidak ditemukan",
+			"emptyHint": "Pasang GitHub App pada repositori Anda untuk melihatnya di sini.",
+			"installGithubApp": "Pasang GitHub App",
+			"noSearchMatchTitle": "Tidak ada repositori yang cocok dengan pencarian Anda",
+			"noSearchMatchHint": "Coba sesuaikan kata pencarian atau hapus pencarian untuk melihat semua repositori.",
+			"footerSummary": "{{repoCount}} repositori di {{installationCount}} pemasangan",
+			"manageInstallations": "Kelola Pemasangan",
+			"updatedPrefix": "Diperbarui",
+			"relativeJustNow": "baru saja",
+			"relativeMinutesAgo": "{{count}}m lalu",
+			"relativeHoursAgo": "{{count}}j lalu",
+			"relativeDaysAgo": "{{count}}h lalu"
+		},
+		"tasksImportExport": {
+			"exportTasks": "Ekspor Tugas",
+			"importTasks": "Impor Tugas",
+			"dialogTitle": "Impor Tugas",
+			"dialogDescription": "Unggah file JSON berisi tugas untuk diimpor ke proyek ini.",
+			"expectedFormat": "Format yang diharapkan:",
+			"dropHint": "Seret dan lepaskan file JSON Anda di sini",
+			"selectFile": "Pilih File",
+			"exporting": "Mengekspor tugas...",
+			"exportSuccess": "Tugas berhasil diekspor",
+			"exportError": "Gagal mengekspor tugas",
+			"importing": "Mengimpor tugas...",
+			"importSuccess": "Berhasil mengimpor {{count}} tugas",
+			"importPartialError": "Gagal mengimpor {{count}} tugas",
+			"importError": "Gagal mengimpor tugas",
+			"invalidFormat": "Format file impor tidak valid",
+			"noFileDropped": "Tidak ada file yang dilepas",
+			"notJsonFile": "Silakan unggah file JSON"
+		},
+		"workflowEditor": {
+			"loading": "Memuat...",
+			"createColumnsFirst": "Buat kolom terlebih dahulu untuk mengonfigurasi aturan otomatisasi.",
+			"githubHeading": "GitHub",
+			"githubHint": "Saat event GitHub terjadi, pindahkan tugas tertaut ke kolom.",
+			"giteaHeading": "Gitea",
+			"giteaHint": "Saat event webhook Gitea terjadi, pindahkan tugas tertaut ke kolom.",
+			"selectColumnPlaceholder": "Pilih kolom...",
+			"toastUpdated": "Aturan alur kerja diperbarui",
+			"toastError": "Gagal memperbarui aturan",
+			"events": {
+				"branch_push": "Push Branch",
+				"pr_opened": "PR Dibuka",
+				"pr_merged": "PR Digabung",
+				"issue_opened": "Issue Dibuka",
+				"issue_closed": "Issue Ditutup"
+			}
+		},
+		"externalLinks": {
+			"resources": "Sumber daya",
+			"issue": "Issue",
+			"branch": "Branch",
+			"merged": "Digabung",
+			"draft": "Draf",
+			"open": "Terbuka"
+		},
+		"workspaceRoles": {
+			"pageTitle": "Peran",
+			"title": "Peran",
+			"subtitle": "Tentukan tindakan yang dapat dilakukan anggota di {{workspaceName}}.",
+			"thisWorkspace": "ruang kerja ini",
+			"noAccess": "Anda memerlukan izin admin atau pemilik untuk mengelola peran ruang kerja.",
+			"sectionTitle": "Peran ruang kerja",
+			"sectionSubtitle": "Ubah peran bawaan atau tambahkan peran khusus. Anggota tetap memakai nama peran yang ditetapkan meski peran diubah.",
+			"newRole": "Peran baru",
+			"loading": "Memuat...",
+			"loadError": "Gagal memuat peran.",
+			"emptyTitle": "Belum ada peran",
+			"emptyDescription": "Peran bawaan akan muncul di sini setelah disiapkan untuk ruang kerja ini.",
+			"defaultBadge": "Bawaan",
+			"permissionCount_one": "{{count}} izin",
+			"permissionCount_other": "{{count}} izin",
+			"nameLabel": "Nama",
+			"nameHint": "Huruf kecil. Tidak dapat diubah nanti.",
+			"namePlaceholder": "mis. peninjau",
+			"discard": "Buang",
+			"createRole": "Buat peran",
+			"deleteRole": "Hapus peran",
+			"defaultRoleHelp": "Peran bawaan - nama dicadangkan dan baris tidak dapat dihapus.",
+			"unsavedChanges": "Ada perubahan yang belum disimpan",
+			"allChangesSaved": "Semua perubahan tersimpan",
+			"saveChanges": "Simpan perubahan",
+			"defaultRoleDescriptions": {
+				"viewer": "Akses hanya baca ke proyek, tugas, dan ruang kerja.",
+				"member": "Dapat membuat dan memperbarui proyek serta tugas.",
+				"admin": "Manajemen penuh proyek dan tugas serta pengaturan ruang kerja."
+			},
+			"resources": {
+				"project": "Proyek",
+				"task": "Tugas",
+				"label": "Label",
+				"workspace": "Ruang kerja"
+			},
+			"permissions": {
+				"project": {
+					"create": {
+						"label": "Buat proyek",
+						"description": "Buat proyek baru di ruang kerja ini."
+					},
+					"read": {
+						"label": "Lihat proyek",
+						"description": "Lihat proyek dan detailnya."
+					},
+					"update": {
+						"label": "Ubah proyek",
+						"description": "Perbarui nama, ikon, deskripsi, dan pengaturan proyek."
+					},
+					"delete": {
+						"label": "Hapus proyek",
+						"description": "Hapus proyek di ruang kerja ini secara permanen."
+					},
+					"share": {
+						"label": "Bagikan proyek",
+						"description": "Jadikan proyek dapat diakses publik melalui tautan berbagi."
+					}
+				},
+				"task": {
+					"create": {
+						"label": "Buat tugas",
+						"description": "Buat tugas baru di proyek mana pun."
+					},
+					"read": {
+						"label": "Lihat tugas",
+						"description": "Lihat tugas di semua proyek."
+					},
+					"update": {
+						"label": "Ubah tugas",
+						"description": "Ubah isi tugas, status, prioritas, tenggat, dan label."
+					},
+					"delete": {
+						"label": "Hapus tugas",
+						"description": "Hapus tugas secara permanen."
+					},
+					"assign": {
+						"label": "Tugaskan tugas",
+						"description": "Tugaskan tugas kepada anggota ruang kerja lain."
+					}
+				},
+				"label": {
+					"create": {
+						"label": "Buat label",
+						"description": "Tambahkan label baru ke tugas di ruang kerja ini."
+					},
+					"read": {
+						"label": "Lihat label",
+						"description": "Lihat label yang terpasang pada tugas."
+					},
+					"update": {
+						"label": "Ubah label",
+						"description": "Ganti nama, warna, dan penugasan label."
+					},
+					"delete": {
+						"label": "Hapus label",
+						"description": "Hapus label dari ruang kerja ini secara permanen."
+					}
+				},
+				"workspace": {
+					"read": {
+						"label": "Akses ruang kerja",
+						"description": "Baca metadata dan anggota ruang kerja."
+					},
+					"update": {
+						"label": "Ubah ruang kerja",
+						"description": "Ubah nama dan deskripsi ruang kerja."
+					},
+					"delete": {
+						"label": "Hapus ruang kerja",
+						"description": "Hapus ruang kerja ini secara permanen."
+					},
+					"manage_settings": {
+						"label": "Kelola pengaturan",
+						"description": "Atur integrasi, aturan notifikasi, dan preferensi ruang kerja."
+					}
+				}
+			},
+			"validation": {
+				"nameRequired": "Nama wajib diisi",
+				"nameExists": "Peran dengan nama tersebut sudah ada",
+				"permissionRequired": "Pilih setidaknya satu izin"
+			},
+			"toast": {
+				"created": "Peran dibuat",
+				"createError": "Gagal membuat peran",
+				"updated": "Peran diperbarui",
+				"updateError": "Gagal memperbarui peran",
+				"deleted": "Peran dihapus",
+				"deleteError": "Gagal menghapus peran"
+			},
+			"deleteDialog": {
+				"title": "Hapus peran",
+				"description": "Ini akan menghapus peran \"{{role}}\" secara permanen. Anggota yang memakai peran ini akan kehilangan izinnya."
+			}
+		}
+	},
+	"navigation": {
+		"commandPalette": {
+			"suggestions": "Saran",
+			"commands": "Perintah",
+			"projects": "Proyek",
+			"search": "Cari",
+			"members": "Anggota",
+			"createTask": "Buat tugas",
+			"createProject": "Buat proyek",
+			"createWorkspace": "Buat ruang kerja",
+			"lightTheme": "Tema terang",
+			"darkTheme": "Tema gelap",
+			"systemTheme": "Tema sistem",
+			"keyboardShortcuts": "Pintasan keyboard",
+			"inputPlaceholder": "Cari aplikasi dan perintah...",
+			"empty": "Tidak ada hasil ditemukan.",
+			"footer": {
+				"navigate": "Navigasi",
+				"open": "Buka",
+				"close": "Tutup"
+			}
+		},
+		"notifications": "Notifikasi",
+		"sidebar": {
+			"overview": "Ringkasan",
+			"projects": "Proyek",
+			"members": "Anggota",
+			"invitations": "Undangan",
+			"more": "Lainnya",
+			"backToBoard": "Kembali ke papan"
+		},
+		"projectList": {
+			"viewProject": "Lihat Proyek",
+			"shareProject": "Bagikan Proyek",
+			"projectSettings": "Pengaturan proyek",
+			"linkCopied": "Tautan proyek disalin ke papan klip",
+			"addProject": "Tambah proyek",
+			"deleteConfirmTitle": "Hapus Proyek?",
+			"deleteConfirmDescription": "Ini akan menghapus proyek dan semua datanya secara permanen. Anda tidak dapat membatalkan tindakan ini.",
+			"deletedToast": "Proyek dihapus",
+			"deleteProject": "Hapus Proyek"
+		},
+		"search": {
+			"inputPlaceholder": "Cari tugas, proyek, komentar...",
+			"minCharsHint": "Ketik minimal 3 karakter untuk mencari",
+			"groups": {
+				"task": "Tugas",
+				"project": "Proyek",
+				"workspace": "Ruang kerja",
+				"comment": "Komentar",
+				"activity": "Aktivitas",
+				"fallback": "Hasil"
+			}
+		},
+		"settingsLayout": {
+			"toggleSidebar": "Tampilkan/sembunyikan panel samping",
+			"back": "Kembali"
+		},
+		"userMenu": {
+			"signedOutSuccess": "Berhasil keluar",
+			"signOutFailed": "Gagal keluar",
+			"unnamedUser": "Pengguna",
+			"settings": "Pengaturan",
+			"signingOut": "Keluar...",
+			"logOut": "Keluar"
+		},
+		"workspaceSwitcher": {
+			"workspaces": "Ruang kerja",
+			"switching": "Beralih...",
+			"addWorkspace": "Tambah ruang kerja",
+			"selectWorkspace": "Pilih ruang kerja"
+		},
+		"page": {
+			"projectsTitle": "Proyek",
+			"settingsTitle": "Pengaturan",
+			"backToWorkspace": "Kembali ke Ruang Kerja",
+			"settingsWorkspaceTab": "Ruang Kerja"
+		},
+		"projectSettings": {
+			"projectLabel": "Proyek"
+		},
+		"keyboardShortcuts": {
+			"title": "Pintasan Keyboard",
+			"subtitle": "Percepat alur kerja Anda dengan pintasan keyboard",
+			"searchPlaceholder": "Cari pintasan...",
+			"footer": "Tekan <kbd>Escape</kbd> untuk menutup",
+			"categories": {
+				"general": "Umum",
+				"create": "Buat",
+				"views": "Tampilan",
+				"navigation": "Navigasi",
+				"quickSelect": "Pilih Cepat (di popover)"
+			},
+			"items": {
+				"openCommandPalette": "Buka palet perintah",
+				"globalSearch": "Pencarian global",
+				"toggleSidebar": "Tampilkan/sembunyikan panel samping",
+				"showShortcuts": "Tampilkan pintasan keyboard",
+				"closeModal": "Tutup modal/popover",
+				"createTask": "Buat tugas",
+				"createProject": "Buat proyek",
+				"createWorkspace": "Buat ruang kerja",
+				"boardView": "Beralih ke tampilan papan",
+				"listView": "Beralih ke tampilan daftar",
+				"backlogView": "Beralih ke tampilan backlog",
+				"nextTask": "Tugas berikutnya",
+				"prevTask": "Tugas sebelumnya",
+				"openTask": "Buka tugas terpilih",
+				"quickSelectNumber": "Pilih opsi berdasarkan nomor"
+			}
+		}
+	},
+	"notifications": {
+		"title": "Notifikasi",
+		"newCount_one": "{{count}} baru",
+		"newCount_other": "{{count}} baru",
+		"emptyTitle": "Belum ada notifikasi",
+		"emptySubtitle": "Pembaruan dan aktivitas akan muncul di sini.",
+		"clearAll": "Hapus semua notifikasi",
+		"clearDialogTitle": "Hapus semua notifikasi?",
+		"clearDialogDescription": "Ini akan menghapus semua notifikasi secara permanen. Anda tidak dapat membatalkan tindakan ini.",
+		"shortcuts": {
+			"open": "Buka notifikasi"
+		},
+		"events": {
+			"task_created": {
+				"title": "Tugas Baru Dibuat",
+				"content": "Tugas \"{{taskTitle}}\" dibuat"
+			},
+			"workspace_created": {
+				"title": "Ruang kerja dibuat",
+				"content": "Ruang kerja Anda \"{{workspaceName}}\" berhasil dibuat"
+			},
+			"task_status_changed": {
+				"title": "Status tugas berubah",
+				"content": "Status tugas \"{{taskTitle}}\" berubah dari \"{{oldStatus}}\" menjadi \"{{newStatus}}\""
+			},
+			"task_assignee_changed": {
+				"title": "Tugas ditugaskan kepada Anda",
+				"content": "Anda ditugaskan ke tugas: {{taskTitle}}"
+			},
+			"task_mention": {
+				"title": "{{mentionerName}} menyebut Anda",
+				"content": "{{mentionerName}} menyebut Anda di: {{taskTitle}}"
+			},
+			"time_entry_created": {
+				"title": "Pelacakan waktu dimulai",
+				"contentWithTask": "Pelacakan waktu dimulai pada tugas: {{taskTitle}}",
+				"contentWithoutTask": "Pelacakan waktu dimulai pada sebuah tugas"
+			}
+		}
+	},
+	"activity": {
+		"assignedToSelf": "menugaskan tugas kepada dirinya sendiri",
+		"unassigned": "menghapus penugasan tugas",
+		"assignedTo": "menugaskan tugas kepada {{name}}",
+		"changedStatus": "mengubah status dari {{from}} menjadi {{to}}",
+		"changedPriority": "mengubah prioritas dari {{from}} menjadi {{to}}",
+		"clearedDueDate": "menghapus tenggat",
+		"setDueDate": "mengatur tenggat ke {{date}}",
+		"changedDueDate": "mengubah tenggat dari {{from}} menjadi {{to}}",
+		"changedTitle": "mengubah judul dari \"{{from}}\" menjadi \"{{to}}\"",
+		"moved": "memindahkan tugas dari \"{{from}}\" ke \"{{to}}\"",
+		"created": "membuat tugas ini",
+		"githubUser": "Pengguna GitHub",
+		"comment": {
+			"github": "GitHub",
+			"viewGithubProfile": "Lihat Profil GitHub",
+			"commentedOnGithub": "berkomentar di GitHub",
+			"cannotBeEmpty": "Komentar tidak boleh kosong",
+			"mustBeLoggedInToEdit": "Anda harus masuk untuk mengedit komentar",
+			"updated": "Komentar diperbarui",
+			"failedToUpdate": "Gagal memperbarui komentar",
+			"edit": "Edit komentar",
+			"editPlaceholder": "Edit komentar...",
+			"save": "Simpan",
+			"added": "Komentar ditambahkan",
+			"failedToAdd": "Gagal menambahkan komentar",
+			"leavePlaceholder": "Tinggalkan komentar...",
+			"attachFile": "Lampirkan file",
+			"submitShortcut": "Kirim komentar",
+			"editor": {
+				"uploadsOnlyOnSavedTasks": "Unggahan file hanya tersedia pada tugas yang sudah disimpan.",
+				"uploadingFile": "Mengunggah file...",
+				"imageUploaded": "Gambar diunggah",
+				"fileAttached": "File dilampirkan",
+				"failedToUploadFile": "Gagal mengunggah file",
+				"enterUrl": "Masukkan URL",
+				"plaintext": "Teks biasa",
+				"autoDetect": "Deteksi otomatis",
+				"slashGroupText": "Teks",
+				"slashGroupLists": "Daftar",
+				"slashGroupInsert": "Sisipkan",
+				"slashParagraph": "Teks",
+				"slashHeading": "Heading",
+				"slashBulletList": "Daftar berpoin",
+				"slashTaskList": "Daftar tugas",
+				"slashOrderedList": "Daftar bernomor",
+				"slashQuote": "Kutipan",
+				"slashCodeBlock": "Blok kode",
+				"slashTable": "Tabel",
+				"slashFile": "File",
+				"searchParagraph": "paragraf teks normal",
+				"searchHeading": "heading judul h2",
+				"searchBulletList": "daftar bullet tidak berurutan",
+				"searchTaskList": "todo to-do checklist checkbox daftar tugas",
+				"searchOrderedList": "daftar berurutan bernomor",
+				"searchQuote": "kutipan blockquote",
+				"searchCodeBlock": "cuplikan kode",
+				"searchTable": "tabel grid",
+				"searchFile": "file lampiran gambar foto unggah",
+				"embedErrorInvalidUrl": "Masukkan URL yang valid",
+				"embedErrorYoutubeOnly": "Hanya tautan YouTube yang dapat disematkan.",
+				"embedVideo": "Sematkan video",
+				"keepAsLink": "Biarkan sebagai tautan",
+				"hintTab": "Tab",
+				"hintEsc": "Esc",
+				"pasteUrl": "Tempel URL",
+				"asLink": "Sebagai tautan",
+				"embed": "Sematkan",
+				"noCommands": "Tidak ada perintah",
+				"ariaCommentContent": "Konten komentar",
+				"ariaCommentEditor": "Editor komentar",
+				"ariaCopyCode": "Salin kode",
+				"ariaCopied": "Disalin",
+				"copy": "Salin",
+				"copied": "Disalin",
+				"dropImageToUpload": "Lepaskan gambar untuk mengunggah",
+				"previewImageAlt": "Pratinjau gambar",
+				"codeLang": {
+					"bash": "Bash",
+					"csharp": "C#",
+					"cpp": "C++",
+					"css": "CSS",
+					"go": "Golang",
+					"graphql": "GraphQL",
+					"html": "HTML",
+					"json": "JSON",
+					"java": "Java",
+					"javascript": "JavaScript",
+					"markdown": "Markdown",
+					"plaintext": "Teks biasa",
+					"python": "Python",
+					"rust": "Rust",
+					"sql": "SQL",
+					"swift": "Swift",
+					"typescript": "TypeScript",
+					"yaml": "YAML"
+				}
+			}
+		}
+	},
+	"tasks": {
+		"status": {
+			"label": "Status",
+			"to-do": "Perlu Dikerjakan",
+			"in-progress": "Sedang Berjalan",
+			"in-review": "Dalam Review",
+			"done": "Selesai",
+			"archived": "Diarsipkan",
+			"planned": "Direncanakan"
+		},
+		"priority": {
+			"label": "Prioritas",
+			"no-priority": "Tanpa prioritas",
+			"low": "Rendah",
+			"medium": "Sedang",
+			"high": "Tinggi",
+			"urgent": "Mendesak"
+		},
+		"boardSearchPlaceholder": "Cari tiket...",
+		"view": {
+			"board": "Papan",
+			"list": "Daftar"
+		},
+		"common": {
+			"selectTask": "Pilih tugas",
+			"loadingTask": "Memuat tugas...",
+			"taskNotFound": "Tugas tidak ditemukan",
+			"taskNotFoundDescription": "Tugas yang Anda cari tidak ada atau telah dihapus."
+		},
+		"detail": {
+			"subtaskOf": "Subtugas dari",
+			"activity": "Aktivitas",
+			"noActivity": "Tidak ada aktivitas ditemukan",
+			"openInFullPage": "Buka di halaman penuh",
+			"titlePlaceholder": "Klik untuk menambahkan judul",
+			"addDescription": "Tambahkan deskripsi...",
+			"editor": {
+				"ariaLabel": "Editor deskripsi tugas",
+				"placeholder": "Tulis deskripsi...",
+				"previewImage": "Pratinjau gambar",
+				"enterUrl": "Masukkan URL",
+				"autoDetect": "Deteksi otomatis",
+				"copyCode": "Salin kode",
+				"copy": "Salin",
+				"copied": "Disalin",
+				"attachFile": "Lampirkan file",
+				"dropToUpload": "Lepaskan gambar untuk mengunggah",
+				"checkbox": {
+					"markIncomplete": "Tandai tugas belum selesai",
+					"markComplete": "Tandai tugas selesai"
+				},
+				"upload": {
+					"loading": "Mengunggah file...",
+					"failed": "Gagal mengunggah file",
+					"imageSuccess": "Gambar diunggah",
+					"fileSuccess": "File dilampirkan"
+				},
+				"slash": {
+					"groups": {
+						"text": "Teks",
+						"lists": "Daftar",
+						"insert": "Sisipkan"
+					},
+					"empty": "Tidak ada perintah",
+					"commands": {
+						"paragraph": "Teks",
+						"heading-2": "Heading",
+						"bullet-list": "Daftar berpoin",
+						"task-list": "Daftar tugas",
+						"ordered-list": "Daftar bernomor",
+						"blockquote": "Kutipan",
+						"code-block": "Blok kode",
+						"table": "Tabel",
+						"file": "File"
+					}
+				},
+				"languages": {
+					"bash": "Bash",
+					"csharp": "C#",
+					"cpp": "C++",
+					"css": "CSS",
+					"clojure": "Clojure",
+					"cypher": "Cypher",
+					"dart": "Dart",
+					"diff": "Diff",
+					"elixir": "Elixir",
+					"excel": "Excel",
+					"go": "Golang",
+					"graphql": "GraphQL",
+					"html": "HTML",
+					"haskell": "Haskell",
+					"json": "JSON",
+					"java": "Java",
+					"javascript": "JavaScript",
+					"kotlin": "Kotlin",
+					"makefile": "Makefile",
+					"markdown": "Markdown",
+					"ocaml": "OCaml",
+					"php": "PHP",
+					"perl": "Perl",
+					"plaintext": "Plaintext",
+					"python": "Python",
+					"r": "R",
+					"reasonml": "ReasonML",
+					"ruby": "Ruby",
+					"rust": "Rust",
+					"sql": "SQL",
+					"swift": "Swift",
+					"toml": "TOML",
+					"terraform": "Terraform",
+					"typescript": "TypeScript",
+					"xml": "XML",
+					"yaml": "YAML"
+				},
+				"embed": {
+					"choice": {
+						"embedVideo": "Sematkan video",
+						"keepAsLink": "Biarkan sebagai tautan"
+					},
+					"inputPlaceholder": "Tempel URL",
+					"embeddedContent": "Konten disematkan",
+					"asLink": "Sebagai tautan",
+					"submit": "Sematkan",
+					"errors": {
+						"invalidUrl": "Masukkan URL yang valid",
+						"onlyYoutube": "Hanya tautan YouTube yang dapat disematkan."
+					},
+					"onlyYoutubeInline": "Hanya URL YouTube yang dapat disematkan. Gunakan mode tautan."
+				}
+			}
+		},
+		"entity": {
+			"task": "Tugas"
+		},
+		"relations": {
+			"title": "Relasi",
+			"tasksInProject": "Tugas dalam proyek",
+			"linkError": "Gagal menautkan tugas",
+			"empty": "Tidak ada tugas terkait",
+			"searchPlaceholder": "Cari tugas untuk ditautkan...",
+			"noTasksFound": "Tugas tidak ditemukan",
+			"openTask": "Buka tugas",
+			"removeRelation": "Hapus relasi",
+			"related": "Terkait",
+			"blocks": "Memblokir",
+			"selectTask": "Pilih tugas untuk ditautkan",
+			"types": {
+				"blocks": "memblokir",
+				"blocked_by": "diblokir oleh",
+				"related": "terkait dengan"
+			}
+		},
+		"subtasks": {
+			"title": "Subtugas",
+			"inputPlaceholder": "Judul subtugas...",
+			"addAction": "Tambah",
+			"empty": "Belum ada subtugas",
+			"createError": "Gagal membuat subtugas",
+			"deleteSuccess": "Tugas berhasil dihapus",
+			"deleteError": "Gagal menghapus tugas",
+			"deleteDialogTitle": "Hapus Tugas?",
+			"deleteDialogDescription": "Ini akan menghapus tugas dan semua datanya secara permanen. Anda tidak dapat membatalkan tindakan ini.",
+			"deleteAction": "Hapus Tugas"
+		},
+		"properties": {
+			"title": "Properti",
+			"labels": "Label",
+			"copyTaskLink": "Salin tautan tugas",
+			"copyTaskBranch": "Salin branch tugas",
+			"start": "Mulai",
+			"startDate": "Tanggal mulai",
+			"noDate": "Tanpa tanggal"
+		},
+		"move": {
+			"title": "Pindahkan tugas",
+			"projectLabel": "Proyek tujuan",
+			"projectPlaceholder": "Pilih proyek",
+			"statusLabel": "Status tujuan",
+			"statusHintKeep": "Alur kerja proyek ini sudah mendukung status saat ini.",
+			"statusHintAdjust": "Pilih status yang akan digunakan di proyek tujuan.",
+			"action": "Pindahkan tugas",
+			"success": "Tugas berhasil dipindahkan",
+			"error": "Gagal memindahkan tugas"
+		},
+		"popover": {
+			"assignee": {
+				"unassigned": "Belum ditugaskan",
+				"updateError": "Gagal memperbarui penanggung jawab tugas"
+			},
+			"status": {
+				"updateError": "Gagal memperbarui status tugas"
+			},
+			"priority": {
+				"updateError": "Gagal memperbarui prioritas tugas"
+			},
+			"dueDate": {
+				"updateSuccess": "Tenggat tugas berhasil diperbarui",
+				"updateError": "Gagal memperbarui tenggat tugas",
+				"clear": "Hapus tanggal"
+			},
+			"startDate": {
+				"updateSuccess": "Tanggal mulai tugas berhasil diperbarui",
+				"updateError": "Gagal memperbarui tanggal mulai tugas",
+				"clear": "Hapus tanggal mulai"
+			},
+			"labels": {
+				"searchPlaceholder": "Cari label...",
+				"empty": "Label tidak ditemukan",
+				"create": "Buat \"{{name}}\"",
+				"chooseColor": "Pilih warna",
+				"addSuccess": "Label ditambahkan",
+				"removeSuccess": "Label dihapus",
+				"updateError": "Gagal memperbarui label",
+				"createSuccess": "Label dibuat dan ditambahkan",
+				"createError": "Gagal membuat label",
+				"colors": {
+					"stone": "Batu",
+					"slate": "Slate",
+					"lavender": "Lavender",
+					"sage": "Sage",
+					"forest": "Forest",
+					"amber": "Amber",
+					"terracotta": "Terracotta",
+					"rose": "Rose",
+					"crimson": "Crimson"
+				}
+			}
+		},
+		"backlog": {
+			"pageTitle": "Backlog {{name}}",
+			"noTasksToMove": "Tidak ada tugas terencana untuk dipindahkan",
+			"moveAllConfirm": "Pindahkan semua {{count}} tugas terencana ke Perlu Dikerjakan?",
+			"moveAllSuccess": "Memindahkan {{count}} tugas ke Perlu Dikerjakan",
+			"plan": "Rencanakan",
+			"moveAllTooltip": "Pindahkan Semua yang Direncanakan ke Perlu Dikerjakan",
+			"moveAll": "Pindahkan Semua",
+			"addTask": "Tambah tugas",
+			"filter": "Filter",
+			"addFilter": "Tambah filter...",
+			"sections": {
+				"planned": "Direncanakan",
+				"archived": "Diarsipkan"
+			},
+			"noTasksInSection": "Tidak ada tugas {{section}}",
+			"filters": {
+				"priority": "Prioritas: {{name}}",
+				"assignee": "Penanggung jawab: {{name}}",
+				"due": "Tenggat: {{date}}",
+				"label": "Label: {{name}}",
+				"dueThisWeek": "Tenggat minggu ini",
+				"dueNextWeek": "Tenggat minggu depan",
+				"noDueDate": "Tanpa tenggat"
+			}
+		},
+		"sort": {
+			"label": "Urutkan",
+			"by": "Urutkan Berdasarkan",
+			"direction": "Arah",
+			"ascending": "Naik",
+			"descending": "Turun",
+			"fields": {
+				"position": "Manual (posisi)",
+				"createdAt": "Tanggal dibuat",
+				"priority": "Prioritas",
+				"dueDate": "Tenggat",
+				"title": "Judul",
+				"number": "Nomor tugas"
+			}
+		},
+		"boardFilters": {
+			"filterBy": "Filter Berdasarkan",
+			"allStatuses": "Semua status",
+			"allPriorities": "Semua prioritas",
+			"allAssignees": "Semua penanggung jawab",
+			"allDueDates": "Semua tenggat",
+			"allLabels": "Semua label",
+			"selectedCount": "{{count}} dipilih",
+			"subjects": {
+				"status": "Status",
+				"priority": "Prioritas",
+				"assignee": "Penanggung jawab",
+				"dueDate": "Tenggat",
+				"labels": "Label"
+			},
+			"operators": {
+				"isAnyOf": "adalah salah satu dari",
+				"includeAnyOf": "menyertakan salah satu dari"
+			}
+		},
+		"gantt": {
+			"pageTitle": "{{name}} — Gantt",
+			"title": "Linimasa Gantt",
+			"searchPlaceholder": "Cari tiket terjadwal...",
+			"hideTasks": "Sembunyikan tugas",
+			"showTasks": "Tampilkan tugas",
+			"noTasks": "Tidak ada tugas terjadwal",
+			"noTasksSubtitle": "Tambahkan tanggal mulai, tenggat, atau keduanya ke tugas untuk menempatkannya di linimasa proyek.",
+			"noTasksFound": "Tugas tidak ditemukan",
+			"noTasksMatch": "Tidak ada tugas terjadwal yang cocok dengan \"{{query}}\"",
+			"taskHeader": "Tugas",
+			"updateDatesError": "Gagal memperbarui tanggal tugas",
+			"resizeStart": "Ubah ukuran tanggal mulai",
+			"resizeDue": "Ubah ukuran tenggat",
+			"taskAriaLabel": "{{title}} — buka atau seret untuk memindahkan"
+		},
+		"delete": {
+			"title": "Hapus Tugas?",
+			"description": "Ini akan menghapus tugas dan semua datanya secara permanen. Anda tidak dapat membatalkan tindakan ini.",
+			"action": "Hapus Tugas",
+			"success": "Tugas berhasil dihapus",
+			"error": "Gagal menghapus tugas"
+		},
+		"archive": {
+			"success": "{{count}} tugas diarsipkan"
+		},
+		"listView": {
+			"addTask": "Tambah tugas",
+			"archiveAllTooltip": "Arsipkan semua tugas yang selesai",
+			"noTasks": "Tidak ada tugas"
+		},
+		"kanban": {
+			"addTask": "Tambah tugas"
+		},
+		"pr": {
+			"merged": "Digabung",
+			"draft": "Draf",
+			"open": "Terbuka",
+			"label": "Pull Request",
+			"count_one": "{{count}} PR",
+			"count_other": "{{count}} PR"
+		},
+		"assignee": {
+			"label": "Penanggung jawab",
+			"unassigned": "Belum ditugaskan"
+		},
+		"dueDate": {
+			"label": "Tenggat",
+			"clear": "Hapus tanggal",
+			"updateSuccess": "Tenggat tugas berhasil diperbarui",
+			"updateError": "Gagal memperbarui tenggat tugas",
+			"clearSuccess": "Tenggat tugas dihapus",
+			"clearError": "Gagal menghapus tenggat"
+		},
+		"labels": {
+			"label": "Label",
+			"empty": "Tidak ada label tersedia"
+		},
+		"update": {
+			"success": "Tugas berhasil diperbarui",
+			"error": "Gagal memperbarui tugas"
+		},
+		"contextMenu": {
+			"copyLink": "Salin tautan",
+			"copyLinkSuccess": "Tautan tugas disalin!"
+		},
+		"actions": {
+			"archive": "Arsipkan",
+			"markAsPlanned": "Tandai sebagai direncanakan",
+			"delete": "Hapus..."
+		},
+		"bulk": {
+			"selectedCount": "{{count}} dipilih",
+			"moveToBacklog": "Pindahkan ke Backlog",
+			"moveToBacklogSuccess": "{{count}} tugas dipindahkan ke backlog",
+			"moveToBacklogError": "Gagal memindahkan tugas ke backlog",
+			"moveToBoard": "Pindahkan ke Papan",
+			"moveToBoardSuccess": "{{count}} tugas dipindahkan ke papan",
+			"moveToBoardError": "Gagal memindahkan tugas ke papan",
+			"delete": "Hapus tugas",
+			"deleteConfirm": "Hapus {{count}} tugas? Tindakan ini tidak dapat dibatalkan.",
+			"deleteSuccess": "{{count}} tugas dihapus",
+			"deleteError": "Gagal menghapus tugas",
+			"archive": "Arsipkan tugas",
+			"archiveSuccess": "{{count}} tugas diarsipkan",
+			"archiveError": "Gagal mengarsipkan tugas",
+			"updateSuccess": "{{count}} tugas diperbarui",
+			"updateError": "Gagal memperbarui tugas",
+			"assignTo": "Tugaskan ke",
+			"assignSuccess": "{{count}} tugas ditugaskan",
+			"assignError": "Gagal menugaskan tugas",
+			"setPriority": "Atur Prioritas",
+			"updatePriorityError": "Gagal memperbarui prioritas",
+			"addLabel": "Tambah Label",
+			"addLabelSuccess": "Label ditambahkan ke {{count}} tugas",
+			"addLabelError": "Gagal menambahkan label",
+			"setDueDate": "Atur Tenggat",
+			"updateDueDateError": "Gagal memperbarui tenggat",
+			"actions": "Aksi",
+			"searchActions": "Cari aksi...",
+			"noActionsFound": "Tidak ada aksi ditemukan.",
+			"changeStatus": "Ubah Status"
+		}
+	},
+	"invitations": {
+		"pageTitle": "Undangan",
+		"pendingInvitations": "Undangan Tertunda",
+		"acceptSubtitle": "Terima undangan untuk bergabung ke ruang kerja",
+		"noPendingTitle": "Tidak ada undangan tertunda",
+		"noPendingDescription": "Saat ini Anda tidak memiliki undangan ruang kerja yang tertunda.",
+		"continueToSetup": "Lanjutkan ke Penyiapan",
+		"skipForNow": "Lewati dulu",
+		"table": {
+			"workspace": "Ruang kerja",
+			"invitedBy": "Diundang Oleh",
+			"expires": "Kedaluwarsa"
+		},
+		"toast": {
+			"acceptError": "Gagal menerima undangan",
+			"acceptSuccess": "Undangan diterima! Selamat bergabung dengan tim.",
+			"rejectError": "Gagal menolak undangan",
+			"rejectSuccess": "Undangan ditolak"
+		}
+	},
+	"workspace": {
+		"projects": {
+			"pageTitle": "Proyek",
+			"createProject": "Buat proyek",
+			"title": "Judul",
+			"progress": "Progres",
+			"targetDate": "Tanggal target",
+			"dueDate": "Tenggat",
+			"status": "Status",
+			"emptyTitle": "Belum ada proyek",
+			"emptyDescription": "Mulai dengan membuat proyek pertama Anda.",
+			"emptyDescriptionReadOnly": "Belum ada proyek di ruang kerja ini. Minta admin untuk membuatnya.",
+			"projectStatus": {
+				"notStarted": "Belum dimulai",
+				"complete": "Selesai",
+				"inProgress": "Sedang berjalan"
+			},
+			"noDueDate": "Tanpa tenggat"
+		},
+		"search": {
+			"pageTitle": "Cari",
+			"backToDashboard": "Kembali ke Dasbor",
+			"placeholder": "Cari tugas berdasarkan judul atau ID pendek (mis. DEP-23)...",
+			"hint": "Cari di semua proyek dalam ruang kerja ini. Gunakan ID pendek seperti DEP-23 untuk menemukan tugas tertentu.",
+			"searching": "Mencari...",
+			"resultsFound_one": "{{count}} hasil ditemukan",
+			"resultsFound_other": "{{count}} hasil ditemukan",
+			"noResultsTitle": "Tidak ada hasil ditemukan",
+			"noResultsDescription": "Coba sesuaikan kata pencarian atau cari hal lain",
+			"startTitle": "Mulai Mencari",
+			"startDescription": "Masukkan kata pencarian untuk menemukan tugas di semua proyek",
+			"quickSearchesLabel": "Pencarian cepat:",
+			"suggestionHighPriority": "Prioritas tinggi",
+			"suggestionBug": "Bug",
+			"suggestionFeature": "Fitur",
+			"suggestionInProgress": "Sedang berjalan",
+			"suggestionCompleted": "Selesai"
+		},
+		"create": {
+			"pageTitle": "Buat Ruang Kerja",
+			"heading": "Buat ruang kerja baru",
+			"subtitle": "Ruang kerja adalah lingkungan bersama tempat tim dapat bekerja pada proyek, siklus, dan issue.",
+			"nameLabel": "Nama Ruang Kerja",
+			"namePlaceholder": "Masukkan nama ruang kerja",
+			"descriptionLabel": "Deskripsi (opsional)",
+			"descriptionPlaceholder": "Tambahkan deskripsi untuk ruang kerja Anda",
+			"required": "Wajib",
+			"creating": "Membuat...",
+			"submit": "Buat ruang kerja",
+			"success": "Ruang kerja berhasil dibuat",
+			"error": "Gagal membuat ruang kerja"
+		}
+	},
+	"team": {
+		"roles": {
+			"owner": "Pemilik",
+			"admin": "Admin",
+			"member": "Anggota",
+			"viewer": "Lihat Saja"
+		},
+		"members": {
+			"pageTitle": "Anggota",
+			"inviteMember": "Undang anggota"
+		},
+		"inviteModal": {
+			"title": "Undang Anggota Tim",
+			"emailLabel": "Email",
+			"emailPlaceholder": "rekan@perusahaan.com",
+			"sendInvitation": "Kirim Undangan",
+			"success": "Undangan berhasil dikirim",
+			"error": "Gagal mengundang anggota tim"
+		},
+		"membersTable": {
+			"emptyTitle": "Belum ada anggota tim",
+			"emptyDescription": "Undang anggota tim pertama Anda untuk memulai.",
+			"columns": {
+				"name": "Nama",
+				"role": "Peran",
+				"joined": "Bergabung",
+				"actions": "Aksi"
+			},
+			"memberRolePending": "{{role}} (Tertunda)",
+			"ariaCancelInvitation": "Batalkan undangan",
+			"ariaRemoveMember": "Hapus anggota",
+			"removeDialogTitle": "Hapus Anggota Tim?",
+			"removeDialogDescription": "Apakah Anda yakin ingin menghapus {{name}} dari ruang kerja? Tindakan ini tidak dapat dibatalkan.",
+			"cancelDialogTitle": "Batalkan Undangan?",
+			"cancelDialogDescription": "Apakah Anda yakin ingin membatalkan undangan untuk {{email}}? Tindakan ini tidak dapat dibatalkan.",
+			"removeMember": "Hapus Anggota",
+			"cancelInvitation": "Batalkan Undangan",
+			"removeSuccess": "Anggota tim berhasil dihapus",
+			"removeError": "Gagal menghapus anggota tim",
+			"cancelInviteSuccess": "Undangan berhasil dibatalkan",
+			"cancelInviteError": "Gagal membatalkan undangan",
+			"roleUpdateSuccess": "Peran diperbarui",
+			"roleUpdateError": "Gagal memperbarui peran"
+		}
+	},
+	"publicProject": {
+		"pageTitle": "Tampilan Publik",
+		"badge": "Publik",
+		"readOnly": "Hanya baca",
+		"error": {
+			"title": "Proyek Tidak Ditemukan",
+			"description": "Proyek ini tidak ada atau tidak dapat diakses publik."
+		},
+		"taskCard": {
+			"viewDetailsAria": "Lihat detail tugas {{title}}"
+		},
+		"taskDetail": {
+			"labels": "Label",
+			"externalLinks": "Tautan Eksternal",
+			"pullRequestFallback": "Pull Request",
+			"issueFallback": "Issue",
+			"prStatusMerged": "Digabung",
+			"prStatusDraft": "Draf",
+			"prStatusOpen": "Terbuka",
+			"dueWithDate": "Tenggat {{date}}",
+			"created": "Dibuat",
+			"dueDateLabel": "Tenggat"
+		},
+		"theme": {
+			"switchToLight": "Beralih ke mode terang",
+			"switchToDark": "Beralih ke mode gelap"
+		},
+		"copyUrl": {
+			"successToast": "URL disalin",
+			"errorToast": "Gagal menyalin URL",
+			"copied": "Disalin",
+			"share": "Bagikan"
+		},
+		"branding": {
+			"poweredBy": "Didukung oleh"
+		}
+	}
+}

--- a/i18n/resources.ts
+++ b/i18n/resources.ts
@@ -3,6 +3,7 @@ import elGR from "./el-GR.json";
 import enUS from "./en-US.json";
 import esES from "./es-ES.json";
 import frFR from "./fr-FR.json";
+import idID from "./id-ID.json";
 import koKR from "./ko-KR.json";
 import mkMK from "./mk-MK.json";
 import nlNL from "./nl-NL.json";
@@ -17,6 +18,7 @@ export const supportedLocales = [
   "en-US",
   "es-ES",
   "fr-FR",
+  "id-ID",
   "ko-KR",
   "ru-RU",
   "uk-UA",
@@ -33,6 +35,7 @@ export const resources = {
   "de-DE": deDE,
   "el-GR": elGR,
   "fr-FR": frFR,
+  "id-ID": idID,
   "es-ES": esES,
   "ko-KR": koKR,
   "ru-RU": ruRU,

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -157,11 +157,26 @@
 						"french": {
 							"type": "string"
 						},
+						"spanish": {
+							"type": "string"
+						},
+						"dutch": {
+							"type": "string"
+						},
 						"korean": {
 							"type": "string"
 						}
 					},
-					"required": ["english", "german", "greek", "macedonian", "french"]
+					"required": [
+						"english",
+						"german",
+						"greek",
+						"macedonian",
+						"french",
+						"spanish",
+						"dutch",
+						"korean"
+					]
 				},
 				"people": {
 					"type": "object",
@@ -572,6 +587,22 @@
 						},
 						"discordError": {
 							"type": "string"
+						},
+						"errors": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"oauth_code_verification_failed": {
+									"type": "string"
+								},
+								"registration_is_currently_disabled_you_need_a_valid_invitation_to_create_an_account_": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"oauth_code_verification_failed",
+								"registration_is_currently_disabled_you_need_a_valid_invitation_to_create_an_account_"
+							]
 						}
 					},
 					"required": [
@@ -595,7 +626,8 @@
 						"oidcError",
 						"googleError",
 						"githubError",
-						"discordError"
+						"discordError",
+						"errors"
 					]
 				},
 				"providers": {
@@ -2154,6 +2186,485 @@
 						"validation"
 					]
 				},
+				"workspaceRoles": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"pageTitle": {
+							"type": "string"
+						},
+						"title": {
+							"type": "string"
+						},
+						"subtitle": {
+							"type": "string"
+						},
+						"thisWorkspace": {
+							"type": "string"
+						},
+						"noAccess": {
+							"type": "string"
+						},
+						"sectionTitle": {
+							"type": "string"
+						},
+						"sectionSubtitle": {
+							"type": "string"
+						},
+						"newRole": {
+							"type": "string"
+						},
+						"loading": {
+							"type": "string"
+						},
+						"loadError": {
+							"type": "string"
+						},
+						"emptyTitle": {
+							"type": "string"
+						},
+						"emptyDescription": {
+							"type": "string"
+						},
+						"defaultBadge": {
+							"type": "string"
+						},
+						"permissionCount_one": {
+							"type": "string"
+						},
+						"permissionCount_other": {
+							"type": "string"
+						},
+						"nameLabel": {
+							"type": "string"
+						},
+						"nameHint": {
+							"type": "string"
+						},
+						"namePlaceholder": {
+							"type": "string"
+						},
+						"discard": {
+							"type": "string"
+						},
+						"createRole": {
+							"type": "string"
+						},
+						"deleteRole": {
+							"type": "string"
+						},
+						"defaultRoleHelp": {
+							"type": "string"
+						},
+						"unsavedChanges": {
+							"type": "string"
+						},
+						"allChangesSaved": {
+							"type": "string"
+						},
+						"saveChanges": {
+							"type": "string"
+						},
+						"defaultRoleDescriptions": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"viewer": {
+									"type": "string"
+								},
+								"member": {
+									"type": "string"
+								},
+								"admin": {
+									"type": "string"
+								}
+							},
+							"required": ["viewer", "member", "admin"]
+						},
+						"resources": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"project": {
+									"type": "string"
+								},
+								"task": {
+									"type": "string"
+								},
+								"label": {
+									"type": "string"
+								},
+								"workspace": {
+									"type": "string"
+								}
+							},
+							"required": ["project", "task", "label", "workspace"]
+						},
+						"permissions": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"project": {
+									"type": "object",
+									"additionalProperties": false,
+									"properties": {
+										"create": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"read": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"update": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"delete": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"share": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										}
+									},
+									"required": ["create", "read", "update", "delete", "share"]
+								},
+								"task": {
+									"type": "object",
+									"additionalProperties": false,
+									"properties": {
+										"create": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"read": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"update": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"delete": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"assign": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										}
+									},
+									"required": ["create", "read", "update", "delete", "assign"]
+								},
+								"label": {
+									"type": "object",
+									"additionalProperties": false,
+									"properties": {
+										"create": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"read": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"update": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"delete": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										}
+									},
+									"required": ["create", "read", "update", "delete"]
+								},
+								"workspace": {
+									"type": "object",
+									"additionalProperties": false,
+									"properties": {
+										"read": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"update": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"delete": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										},
+										"manage_settings": {
+											"type": "object",
+											"additionalProperties": false,
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												}
+											},
+											"required": ["label", "description"]
+										}
+									},
+									"required": ["read", "update", "delete", "manage_settings"]
+								}
+							},
+							"required": ["project", "task", "label", "workspace"]
+						},
+						"validation": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"nameRequired": {
+									"type": "string"
+								},
+								"nameExists": {
+									"type": "string"
+								},
+								"permissionRequired": {
+									"type": "string"
+								}
+							},
+							"required": ["nameRequired", "nameExists", "permissionRequired"]
+						},
+						"toast": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"created": {
+									"type": "string"
+								},
+								"createError": {
+									"type": "string"
+								},
+								"updated": {
+									"type": "string"
+								},
+								"updateError": {
+									"type": "string"
+								},
+								"deleted": {
+									"type": "string"
+								},
+								"deleteError": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"created",
+								"createError",
+								"updated",
+								"updateError",
+								"deleted",
+								"deleteError"
+							]
+						},
+						"deleteDialog": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"description": {
+									"type": "string"
+								}
+							},
+							"required": ["title", "description"]
+						}
+					},
+					"required": [
+						"pageTitle",
+						"title",
+						"subtitle",
+						"thisWorkspace",
+						"noAccess",
+						"sectionTitle",
+						"sectionSubtitle",
+						"newRole",
+						"loading",
+						"loadError",
+						"emptyTitle",
+						"emptyDescription",
+						"defaultBadge",
+						"permissionCount_one",
+						"permissionCount_other",
+						"nameLabel",
+						"nameHint",
+						"namePlaceholder",
+						"discard",
+						"createRole",
+						"deleteRole",
+						"defaultRoleHelp",
+						"unsavedChanges",
+						"allChangesSaved",
+						"saveChanges",
+						"defaultRoleDescriptions",
+						"resources",
+						"permissions",
+						"validation",
+						"toast",
+						"deleteDialog"
+					]
+				},
 				"projectGeneral": {
 					"type": "object",
 					"additionalProperties": false,
@@ -2276,6 +2787,12 @@
 								"keyMax",
 								"iconRequired"
 							]
+						},
+						"importExportTasks": {
+							"type": "string"
+						},
+						"importExportTasksDescription": {
+							"type": "string"
 						}
 					},
 					"required": [
@@ -2308,7 +2825,9 @@
 						"toastUpdateError",
 						"toastDeleted",
 						"toastDeleteError",
-						"validation"
+						"validation",
+						"importExportTasks",
+						"importExportTasksDescription"
 					]
 				},
 				"projectIntegrations": {
@@ -2330,6 +2849,12 @@
 						"githubSectionSubtitle": {
 							"type": "string"
 						},
+						"giteaSectionTitle": {
+							"type": "string"
+						},
+						"giteaSectionSubtitle": {
+							"type": "string"
+						},
 						"discordSectionTitle": {
 							"type": "string"
 						},
@@ -2347,6 +2872,12 @@
 						},
 						"slackSectionSubtitle": {
 							"type": "string"
+						},
+						"telegramSectionTitle": {
+							"type": "string"
+						},
+						"telegramSectionSubtitle": {
+							"type": "string"
 						}
 					},
 					"required": [
@@ -2355,12 +2886,16 @@
 						"subtitle",
 						"githubSectionTitle",
 						"githubSectionSubtitle",
+						"giteaSectionTitle",
+						"giteaSectionSubtitle",
 						"discordSectionTitle",
 						"discordSectionSubtitle",
 						"genericWebhookSectionTitle",
 						"genericWebhookSectionSubtitle",
 						"slackSectionTitle",
-						"slackSectionSubtitle"
+						"slackSectionSubtitle",
+						"telegramSectionTitle",
+						"telegramSectionSubtitle"
 					]
 				},
 				"projectVisibility": {
@@ -2497,6 +3032,9 @@
 						"toastUpdateError": {
 							"type": "string"
 						},
+						"toastIconUpdated": {
+							"type": "string"
+						},
 						"toastDeleted": {
 							"type": "string"
 						},
@@ -2504,6 +3042,12 @@
 							"type": "string"
 						},
 						"loading": {
+							"type": "string"
+						},
+						"pickIconTitle": {
+							"type": "string"
+						},
+						"searchIconsPlaceholder": {
 							"type": "string"
 						},
 						"doneColumnTooltip": {
@@ -2536,9 +3080,12 @@
 						"toastFinalOn",
 						"toastFinalOff",
 						"toastUpdateError",
+						"toastIconUpdated",
 						"toastDeleted",
 						"toastDeleteError",
 						"loading",
+						"pickIconTitle",
+						"searchIconsPlaceholder",
 						"doneColumnTooltip",
 						"doneColumn",
 						"markDoneAria",
@@ -2792,6 +3339,304 @@
 						"importing",
 						"importIssues",
 						"importDisabledHint"
+					]
+				},
+				"giteaIntegration": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"validation": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"baseUrlRequired": {
+									"type": "string"
+								},
+								"baseUrlInvalid": {
+									"type": "string"
+								},
+								"ownerRequired": {
+									"type": "string"
+								},
+								"ownerInvalid": {
+									"type": "string"
+								},
+								"nameRequired": {
+									"type": "string"
+								},
+								"nameInvalid": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"baseUrlRequired",
+								"baseUrlInvalid",
+								"ownerRequired",
+								"ownerInvalid",
+								"nameRequired",
+								"nameInvalid"
+							]
+						},
+						"toast": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"verifyOk": {
+									"type": "string"
+								},
+								"verifyWarning": {
+									"type": "string"
+								},
+								"repoNotFound": {
+									"type": "string"
+								},
+								"verifyError": {
+									"type": "string"
+								},
+								"tokenRequired": {
+									"type": "string"
+								},
+								"tokenRequiredVerify": {
+									"type": "string"
+								},
+								"verifyFirst": {
+									"type": "string"
+								},
+								"updated": {
+									"type": "string"
+								},
+								"updateError": {
+									"type": "string"
+								},
+								"removed": {
+									"type": "string"
+								},
+								"removeError": {
+									"type": "string"
+								},
+								"issuesImported": {
+									"type": "string"
+								},
+								"importError": {
+									"type": "string"
+								},
+								"commentOnEnabled": {
+									"type": "string"
+								},
+								"commentOnDisabled": {
+									"type": "string"
+								},
+								"settingsUpdateError": {
+									"type": "string"
+								},
+								"secretCopied": {
+									"type": "string"
+								},
+								"unableToCopySecret": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"verifyOk",
+								"verifyWarning",
+								"repoNotFound",
+								"verifyError",
+								"tokenRequired",
+								"tokenRequiredVerify",
+								"verifyFirst",
+								"updated",
+								"updateError",
+								"removed",
+								"removeError",
+								"issuesImported",
+								"importError",
+								"commentOnEnabled",
+								"commentOnDisabled",
+								"settingsUpdateError",
+								"secretCopied",
+								"unableToCopySecret"
+							]
+						},
+						"webhookShow": {
+							"type": "string"
+						},
+						"webhookHide": {
+							"type": "string"
+						},
+						"webhookCopy": {
+							"type": "string"
+						},
+						"connectionStatus": {
+							"type": "string"
+						},
+						"connectedActive": {
+							"type": "string"
+						},
+						"notConnectedHint": {
+							"type": "string"
+						},
+						"badgeConnected": {
+							"type": "string"
+						},
+						"badgeNotConnected": {
+							"type": "string"
+						},
+						"repository": {
+							"type": "string"
+						},
+						"repositoryHint": {
+							"type": "string"
+						},
+						"commentTaskLinkTitle": {
+							"type": "string"
+						},
+						"commentTaskLinkHint": {
+							"type": "string"
+						},
+						"webhookTitle": {
+							"type": "string"
+						},
+						"webhookHint": {
+							"type": "string"
+						},
+						"webhookSecretLabel": {
+							"type": "string"
+						},
+						"baseUrlLabel": {
+							"type": "string"
+						},
+						"baseUrlHint": {
+							"type": "string"
+						},
+						"tokenLabel": {
+							"type": "string"
+						},
+						"tokenHint": {
+							"type": "string"
+						},
+						"tokenPlaceholder": {
+							"type": "string"
+						},
+						"tokenPlaceholderUpdate": {
+							"type": "string"
+						},
+						"currentToken": {
+							"type": "string"
+						},
+						"ownerLabel": {
+							"type": "string"
+						},
+						"ownerHint": {
+							"type": "string"
+						},
+						"repoNameLabel": {
+							"type": "string"
+						},
+						"repoNameHint": {
+							"type": "string"
+						},
+						"actionsTitle": {
+							"type": "string"
+						},
+						"actionsHint": {
+							"type": "string"
+						},
+						"browse": {
+							"type": "string"
+						},
+						"verify": {
+							"type": "string"
+						},
+						"update": {
+							"type": "string"
+						},
+						"connect": {
+							"type": "string"
+						},
+						"disconnect": {
+							"type": "string"
+						},
+						"importSectionTitle": {
+							"type": "string"
+						},
+						"importSectionHint": {
+							"type": "string"
+						},
+						"importing": {
+							"type": "string"
+						},
+						"importIssues": {
+							"type": "string"
+						},
+						"importDisabledHint": {
+							"type": "string"
+						},
+						"browseModalTitle": {
+							"type": "string"
+						},
+						"browseModalHint": {
+							"type": "string"
+						},
+						"searchRepos": {
+							"type": "string"
+						},
+						"browseNeedsCredentials": {
+							"type": "string"
+						},
+						"loadingRepos": {
+							"type": "string"
+						},
+						"retry": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"validation",
+						"toast",
+						"webhookShow",
+						"webhookHide",
+						"webhookCopy",
+						"connectionStatus",
+						"connectedActive",
+						"notConnectedHint",
+						"badgeConnected",
+						"badgeNotConnected",
+						"repository",
+						"repositoryHint",
+						"commentTaskLinkTitle",
+						"commentTaskLinkHint",
+						"webhookTitle",
+						"webhookHint",
+						"webhookSecretLabel",
+						"baseUrlLabel",
+						"baseUrlHint",
+						"tokenLabel",
+						"tokenHint",
+						"tokenPlaceholder",
+						"tokenPlaceholderUpdate",
+						"currentToken",
+						"ownerLabel",
+						"ownerHint",
+						"repoNameLabel",
+						"repoNameHint",
+						"actionsTitle",
+						"actionsHint",
+						"browse",
+						"verify",
+						"update",
+						"connect",
+						"disconnect",
+						"importSectionTitle",
+						"importSectionHint",
+						"importing",
+						"importIssues",
+						"importDisabledHint",
+						"browseModalTitle",
+						"browseModalHint",
+						"searchRepos",
+						"browseNeedsCredentials",
+						"loadingRepos",
+						"retry"
 					]
 				},
 				"slackIntegration": {
@@ -3253,6 +4098,193 @@
 						"disconnect"
 					]
 				},
+				"telegramIntegration": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"validation": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"botTokenInvalid": {
+									"type": "string"
+								},
+								"chatIdRequired": {
+									"type": "string"
+								},
+								"threadIdInvalid": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"botTokenInvalid",
+								"chatIdRequired",
+								"threadIdInvalid"
+							]
+						},
+						"toast": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"saved": {
+									"type": "string"
+								},
+								"saveError": {
+									"type": "string"
+								},
+								"enabled": {
+									"type": "string"
+								},
+								"disabled": {
+									"type": "string"
+								},
+								"updateError": {
+									"type": "string"
+								},
+								"removed": {
+									"type": "string"
+								},
+								"removeError": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"saved",
+								"saveError",
+								"enabled",
+								"disabled",
+								"updateError",
+								"removed",
+								"removeError"
+							]
+						},
+						"connectionTitle": {
+							"type": "string"
+						},
+						"connectionHint": {
+							"type": "string"
+						},
+						"connected": {
+							"type": "string"
+						},
+						"paused": {
+							"type": "string"
+						},
+						"botTokenLabel": {
+							"type": "string"
+						},
+						"botTokenPlaceholder": {
+							"type": "string"
+						},
+						"botTokenHint": {
+							"type": "string"
+						},
+						"botTokenHintConfigured": {
+							"type": "string"
+						},
+						"chatIdLabel": {
+							"type": "string"
+						},
+						"chatIdPlaceholder": {
+							"type": "string"
+						},
+						"chatIdHint": {
+							"type": "string"
+						},
+						"threadIdLabel": {
+							"type": "string"
+						},
+						"threadIdPlaceholder": {
+							"type": "string"
+						},
+						"threadIdHint": {
+							"type": "string"
+						},
+						"chatLabelLabel": {
+							"type": "string"
+						},
+						"chatLabelPlaceholder": {
+							"type": "string"
+						},
+						"chatLabelHint": {
+							"type": "string"
+						},
+						"eventsTitle": {
+							"type": "string"
+						},
+						"eventsHint": {
+							"type": "string"
+						},
+						"events": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"taskCreated": {
+									"type": "string"
+								},
+								"taskStatusChanged": {
+									"type": "string"
+								},
+								"taskPriorityChanged": {
+									"type": "string"
+								},
+								"taskTitleChanged": {
+									"type": "string"
+								},
+								"taskDescriptionChanged": {
+									"type": "string"
+								},
+								"taskCommentCreated": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"taskCreated",
+								"taskStatusChanged",
+								"taskPriorityChanged",
+								"taskTitleChanged",
+								"taskDescriptionChanged",
+								"taskCommentCreated"
+							]
+						},
+						"connect": {
+							"type": "string"
+						},
+						"saveChanges": {
+							"type": "string"
+						},
+						"disconnect": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"validation",
+						"toast",
+						"connectionTitle",
+						"connectionHint",
+						"connected",
+						"paused",
+						"botTokenLabel",
+						"botTokenPlaceholder",
+						"botTokenHint",
+						"botTokenHintConfigured",
+						"chatIdLabel",
+						"chatIdPlaceholder",
+						"chatIdHint",
+						"threadIdLabel",
+						"threadIdPlaceholder",
+						"threadIdHint",
+						"chatLabelLabel",
+						"chatLabelPlaceholder",
+						"chatLabelHint",
+						"eventsTitle",
+						"eventsHint",
+						"events",
+						"connect",
+						"saveChanges",
+						"disconnect"
+					]
+				},
 				"repositoryBrowser": {
 					"type": "object",
 					"additionalProperties": false,
@@ -3421,6 +4453,12 @@
 						"githubHint": {
 							"type": "string"
 						},
+						"giteaHeading": {
+							"type": "string"
+						},
+						"giteaHint": {
+							"type": "string"
+						},
 						"selectColumnPlaceholder": {
 							"type": "string"
 						},
@@ -3464,6 +4502,8 @@
 						"createColumnsFirst",
 						"githubHeading",
 						"githubHint",
+						"giteaHeading",
+						"giteaHint",
 						"selectColumnPlaceholder",
 						"toastUpdated",
 						"toastError",
@@ -3516,6 +4556,7 @@
 				"developerPage",
 				"apiKey",
 				"workspaceGeneral",
+				"workspaceRoles",
 				"projectGeneral",
 				"projectIntegrations",
 				"projectVisibility",
@@ -3523,9 +4564,11 @@
 				"projectSwitcher",
 				"columnEditor",
 				"githubIntegration",
+				"giteaIntegration",
 				"slackIntegration",
 				"discordIntegration",
 				"genericWebhookIntegration",
+				"telegramIntegration",
 				"repositoryBrowser",
 				"tasksImportExport",
 				"workflowEditor",
@@ -3638,9 +4681,19 @@
 						},
 						"more": {
 							"type": "string"
+						},
+						"backToBoard": {
+							"type": "string"
 						}
 					},
-					"required": ["overview", "projects", "members", "invitations", "more"]
+					"required": [
+						"overview",
+						"projects",
+						"members",
+						"invitations",
+						"more",
+						"backToBoard"
+					]
 				},
 				"projectList": {
 					"type": "object",
@@ -4065,6 +5118,19 @@
 							},
 							"required": ["title", "content"]
 						},
+						"task_mention": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"content": {
+									"type": "string"
+								}
+							},
+							"required": ["title", "content"]
+						},
 						"time_entry_created": {
 							"type": "object",
 							"additionalProperties": false,
@@ -4087,6 +5153,7 @@
 						"workspace_created",
 						"task_status_changed",
 						"task_assignee_changed",
+						"task_mention",
 						"time_entry_created"
 					]
 				}
@@ -4133,6 +5200,12 @@
 					"type": "string"
 				},
 				"changedTitle": {
+					"type": "string"
+				},
+				"moved": {
+					"type": "string"
+				},
+				"created": {
 					"type": "string"
 				},
 				"githubUser": {
@@ -4495,6 +5568,8 @@
 				"setDueDate",
 				"changedDueDate",
 				"changedTitle",
+				"moved",
+				"created",
 				"githubUser",
 				"comment"
 			]
@@ -4596,9 +5671,20 @@
 						},
 						"loadingTask": {
 							"type": "string"
+						},
+						"taskNotFound": {
+							"type": "string"
+						},
+						"taskNotFoundDescription": {
+							"type": "string"
 						}
 					},
-					"required": ["selectTask", "loadingTask"]
+					"required": [
+						"selectTask",
+						"loadingTask",
+						"taskNotFound",
+						"taskNotFoundDescription"
+					]
 				},
 				"detail": {
 					"type": "object",
@@ -5055,11 +6141,14 @@
 								"blocks": {
 									"type": "string"
 								},
+								"blocked_by": {
+									"type": "string"
+								},
 								"related": {
 									"type": "string"
 								}
 							},
-							"required": ["blocks", "related"]
+							"required": ["blocks", "blocked_by", "related"]
 						}
 					},
 					"required": [
@@ -5159,6 +6248,50 @@
 						"start",
 						"startDate",
 						"noDate"
+					]
+				},
+				"move": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"projectLabel": {
+							"type": "string"
+						},
+						"projectPlaceholder": {
+							"type": "string"
+						},
+						"statusLabel": {
+							"type": "string"
+						},
+						"statusHintKeep": {
+							"type": "string"
+						},
+						"statusHintAdjust": {
+							"type": "string"
+						},
+						"action": {
+							"type": "string"
+						},
+						"success": {
+							"type": "string"
+						},
+						"error": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"title",
+						"projectLabel",
+						"projectPlaceholder",
+						"statusLabel",
+						"statusHintKeep",
+						"statusHintAdjust",
+						"action",
+						"success",
+						"error"
 					]
 				},
 				"popover": {
@@ -5966,6 +7099,7 @@
 				"relations",
 				"subtasks",
 				"properties",
+				"move",
 				"popover",
 				"backlog",
 				"sort",
@@ -6098,6 +7232,9 @@
 						"emptyDescription": {
 							"type": "string"
 						},
+						"emptyDescriptionReadOnly": {
+							"type": "string"
+						},
 						"projectStatus": {
 							"type": "object",
 							"additionalProperties": false,
@@ -6128,6 +7265,7 @@
 						"status",
 						"emptyTitle",
 						"emptyDescription",
+						"emptyDescriptionReadOnly",
 						"projectStatus",
 						"noDueDate"
 					]
@@ -6283,9 +7421,12 @@
 						},
 						"member": {
 							"type": "string"
+						},
+						"viewer": {
+							"type": "string"
 						}
 					},
-					"required": ["owner", "admin", "member"]
+					"required": ["owner", "admin", "member", "viewer"]
 				},
 				"members": {
 					"type": "object",
@@ -6399,6 +7540,12 @@
 						},
 						"cancelInviteError": {
 							"type": "string"
+						},
+						"roleUpdateSuccess": {
+							"type": "string"
+						},
+						"roleUpdateError": {
+							"type": "string"
 						}
 					},
 					"required": [
@@ -6417,7 +7564,9 @@
 						"removeSuccess",
 						"removeError",
 						"cancelInviteSuccess",
-						"cancelInviteError"
+						"cancelInviteError",
+						"roleUpdateSuccess",
+						"roleUpdateError"
 					]
 				}
 			},


### PR DESCRIPTION
## Summary

- Add `id-ID` Indonesian translations.
- Register `id-ID` in the shared i18n resources so it appears in the account language picker.
- Regenerate the i18n JSON schema.

## Dependency

This branch is stacked on top of #1361 so the Indonesian locale includes the new workspace roles strings instead of adding a locale that still falls back to English on the Roles page. Until #1361 is merged, this PR's diff will include that dependency commit too.

## Validation

- `pnpm i18n:check id-ID` passes.
- `pnpm exec biome ci i18n/id-ID.json i18n/resources.ts i18n/schema.json` passes.
- `pnpm --filter @kaneo/web build` passes.
- Runtime tested on a self-hosted Kaneo 2.9.0 deployment using this branch plus #1361: health endpoint OK, sign-in page renders without React error #321, `id-ID` workspace role strings are present in the deployed bundle, and the Roles route chunk is present.

Known repo-wide i18n status:

- `pnpm i18n:check` still fails because existing locales are missing keys, including the new workspace roles keys from #1361.
- `pnpm i18n:report` still reports pre-existing missing/unused/dynamic-key findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Indonesian language support across the app.
  * Localized the workspace roles settings experience, including titles, labels, actions, and status messages.

* **Bug Fixes**
  * Improved consistency of translated text across role management, permissions, notifications, tasks, and settings screens.
  * Added missing wording for several empty, loading, error, and confirmation states.

* **Chores**
  * Expanded language coverage and updated translation structure to support additional localized content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->