### PR TITLE
feat(task): resize images in the description editor

### DIFF
--- a/apps/web/src/components/task/extensions/resizable-image.test.ts
+++ b/apps/web/src/components/task/extensions/resizable-image.test.ts
@@ -1,0 +1,104 @@
+import { Editor } from "@tiptap/core";
+import { Markdown } from "@tiptap/markdown";
+import StarterKit from "@tiptap/starter-kit";
+import { describe, expect, it } from "vitest";
+import { ResizableImage } from "./resizable-image";
+
+type JSONNode = {
+  type?: string;
+  attrs?: Record<string, unknown>;
+  content?: JSONNode[];
+};
+
+const SRC = "https://example.com/diagram.png";
+
+function createEditor() {
+  return new Editor({
+    extensions: [
+      StarterKit,
+      Markdown.configure({ markedOptions: { breaks: true, gfm: true } }),
+      ResizableImage.configure({
+        resize: {
+          enabled: true,
+          alwaysPreserveAspectRatio: true,
+          minWidth: 80,
+          minHeight: 80,
+        },
+        HTMLAttributes: { class: "kaneo-editor-image", loading: "lazy" },
+      }),
+    ],
+    content: "",
+  });
+}
+
+function findImage(node: JSONNode): JSONNode | null {
+  if (node.type === "image") return node;
+  for (const child of node.content ?? []) {
+    const found = findImage(child);
+    if (found) return found;
+  }
+  return null;
+}
+
+describe("ResizableImage markdown persistence", () => {
+  it("keeps an unresized image as plain markdown", () => {
+    const editor = createEditor();
+    editor.commands.setContent(`![Diagram](${SRC})`, {
+      contentType: "markdown",
+    });
+
+    const markdown = editor.getMarkdown();
+    expect(markdown).toContain(`![Diagram](${SRC})`);
+    expect(markdown).not.toContain("<img");
+
+    editor.destroy();
+  });
+
+  it("serializes a resized image as an <img> tag carrying the size", () => {
+    const editor = createEditor();
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        {
+          type: "image",
+          attrs: { src: SRC, alt: "Diagram", width: 640, height: 360 },
+        },
+      ],
+    });
+
+    const markdown = editor.getMarkdown();
+    expect(markdown).toContain("<img");
+    expect(markdown).toContain(`src="${SRC}"`);
+    expect(markdown).toContain('width="640"');
+    expect(markdown).toContain('height="360"');
+
+    editor.destroy();
+  });
+
+  it("restores the size when a resized image round-trips through markdown", () => {
+    const editor = createEditor();
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        {
+          type: "image",
+          attrs: { src: SRC, alt: "Diagram", width: 640, height: 360 },
+        },
+      ],
+    });
+
+    // Reload from the serialized markdown, exactly like the task view does.
+    const markdown = editor.getMarkdown();
+    editor.commands.setContent(markdown, { contentType: "markdown" });
+
+    const image = findImage(editor.getJSON() as JSONNode);
+    expect(image).not.toBeNull();
+    expect(String(image?.attrs?.width)).toBe("640");
+    expect(String(image?.attrs?.height)).toBe("360");
+
+    // Serializing the reloaded document is stable.
+    expect(editor.getMarkdown()).toContain('width="640"');
+
+    editor.destroy();
+  });
+});

--- a/apps/web/src/components/task/extensions/resizable-image.test.ts
+++ b/apps/web/src/components/task/extensions/resizable-image.test.ts
@@ -101,4 +101,26 @@ describe("ResizableImage markdown persistence", () => {
 
     editor.destroy();
   });
+
+  it("round-trips an alt that plain markdown can't represent", () => {
+    const editor = createEditor();
+    // Filename-derived alt text can contain brackets, which would break the
+    // `![alt](src)` form; it must fall back to HTML and survive a reload.
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        { type: "image", attrs: { src: SRC, alt: "screenshot [final]" } },
+      ],
+    });
+
+    const markdown = editor.getMarkdown();
+    expect(markdown).toContain("<img");
+    expect(markdown).toContain('alt="screenshot [final]"');
+
+    editor.commands.setContent(markdown, { contentType: "markdown" });
+    const image = findImage(editor.getJSON() as JSONNode);
+    expect(image?.attrs?.alt).toBe("screenshot [final]");
+
+    editor.destroy();
+  });
 });

--- a/apps/web/src/components/task/extensions/resizable-image.tsx
+++ b/apps/web/src/components/task/extensions/resizable-image.tsx
@@ -41,7 +41,15 @@ export const ResizableImage = Image.extend({
     const height =
       attrs.height != null && attrs.height !== "" ? String(attrs.height) : "";
 
-    if (width || height) {
+    // Fall back to a (fully escaped) HTML <img> when the image is resized, or
+    // when a field contains characters that can't be represented safely in the
+    // `![alt](src "title")` form — e.g. a filename-derived alt containing
+    // brackets, or a src with spaces/parens. Otherwise keep the plain markdown
+    // so existing content is untouched.
+    const hasUnsafeMarkdown =
+      /[[\]\\]/.test(alt) || /[\s()<>\\]/.test(src) || /["\\]/.test(title);
+
+    if (width || height || hasUnsafeMarkdown) {
       const parts = [
         `src="${escapeHtmlAttribute(src)}"`,
         `alt="${escapeHtmlAttribute(alt)}"`,

--- a/apps/web/src/components/task/extensions/resizable-image.tsx
+++ b/apps/web/src/components/task/extensions/resizable-image.tsx
@@ -1,0 +1,57 @@
+import Image from "@tiptap/extension-image";
+
+function escapeHtmlAttribute(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+// The stock image extension already supports width/height attributes and
+// drag-to-resize (via the `resize` option). The only missing piece is
+// persistence: its markdown serializer emits `![alt](src)`, which drops the
+// size. This extension keeps everything from the base extension and overrides
+// only `renderMarkdown` so a resized image round-trips through markdown as an
+// HTML `<img>` tag (raw HTML survives the markdown pipeline, the same technique
+// EmbedBlock / KaneoIssueLink use). Unresized images keep the plain markdown
+// syntax, so existing content is untouched.
+export const ResizableImage = Image.extend({
+  renderMarkdown(
+    node: {
+      attrs?: {
+        src?: string;
+        alt?: string;
+        title?: string;
+        width?: string | number | null;
+        height?: string | number | null;
+      };
+    },
+    _helpers: unknown,
+    _context: unknown,
+  ) {
+    const attrs = node.attrs ?? {};
+    const src = attrs.src ? String(attrs.src) : "";
+    if (!src) return "";
+
+    const alt = attrs.alt ? String(attrs.alt) : "";
+    const title = attrs.title ? String(attrs.title) : "";
+    const width =
+      attrs.width != null && attrs.width !== "" ? String(attrs.width) : "";
+    const height =
+      attrs.height != null && attrs.height !== "" ? String(attrs.height) : "";
+
+    if (width || height) {
+      const parts = [
+        `src="${escapeHtmlAttribute(src)}"`,
+        `alt="${escapeHtmlAttribute(alt)}"`,
+        title ? `title="${escapeHtmlAttribute(title)}"` : "",
+        width ? `width="${escapeHtmlAttribute(width)}"` : "",
+        height ? `height="${escapeHtmlAttribute(height)}"` : "",
+      ].filter(Boolean);
+      return `\n<img ${parts.join(" ")} />\n`;
+    }
+
+    return title ? `![${alt}](${src} "${title}")` : `![${alt}](${src})`;
+  },
+});

--- a/apps/web/src/components/task/task-description.tsx
+++ b/apps/web/src/components/task/task-description.tsx
@@ -1,5 +1,4 @@
 import type { Editor } from "@tiptap/core";
-import Image from "@tiptap/extension-image";
 import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import { Table } from "@tiptap/extension-table";
@@ -72,6 +71,7 @@ import { uploadTaskImage } from "@/lib/upload-task-image";
 import { AttachmentCard } from "./extensions/attachment-card";
 import { EmbedBlock } from "./extensions/embed-block";
 import { KaneoIssueLink } from "./extensions/kaneo-issue-link";
+import { ResizableImage } from "./extensions/resizable-image";
 import {
   SHIKI_CODEBLOCK_REFRESH_META,
   ShikiCodeBlock,
@@ -577,7 +577,13 @@ export default function TaskDescription({ taskId }: TaskDescriptionProps) {
         AttachmentCard,
         KaneoIssueLink,
         TaskList,
-        Image.configure({
+        ResizableImage.configure({
+          resize: {
+            enabled: true,
+            alwaysPreserveAspectRatio: true,
+            minWidth: 80,
+            minHeight: 80,
+          },
           HTMLAttributes: {
             class: "kaneo-editor-image",
             loading: "lazy",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -670,6 +670,59 @@ input:-webkit-autofill:active {
     overflow: hidden;
   }
 
+  /* Resizable image: drag handles rendered by Tiptap's ResizableNodeView. */
+  .kaneo-tiptap-content .ProseMirror [data-resize-wrapper] {
+    display: inline-block;
+    max-width: 100%;
+  }
+
+  .kaneo-tiptap-content .ProseMirror [data-resize-handle] {
+    width: 12px;
+    height: 12px;
+    z-index: 2;
+    border-radius: 9999px;
+    background: var(--primary);
+    border: 2px solid var(--background);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--border) 65%, transparent);
+    opacity: 0;
+    transition: opacity 0.12s ease;
+  }
+
+  .kaneo-tiptap-content
+    .ProseMirror
+    [data-resize-wrapper]:hover
+    [data-resize-handle],
+  .kaneo-tiptap-content
+    .ProseMirror
+    .ProseMirror-selectednode
+    [data-resize-handle],
+  .kaneo-tiptap-content
+    .ProseMirror
+    [data-resize-container][data-resize-state="true"]
+    [data-resize-handle] {
+    opacity: 1;
+  }
+
+  .kaneo-tiptap-content .ProseMirror [data-resize-handle="top-left"] {
+    transform: translate(-50%, -50%);
+    cursor: nwse-resize;
+  }
+
+  .kaneo-tiptap-content .ProseMirror [data-resize-handle="top-right"] {
+    transform: translate(50%, -50%);
+    cursor: nesw-resize;
+  }
+
+  .kaneo-tiptap-content .ProseMirror [data-resize-handle="bottom-left"] {
+    transform: translate(-50%, 50%);
+    cursor: nesw-resize;
+  }
+
+  .kaneo-tiptap-content .ProseMirror [data-resize-handle="bottom-right"] {
+    transform: translate(50%, 50%);
+    cursor: nwse-resize;
+  }
+
   .kaneo-create-task-modal .kaneo-comment-editor-prose img.kaneo-editor-image {
     max-height: min(50vh, 28rem);
     width: 100%;


### PR DESCRIPTION
## Description

Images added to a task description could not be resized — they always rendered at full width, which is awkward for tall/vertical images that dominate the card (#1211).

Tiptap's `@tiptap/extension-image` (already used here) ships built-in drag-to-resize via `ResizableNodeView` and already has `width`/`height` attributes. The only missing piece was **persistence**: the task description is stored as markdown, and the stock `renderMarkdown` emits `![alt](src)`, which drops the size.

This PR:
1. Enables the built-in resize on the description image (`resize: { enabled: true, alwaysPreserveAspectRatio: true, minWidth: 80, minHeight: 80 }`).
2. Adds a small `ResizableImage` extension that overrides **only** `renderMarkdown` so a resized image serializes as an HTML `<img>` tag carrying `width`/`height`. Raw HTML survives the markdown round-trip (the same technique `EmbedBlock` / `KaneoIssueLink` already use). **Unresized images keep the plain `![alt](src)` markdown, so existing content is untouched.**
3. Styles the drag handles (they render as unstyled `[data-resize-handle]` elements otherwise).

Aspect ratio is locked and the existing `max-width` cap keeps resized images from overflowing the card.

Scope is the **task description** editor (the surface in the issue). The comment editor shares the same base image config and could adopt this in a follow-up.

## Related Issue(s)
Fixes #1211

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other (please describe):

Added `resizable-image.test.ts` covering the markdown round-trip: an unresized image stays `![alt](src)`; a resized image serializes to `<img … width … height>`; and the size is restored after reloading from markdown. Also verified `pnpm exec biome ci .`, `pnpm build`, and the full web test suite (14/14) pass locally.

> Note: I have not yet visually verified the drag interaction in a running browser. Happy to add a screen recording / screenshots.

## Screenshots (if applicable)
_Pending._

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
No new dependencies. No new i18n strings (the drag handles have no text labels).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resizable image support in task descriptions, including improved editor styling with visible resize handles on hover/selection.
  * Resized images now persist their dimensions across save and reload.
* **Bug Fixes**
  * Ensures Markdown round-trips keep `width`/`height` reliably, and safely serialize complex `alt`/`title` content without breaking image rendering.
* **Tests**
  * Added a Vitest suite covering Markdown persistence and round-trip stability for resized and unresized images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->