### PR TITLE
fix(auth): require verified email for account linking

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -187,15 +187,11 @@ export const auth = betterAuth({
       // providers verify the email on their side, so they are trusted to link.
       enabled: true,
       trustedProviders: ["github", "google", "discord", "custom"],
-      // Kaneo does not require email verification on password signup, so the
-      // existing local account is usually unverified; allow linking to it so
-      // OIDC users are not locked out.
-      // SECURITY: with open password registration this means someone who
-      // pre-registered a victim's email (unverified) could be linked into by
-      // that victim's OIDC login. Instances that allow password signup
-      // alongside OIDC should set DISABLE_PASSWORD_REGISTRATION or require email
-      // verification.
-      requireLocalEmailVerified: false,
+      // Only link to an existing local account after its email has been
+      // verified. Without this check, an attacker could pre-register a victim's
+      // email with a password account and retain access after the victim signs
+      // in through a trusted OAuth/OIDC provider.
+      requireLocalEmailVerified: true,
     },
   },
   emailAndPassword: {

--- a/apps/docs/core/installation/environment-variables.mdx
+++ b/apps/docs/core/installation/environment-variables.mdx
@@ -86,6 +86,10 @@ Name | Description | Default |
 | `DISABLE_LOGIN_FORM` | Hide the email/password login form on the sign-in page. When set to `true`, only SSO/OAuth buttons are shown. Useful when you want to enforce authentication exclusively through an external identity provider. | `false` |
 | `CUSTOM_OAUTH_AUTO_LOGIN` | Automatically redirect to the custom OAuth/OIDC provider instead of showing the sign-in page. When set to `true`, users are immediately redirected to your identity provider without seeing the login page. Requires a custom OAuth provider to be configured. | `false` |
 
+<Warning>
+  Before enabling SSO-only access with `DISABLE_LOGIN_FORM=true` or `CUSTOM_OAUTH_AUTO_LOGIN=true` on an existing installation, make sure existing local accounts have verified email addresses. OAuth/OIDC identities cannot be linked to an unverified local account, and affected users will receive `error=account_not_linked`. Keep the login form available until those users have signed in with an email OTP or magic link. If SSO-only access is already enabled, temporarily set both options to `false`, restart Kaneo, and let affected users complete an email sign-in before restoring the SSO-only settings.
+</Warning>
+
 ### Notifications
 
 Name | Description | Default |

--- a/apps/docs/core/social-providers/custom-oauth.mdx
+++ b/apps/docs/core/social-providers/custom-oauth.mdx
@@ -178,9 +178,11 @@ This will automatically discover the authorization, token, and userinfo endpoint
 
 ## Account linking
 
-When a user signs in with this provider using an email that already belongs to a Kaneo account (for example one created with email and password), Kaneo can link the OIDC identity to that existing account instead of failing with `error=account_not_linked`. GitHub, Google, Discord, and this custom provider are trusted to link because they verify the user's email.
+When a user signs in with this provider using an email that already belongs to a Kaneo account (for example one created with email and password), Kaneo can link the OIDC identity to that existing account instead of failing with `error=account_not_linked`. GitHub, Google, and Discord are trusted because they verify email ownership. Kaneo also treats the configured custom provider as trusted, but it cannot verify the provider's email claims itself. Only use a custom provider that guarantees ownership of every returned email address; otherwise, an attacker-controlled email claim could be linked to an existing verified account.
 
 For safety, Kaneo only links to an existing local account if that account's email has already been verified. This prevents someone from pre-registering another person's email with a password account and retaining access after the real owner signs in through OIDC. If your instance allows password registration alongside OIDC, consider setting `DISABLE_PASSWORD_REGISTRATION=true` or requiring email verification for password users to avoid account-linking surprises.
+
+On existing installations, local accounts created before this requirement may still have an unverified email. Those users will receive `error=account_not_linked` until they verify the local account. Before enforcing SSO-only access, keep the login form available so affected users can sign in with an email OTP or magic link, which verifies the email. If users are already locked out, temporarily set `DISABLE_LOGIN_FORM=false` and `CUSTOM_OAUTH_AUTO_LOGIN=false`, restart Kaneo, and have them complete an email sign-in before enabling SSO-only access again.
 
 ## Security Notes
 
@@ -188,4 +190,3 @@ For safety, Kaneo only links to an existing local account if that account's emai
 - Keep your client secret secure and never commit it to version control
 - Enable PKCE when possible for enhanced security
 - Use the most restrictive scopes necessary for your use case
-

--- a/apps/docs/core/social-providers/custom-oauth.mdx
+++ b/apps/docs/core/social-providers/custom-oauth.mdx
@@ -178,9 +178,9 @@ This will automatically discover the authorization, token, and userinfo endpoint
 
 ## Account linking
 
-When a user signs in with this provider using an email that already belongs to a Kaneo account (for example one created with email and password), Kaneo links the OIDC identity to that existing account instead of failing with `error=account_not_linked`. GitHub, Google, Discord, and this custom provider are trusted to link because they verify the user's email.
+When a user signs in with this provider using an email that already belongs to a Kaneo account (for example one created with email and password), Kaneo can link the OIDC identity to that existing account instead of failing with `error=account_not_linked`. GitHub, Google, Discord, and this custom provider are trusted to link because they verify the user's email.
 
-Because Kaneo does not require email verification on password signup, linking also applies to unverified local accounts so OIDC users are not locked out. If your instance allows password registration alongside OIDC, set `DISABLE_PASSWORD_REGISTRATION=true` (or require email verification) so that nobody can pre-register another person's email and have an OIDC login linked into it.
+For safety, Kaneo only links to an existing local account if that account's email has already been verified. This prevents someone from pre-registering another person's email with a password account and retaining access after the real owner signs in through OIDC. If your instance allows password registration alongside OIDC, consider setting `DISABLE_PASSWORD_REGISTRATION=true` or requiring email verification for password users to avoid account-linking surprises.
 
 ## Security Notes
 

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -152,6 +152,7 @@
 			"githubError": "Failed to sign in with GitHub",
 			"discordError": "Failed to sign in with Discord",
 			"errors": {
+				"account_not_linked": "This identity could not be linked to the existing account. Sign in by email to verify the account, then try SSO again. If email sign-in is unavailable, contact your administrator.",
 				"oauth_code_verification_failed": "OAuth verification failed. Please try again.",
 				"registration_is_currently_disabled_you_need_a_valid_invitation_to_create_an_account_": "Registration is currently disabled. You need a valid invitation to create an account."
 			}

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -592,6 +592,9 @@
 							"type": "object",
 							"additionalProperties": false,
 							"properties": {
+								"account_not_linked": {
+									"type": "string"
+								},
 								"oauth_code_verification_failed": {
 									"type": "string"
 								},
@@ -600,6 +603,7 @@
 								}
 							},
 							"required": [
+								"account_not_linked",
 								"oauth_code_verification_failed",
 								"registration_is_currently_disabled_you_need_a_valid_invitation_to_create_an_account_"
 							]


### PR DESCRIPTION
### Motivation
- Prevent automatic same-email OAuth/OIDC account linking from attaching a trusted provider to an unverified local password account, which could allow an attacker who pre-registers a victim's email to retain access after the victim signs in via SSO.

### Description
- Set `requireLocalEmailVerified: true` in the account linking configuration in `apps/api/src/auth.ts` so Better Auth only links when the existing local account's email is verified.
- Update `apps/docs/core/social-providers/custom-oauth.mdx` to document the safer verified-email linking behavior and recommend `DISABLE_PASSWORD_REGISTRATION` or requiring email verification as additional mitigations.

### Testing
- Ran `pnpm exec biome check apps/api/src/auth.ts apps/docs/core/social-providers/custom-oauth.mdx` which reported no issues.
- Ran unit tests for the API with `pnpm --filter @kaneo/api test:unit` and all tests passed (`24` files, `158` tests).
- Project build completed successfully as part of pre-commit build checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a510a323e54832d81c77f05dcdf2743)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Account linking now requires the existing local account’s email to be verified before connecting an OAuth or custom provider identity.

* **Documentation**
  * Updated custom OAuth account-linking guidance and added administrator steps for existing installs with unverified local accounts (temporary setting changes and remediation).

* **Localization**
  * Added a user-facing sign-in error message for `account_not_linked`.
  * Updated the translation schema to require the new error key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->