### PR TITLE
fix(mcp): require explicit OAuth consent

### DIFF
--- a/apps/api/src/mcp/controllers/oauth-consent.ts
+++ b/apps/api/src/mcp/controllers/oauth-consent.ts
@@ -1,0 +1,138 @@
+import { HTTPException } from "hono/http-exception";
+import type * as v from "valibot";
+import { auth } from "../../auth";
+import {
+  consumeAuthorizationRequest,
+  createAuthCode,
+  createAuthorizationRequest,
+  getAuthorizationRequest,
+  getClient,
+  registerClient,
+} from "../oauth";
+import type {
+  authorizationDecisionSchema,
+  authorizationQuerySchema,
+  clientRegistrationSchema,
+} from "../schemas";
+
+const clientUrl = process.env.KANEO_CLIENT_URL || "http://localhost:5173";
+
+type ClientRegistrationInput = v.InferOutput<typeof clientRegistrationSchema>;
+type AuthorizationInput = v.InferOutput<typeof authorizationQuerySchema>;
+type AuthorizationDecisionInput = v.InferOutput<
+  typeof authorizationDecisionSchema
+>;
+
+type OAuthErrorStatus = 400 | 401 | 403 | 404;
+
+function throwOAuthError(status: OAuthErrorStatus, error: string): never {
+  throw new HTTPException(status, {
+    res: Response.json({ error }, { status }),
+  });
+}
+
+function buildAuthorizationRedirect(
+  request: { redirectUri: string; state?: string },
+  params: Record<string, string>,
+): string {
+  const url = new URL(request.redirectUri);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  if (request.state !== undefined) {
+    url.searchParams.set("state", request.state);
+  }
+  return url.toString();
+}
+
+function isTrustedConsentOrigin(origin: string | undefined): boolean {
+  if (!origin) return false;
+
+  try {
+    return new URL(origin).origin === new URL(clientUrl).origin;
+  } catch {
+    return false;
+  }
+}
+
+export function registerMcpClient(input: ClientRegistrationInput) {
+  const client = registerClient({
+    redirectUris: input.redirect_uris,
+    clientName: input.client_name,
+  });
+
+  return {
+    client_id: client.clientId,
+    client_id_issued_at: client.issuedAt,
+    redirect_uris: client.redirectUris,
+    client_name: client.clientName,
+    token_endpoint_auth_method: input.token_endpoint_auth_method ?? "none",
+    grant_types: input.grant_types ?? ["authorization_code"],
+    response_types: input.response_types ?? ["code"],
+  } as const;
+}
+
+export function beginMcpAuthorization(input: AuthorizationInput): string {
+  const client = getClient(input.client_id);
+  if (!client) throwOAuthError(400, "invalid_client");
+  if (!client.redirectUris.includes(input.redirect_uri)) {
+    throwOAuthError(400, "invalid_redirect_uri");
+  }
+
+  const requestId = createAuthorizationRequest({
+    clientId: input.client_id,
+    codeChallenge: input.code_challenge,
+    redirectUri: input.redirect_uri,
+    state: input.state,
+  });
+  const consentUrl = new URL("/mcp/authorize", clientUrl);
+  consentUrl.searchParams.set("request_id", requestId);
+  return consentUrl.toString();
+}
+
+export function getMcpAuthorizationRequest(requestId: string) {
+  const request = getAuthorizationRequest(requestId);
+  if (!request) throwOAuthError(404, "invalid_or_expired_request");
+
+  const client = getClient(request.clientId);
+  if (!client) throwOAuthError(400, "invalid_client");
+
+  return {
+    client_name: client.clientName ?? "MCP client",
+    redirect_uri: request.redirectUri,
+  };
+}
+
+export async function decideMcpAuthorizationRequest(params: {
+  requestId: string;
+  decision: AuthorizationDecisionInput;
+  headers: Headers;
+  origin?: string;
+}): Promise<string> {
+  if (!isTrustedConsentOrigin(params.origin)) {
+    throwOAuthError(403, "invalid_origin");
+  }
+
+  const session = await auth.api.getSession({ headers: params.headers });
+  if (!session?.user?.id) throwOAuthError(401, "unauthorized");
+
+  const request = consumeAuthorizationRequest(params.requestId);
+  if (!request) throwOAuthError(404, "invalid_or_expired_request");
+
+  const client = getClient(request.clientId);
+  if (!client || !client.redirectUris.includes(request.redirectUri)) {
+    throwOAuthError(400, "invalid_client");
+  }
+
+  if (!params.decision.approved) {
+    return buildAuthorizationRedirect(request, { error: "access_denied" });
+  }
+
+  const code = createAuthCode({
+    clientId: request.clientId,
+    userId: session.user.id,
+    codeChallenge: request.codeChallenge,
+    redirectUri: request.redirectUri,
+  });
+  return buildAuthorizationRedirect(request, { code });
+}

--- a/apps/api/src/mcp/index.ts
+++ b/apps/api/src/mcp/index.ts
@@ -4,8 +4,11 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { Hono } from "hono";
 import { auth } from "../auth";
 import {
+  consumeAuthorizationRequest,
   createAuthCode,
+  createAuthorizationRequest,
   exchangeCode,
+  getAuthorizationRequest,
   getClient,
   registerClient,
 } from "./oauth";
@@ -18,6 +21,49 @@ const apiUrl = (process.env.KANEO_API_URL || "http://localhost:1337").replace(
 );
 
 const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
+
+function isValidRedirectUri(value: unknown): value is string {
+  if (typeof value !== "string" || value.length > 2048) return false;
+
+  try {
+    const url = new URL(value);
+    if (url.hash || url.username || url.password) return false;
+    if (["javascript:", "data:", "file:", "vbscript:"].includes(url.protocol)) {
+      return false;
+    }
+    if (url.protocol === "http:") {
+      return ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+    }
+    return (
+      url.protocol === "https:" || /^[a-z][a-z0-9+.-]*:$/.test(url.protocol)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isTrustedConsentOrigin(req: Request): boolean {
+  const origin = req.headers.get("origin");
+  if (!origin) return false;
+
+  try {
+    return new URL(origin).origin === new URL(clientUrl).origin;
+  } catch {
+    return false;
+  }
+}
+
+function buildAuthorizationRedirect(
+  request: { redirectUri: string; state?: string },
+  params: Record<string, string>,
+): string {
+  const url = new URL(request.redirectUri);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  if (request.state) url.searchParams.set("state", request.state);
+  return url.toString();
+}
 
 function createMcpServerForUser(token: string): McpServer {
   const server = new McpServer({
@@ -48,10 +94,40 @@ async function validateBearerToken(
 const mcp = new Hono();
 
 mcp.post("/mcp/register", async (c) => {
-  const body = await c.req.json();
+  const body = (await c.req.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const redirectUris = body?.redirect_uris;
+  if (
+    !body ||
+    !Array.isArray(redirectUris) ||
+    redirectUris.length === 0 ||
+    !redirectUris.every(isValidRedirectUri)
+  ) {
+    return c.json({ error: "invalid_redirect_uris" }, 400);
+  }
+  if (
+    (body.token_endpoint_auth_method !== undefined &&
+      body.token_endpoint_auth_method !== "none") ||
+    (body.grant_types !== undefined &&
+      (!Array.isArray(body.grant_types) ||
+        body.grant_types.length !== 1 ||
+        body.grant_types[0] !== "authorization_code")) ||
+    (body.response_types !== undefined &&
+      (!Array.isArray(body.response_types) ||
+        body.response_types.length !== 1 ||
+        body.response_types[0] !== "code"))
+  ) {
+    return c.json({ error: "invalid_client_metadata" }, 400);
+  }
+
   const client = registerClient({
-    redirectUris: body.redirect_uris ?? [],
-    clientName: body.client_name,
+    redirectUris,
+    clientName:
+      typeof body.client_name === "string"
+        ? body.client_name.slice(0, 100)
+        : undefined,
   });
   return c.json({
     client_id: client.clientId,
@@ -68,9 +144,17 @@ mcp.get("/mcp/authorize", async (c) => {
   const clientId = c.req.query("client_id");
   const redirectUri = c.req.query("redirect_uri");
   const codeChallenge = c.req.query("code_challenge");
+  const codeChallengeMethod = c.req.query("code_challenge_method");
+  const responseType = c.req.query("response_type");
   const state = c.req.query("state");
 
-  if (!clientId || !redirectUri || !codeChallenge) {
+  if (
+    !clientId ||
+    !redirectUri ||
+    !codeChallenge ||
+    codeChallengeMethod !== "S256" ||
+    responseType !== "code"
+  ) {
     return c.json({ error: "invalid_request" }, 400);
   }
 
@@ -78,134 +162,79 @@ mcp.get("/mcp/authorize", async (c) => {
   if (!client) {
     return c.json({ error: "invalid_client" }, 400);
   }
+  if (!client.redirectUris.includes(redirectUri)) {
+    return c.json({ error: "invalid_redirect_uri" }, 400);
+  }
 
-  const session = await auth.api.getSession({
-    headers: c.req.raw.headers,
+  const requestId = createAuthorizationRequest({
+    clientId,
+    codeChallenge,
+    redirectUri,
+    state,
   });
-
-  if (session?.user?.id) {
-    const code = createAuthCode({
-      clientId,
-      userId: session.user.id,
-      codeChallenge,
-      redirectUri,
-    });
-    const url = new URL(redirectUri);
-    url.searchParams.set("code", code);
-    if (state) url.searchParams.set("state", state);
-    return c.redirect(url.toString());
-  }
-
-  const deviceRes = await fetch(`${apiUrl}/api/auth/device/code`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ client_id: "kaneo-mcp" }),
-  });
-
-  if (!deviceRes.ok) {
-    return c.json({ error: "device_code_failed" }, 500);
-  }
-
-  const device = (await deviceRes.json()) as {
-    device_code: string;
-    user_code: string;
-    verification_uri: string;
-    interval: number;
-    expires_in: number;
-  };
-
-  const devicePageUrl = `${clientUrl}/device?user_code=${encodeURIComponent(device.user_code)}`;
-
-  return c.html(`<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Kaneo MCP</title>
-  <script>window.location.href = ${JSON.stringify(devicePageUrl)};</script>
-</head>
-<body>Redirecting to Kaneo…</body>
-<script>
-  const deviceCode = ${JSON.stringify(device.device_code)};
-  const interval = ${device.interval} * 1000;
-  const apiUrl = ${JSON.stringify(apiUrl)};
-  const redirectUri = ${JSON.stringify(redirectUri)};
-  const codeChallenge = ${JSON.stringify(codeChallenge)};
-  const clientId = ${JSON.stringify(clientId)};
-  const state = ${JSON.stringify(state || "")};
-
-  async function poll() {
-    try {
-      const res = await fetch(apiUrl + "/api/auth/device/token", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-          device_code: deviceCode,
-          client_id: "kaneo-mcp"
-        })
-      });
-      const data = await res.json();
-
-      if (res.ok && data.access_token) {
-        const codeRes = await fetch(apiUrl + "/api/mcp/authorize/callback", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            access_token: data.access_token,
-            client_id: clientId,
-            code_challenge: codeChallenge,
-            redirect_uri: redirectUri,
-            state: state
-          })
-        });
-        const codeData = await codeRes.json();
-        if (codeData.redirect) window.location.href = codeData.redirect;
-        return;
-      }
-
-      if (data.error === "authorization_pending" || data.error === "slow_down") {
-        setTimeout(poll, data.error === "slow_down" ? interval + 5000 : interval);
-        return;
-      }
-    } catch {
-      setTimeout(poll, interval);
-    }
-  }
-
-  setTimeout(poll, interval);
-</script>
-</html>`);
+  const consentUrl = new URL("/mcp/authorize", clientUrl);
+  consentUrl.searchParams.set("request_id", requestId);
+  return c.redirect(consentUrl.toString());
 });
 
-mcp.post("/mcp/authorize/callback", async (c) => {
-  const body = await c.req.json();
-  const { access_token, client_id, code_challenge, redirect_uri, state } = body;
+mcp.get("/mcp/authorize/request/:requestId", (c) => {
+  const request = getAuthorizationRequest(c.req.param("requestId"));
+  if (!request) {
+    return c.json({ error: "invalid_or_expired_request" }, 404);
+  }
+  const client = getClient(request.clientId);
+  if (!client) return c.json({ error: "invalid_client" }, 400);
 
-  if (!access_token || !client_id || !code_challenge || !redirect_uri) {
+  return c.json({
+    client_name: client.clientName ?? "MCP client",
+    redirect_uri: request.redirectUri,
+  });
+});
+
+mcp.post("/mcp/authorize/request/:requestId", async (c) => {
+  if (!isTrustedConsentOrigin(c.req.raw)) {
+    return c.json({ error: "invalid_origin" }, 403);
+  }
+
+  const body = (await c.req.json().catch(() => null)) as {
+    approved?: unknown;
+  } | null;
+  if (typeof body?.approved !== "boolean") {
     return c.json({ error: "invalid_request" }, 400);
   }
 
-  const headers = new Headers();
-  headers.set("authorization", `Bearer ${access_token}`);
-  const session = await auth.api.getSession({ headers });
+  const session = await auth.api.getSession({ headers: c.req.raw.headers });
 
   if (!session?.user?.id) {
-    return c.json({ error: "invalid_token" }, 401);
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  const request = consumeAuthorizationRequest(c.req.param("requestId"));
+  if (!request) {
+    return c.json({ error: "invalid_or_expired_request" }, 404);
+  }
+  const client = getClient(request.clientId);
+  if (!client || !client.redirectUris.includes(request.redirectUri)) {
+    return c.json({ error: "invalid_client" }, 400);
+  }
+
+  if (!body.approved) {
+    return c.json({
+      redirect: buildAuthorizationRedirect(request, {
+        error: "access_denied",
+      }),
+    });
   }
 
   const code = createAuthCode({
-    clientId: client_id,
+    clientId: request.clientId,
     userId: session.user.id,
-    codeChallenge: code_challenge,
-    redirectUri: redirect_uri,
+    codeChallenge: request.codeChallenge,
+    redirectUri: request.redirectUri,
   });
-
-  const url = new URL(redirect_uri);
-  url.searchParams.set("code", code);
-  if (state) url.searchParams.set("state", state);
-
-  return c.json({ redirect: url.toString() });
+  return c.json({
+    redirect: buildAuthorizationRedirect(request, { code }),
+  });
 });
 
 mcp.post("/mcp/token", async (c) => {

--- a/apps/api/src/mcp/index.ts
+++ b/apps/api/src/mcp/index.ts
@@ -2,68 +2,33 @@ import { randomUUID } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { Hono } from "hono";
+import { describeRoute, resolver, validator } from "hono-openapi";
 import { auth } from "../auth";
 import {
-  consumeAuthorizationRequest,
-  createAuthCode,
-  createAuthorizationRequest,
-  exchangeCode,
-  getAuthorizationRequest,
-  getClient,
-  registerClient,
-} from "./oauth";
+  beginMcpAuthorization,
+  decideMcpAuthorizationRequest,
+  getMcpAuthorizationRequest,
+  registerMcpClient,
+} from "./controllers/oauth-consent";
+import { exchangeCode } from "./oauth";
+import {
+  authorizationDecisionResponseSchema,
+  authorizationDecisionSchema,
+  authorizationQuerySchema,
+  authorizationRequestParamSchema,
+  authorizationRequestResponseSchema,
+  clientRegistrationResponseSchema,
+  clientRegistrationSchema,
+  oauthErrorSchema,
+} from "./schemas";
 import { registerMcpTools } from "./tools";
 
-const clientUrl = process.env.KANEO_CLIENT_URL || "http://localhost:5173";
 const apiUrl = (process.env.KANEO_API_URL || "http://localhost:1337").replace(
   /\/api\/?$/,
   "",
 );
 
 const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
-
-function isValidRedirectUri(value: unknown): value is string {
-  if (typeof value !== "string" || value.length > 2048) return false;
-
-  try {
-    const url = new URL(value);
-    if (url.hash || url.username || url.password) return false;
-    if (["javascript:", "data:", "file:", "vbscript:"].includes(url.protocol)) {
-      return false;
-    }
-    if (url.protocol === "http:") {
-      return ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
-    }
-    return (
-      url.protocol === "https:" || /^[a-z][a-z0-9+.-]*:$/.test(url.protocol)
-    );
-  } catch {
-    return false;
-  }
-}
-
-function isTrustedConsentOrigin(req: Request): boolean {
-  const origin = req.headers.get("origin");
-  if (!origin) return false;
-
-  try {
-    return new URL(origin).origin === new URL(clientUrl).origin;
-  } catch {
-    return false;
-  }
-}
-
-function buildAuthorizationRedirect(
-  request: { redirectUri: string; state?: string },
-  params: Record<string, string>,
-): string {
-  const url = new URL(request.redirectUri);
-  for (const [key, value] of Object.entries(params)) {
-    url.searchParams.set(key, value);
-  }
-  if (request.state) url.searchParams.set("state", request.state);
-  return url.toString();
-}
 
 function createMcpServerForUser(token: string): McpServer {
   const server = new McpServer({
@@ -93,149 +58,146 @@ async function validateBearerToken(
 
 const mcp = new Hono();
 
-mcp.post("/mcp/register", async (c) => {
-  const body = (await c.req.json().catch(() => null)) as Record<
-    string,
-    unknown
-  > | null;
-  const redirectUris = body?.redirect_uris;
-  if (
-    !body ||
-    !Array.isArray(redirectUris) ||
-    redirectUris.length === 0 ||
-    !redirectUris.every(isValidRedirectUri)
-  ) {
-    return c.json({ error: "invalid_redirect_uris" }, 400);
-  }
-  if (
-    (body.token_endpoint_auth_method !== undefined &&
-      body.token_endpoint_auth_method !== "none") ||
-    (body.grant_types !== undefined &&
-      (!Array.isArray(body.grant_types) ||
-        body.grant_types.length !== 1 ||
-        body.grant_types[0] !== "authorization_code")) ||
-    (body.response_types !== undefined &&
-      (!Array.isArray(body.response_types) ||
-        body.response_types.length !== 1 ||
-        body.response_types[0] !== "code"))
-  ) {
-    return c.json({ error: "invalid_client_metadata" }, 400);
-  }
+mcp.post(
+  "/mcp/register",
+  describeRoute({
+    operationId: "registerMcpOAuthClient",
+    tags: ["MCP"],
+    description: "Register a public OAuth client for the MCP endpoint",
+    security: [],
+    responses: {
+      200: {
+        description: "Registered OAuth client",
+        content: {
+          "application/json": {
+            schema: resolver(clientRegistrationResponseSchema),
+          },
+        },
+      },
+      400: {
+        description: "Invalid client metadata",
+        content: {
+          "application/json": { schema: resolver(oauthErrorSchema) },
+        },
+      },
+    },
+  }),
+  validator("json", clientRegistrationSchema),
+  (c) => c.json(registerMcpClient(c.req.valid("json"))),
+);
 
-  const client = registerClient({
-    redirectUris,
-    clientName:
-      typeof body.client_name === "string"
-        ? body.client_name.slice(0, 100)
-        : undefined,
-  });
-  return c.json({
-    client_id: client.clientId,
-    client_id_issued_at: client.issuedAt,
-    redirect_uris: client.redirectUris,
-    client_name: client.clientName,
-    token_endpoint_auth_method: body.token_endpoint_auth_method ?? "none",
-    grant_types: body.grant_types ?? ["authorization_code"],
-    response_types: body.response_types ?? ["code"],
-  });
-});
+mcp.get(
+  "/mcp/authorize",
+  describeRoute({
+    operationId: "authorizeMcpOAuthClient",
+    tags: ["MCP"],
+    description: "Start an explicit MCP OAuth consent request",
+    security: [],
+    responses: {
+      302: { description: "Redirect to the Kaneo consent page" },
+      400: {
+        description: "Invalid authorization request",
+        content: {
+          "application/json": { schema: resolver(oauthErrorSchema) },
+        },
+      },
+    },
+  }),
+  validator("query", authorizationQuerySchema),
+  (c) => c.redirect(beginMcpAuthorization(c.req.valid("query"))),
+);
 
-mcp.get("/mcp/authorize", async (c) => {
-  const clientId = c.req.query("client_id");
-  const redirectUri = c.req.query("redirect_uri");
-  const codeChallenge = c.req.query("code_challenge");
-  const codeChallengeMethod = c.req.query("code_challenge_method");
-  const responseType = c.req.query("response_type");
-  const state = c.req.query("state");
+mcp.get(
+  "/mcp/authorize/request/:requestId",
+  describeRoute({
+    operationId: "getMcpAuthorizationRequest",
+    tags: ["MCP"],
+    description: "Get display details for an MCP OAuth consent request",
+    security: [],
+    responses: {
+      200: {
+        description: "Authorization request details",
+        content: {
+          "application/json": {
+            schema: resolver(authorizationRequestResponseSchema),
+          },
+        },
+      },
+      400: {
+        description: "Invalid OAuth client",
+        content: {
+          "application/json": { schema: resolver(oauthErrorSchema) },
+        },
+      },
+      404: {
+        description: "Unknown or expired authorization request",
+        content: {
+          "application/json": { schema: resolver(oauthErrorSchema) },
+        },
+      },
+    },
+  }),
+  validator("param", authorizationRequestParamSchema),
+  (c) => {
+    const { requestId } = c.req.valid("param");
+    return c.json(getMcpAuthorizationRequest(requestId));
+  },
+);
 
-  if (
-    !clientId ||
-    !redirectUri ||
-    !codeChallenge ||
-    codeChallengeMethod !== "S256" ||
-    responseType !== "code"
-  ) {
-    return c.json({ error: "invalid_request" }, 400);
-  }
-
-  const client = getClient(clientId);
-  if (!client) {
-    return c.json({ error: "invalid_client" }, 400);
-  }
-  if (!client.redirectUris.includes(redirectUri)) {
-    return c.json({ error: "invalid_redirect_uri" }, 400);
-  }
-
-  const requestId = createAuthorizationRequest({
-    clientId,
-    codeChallenge,
-    redirectUri,
-    state,
-  });
-  const consentUrl = new URL("/mcp/authorize", clientUrl);
-  consentUrl.searchParams.set("request_id", requestId);
-  return c.redirect(consentUrl.toString());
-});
-
-mcp.get("/mcp/authorize/request/:requestId", (c) => {
-  const request = getAuthorizationRequest(c.req.param("requestId"));
-  if (!request) {
-    return c.json({ error: "invalid_or_expired_request" }, 404);
-  }
-  const client = getClient(request.clientId);
-  if (!client) return c.json({ error: "invalid_client" }, 400);
-
-  return c.json({
-    client_name: client.clientName ?? "MCP client",
-    redirect_uri: request.redirectUri,
-  });
-});
-
-mcp.post("/mcp/authorize/request/:requestId", async (c) => {
-  if (!isTrustedConsentOrigin(c.req.raw)) {
-    return c.json({ error: "invalid_origin" }, 403);
-  }
-
-  const body = (await c.req.json().catch(() => null)) as {
-    approved?: unknown;
-  } | null;
-  if (typeof body?.approved !== "boolean") {
-    return c.json({ error: "invalid_request" }, 400);
-  }
-
-  const session = await auth.api.getSession({ headers: c.req.raw.headers });
-
-  if (!session?.user?.id) {
-    return c.json({ error: "unauthorized" }, 401);
-  }
-
-  const request = consumeAuthorizationRequest(c.req.param("requestId"));
-  if (!request) {
-    return c.json({ error: "invalid_or_expired_request" }, 404);
-  }
-  const client = getClient(request.clientId);
-  if (!client || !client.redirectUris.includes(request.redirectUri)) {
-    return c.json({ error: "invalid_client" }, 400);
-  }
-
-  if (!body.approved) {
-    return c.json({
-      redirect: buildAuthorizationRedirect(request, {
-        error: "access_denied",
-      }),
+mcp.post(
+  "/mcp/authorize/request/:requestId",
+  describeRoute({
+    operationId: "decideMcpAuthorizationRequest",
+    tags: ["MCP"],
+    description: "Approve or deny an MCP OAuth consent request",
+    responses: {
+      200: {
+        description: "OAuth client redirect",
+        content: {
+          "application/json": {
+            schema: resolver(authorizationDecisionResponseSchema),
+          },
+        },
+      },
+      400: {
+        description: "Invalid request or OAuth client",
+        content: {
+          "application/json": { schema: resolver(oauthErrorSchema) },
+        },
+      },
+      401: {
+        description: "Authentication required",
+        content: {
+          "application/json": { schema: resolver(oauthErrorSchema) },
+        },
+      },
+      403: {
+        description: "Untrusted request origin",
+        content: {
+          "application/json": { schema: resolver(oauthErrorSchema) },
+        },
+      },
+      404: {
+        description: "Unknown or expired authorization request",
+        content: {
+          "application/json": { schema: resolver(oauthErrorSchema) },
+        },
+      },
+    },
+  }),
+  validator("param", authorizationRequestParamSchema),
+  validator("json", authorizationDecisionSchema),
+  async (c) => {
+    const { requestId } = c.req.valid("param");
+    const redirect = await decideMcpAuthorizationRequest({
+      requestId,
+      decision: c.req.valid("json"),
+      headers: c.req.raw.headers,
+      origin: c.req.header("origin"),
     });
-  }
-
-  const code = createAuthCode({
-    clientId: request.clientId,
-    userId: session.user.id,
-    codeChallenge: request.codeChallenge,
-    redirectUri: request.redirectUri,
-  });
-  return c.json({
-    redirect: buildAuthorizationRedirect(request, { code }),
-  });
-});
+    return c.json({ redirect });
+  },
+);
 
 mcp.post("/mcp/token", async (c) => {
   const contentType = c.req.header("content-type") || "";

--- a/apps/api/src/mcp/oauth.ts
+++ b/apps/api/src/mcp/oauth.ts
@@ -18,8 +18,17 @@ type AuthCode = {
   expiresAt: number;
 };
 
+export type AuthorizationRequest = {
+  clientId: string;
+  codeChallenge: string;
+  redirectUri: string;
+  state?: string;
+  expiresAt: number;
+};
+
 const clients = new Map<string, RegisteredClient>();
 const codes = new Map<string, AuthCode>();
+const authorizationRequests = new Map<string, AuthorizationRequest>();
 
 export function getClient(clientId: string): RegisteredClient | undefined {
   return clients.get(clientId);
@@ -54,6 +63,41 @@ export function createAuthCode(params: {
   return code;
 }
 
+export function createAuthorizationRequest(params: {
+  clientId: string;
+  codeChallenge: string;
+  redirectUri: string;
+  state?: string;
+}): string {
+  const requestId = randomUUID();
+  authorizationRequests.set(requestId, {
+    ...params,
+    expiresAt: Date.now() + 10 * 60 * 1000,
+  });
+  return requestId;
+}
+
+export function getAuthorizationRequest(
+  requestId: string,
+): AuthorizationRequest | undefined {
+  const request = authorizationRequests.get(requestId);
+  if (!request) return undefined;
+  if (request.expiresAt < Date.now()) {
+    authorizationRequests.delete(requestId);
+    return undefined;
+  }
+  return request;
+}
+
+export function consumeAuthorizationRequest(
+  requestId: string,
+): AuthorizationRequest | undefined {
+  const request = getAuthorizationRequest(requestId);
+  if (!request) return undefined;
+  authorizationRequests.delete(requestId);
+  return request;
+}
+
 function base64url(buf: Buffer): string {
   return buf.toString("base64url");
 }
@@ -71,12 +115,12 @@ export async function exchangeCode(
 ): Promise<{ accessToken: string; expiresIn: number } | null> {
   const stored = codes.get(code);
   if (!stored) return null;
-  codes.delete(code);
 
   if (stored.clientId !== clientId) return null;
   if (stored.redirectUri !== redirectUri) return null;
   if (stored.expiresAt < Date.now()) return null;
   if (!verifyPkce(codeVerifier, stored.codeChallenge)) return null;
+  codes.delete(code);
 
   const sessionToken = randomUUID();
   const expiresIn = 30 * 24 * 60 * 60;

--- a/apps/api/src/mcp/oauth.ts
+++ b/apps/api/src/mcp/oauth.ts
@@ -29,6 +29,19 @@ export type AuthorizationRequest = {
 const clients = new Map<string, RegisteredClient>();
 const codes = new Map<string, AuthCode>();
 const authorizationRequests = new Map<string, AuthorizationRequest>();
+const maxAuthorizationRequests = 10_000;
+
+function pruneAuthorizationRequests(now = Date.now()): void {
+  for (const [requestId, request] of authorizationRequests) {
+    if (request.expiresAt < now) authorizationRequests.delete(requestId);
+  }
+
+  while (authorizationRequests.size >= maxAuthorizationRequests) {
+    const oldestRequestId = authorizationRequests.keys().next().value;
+    if (!oldestRequestId) break;
+    authorizationRequests.delete(oldestRequestId);
+  }
+}
 
 export function getClient(clientId: string): RegisteredClient | undefined {
   return clients.get(clientId);
@@ -69,6 +82,7 @@ export function createAuthorizationRequest(params: {
   redirectUri: string;
   state?: string;
 }): string {
+  pruneAuthorizationRequests();
   const requestId = randomUUID();
   authorizationRequests.set(requestId, {
     ...params,
@@ -115,12 +129,12 @@ export async function exchangeCode(
 ): Promise<{ accessToken: string; expiresIn: number } | null> {
   const stored = codes.get(code);
   if (!stored) return null;
+  codes.delete(code);
 
   if (stored.clientId !== clientId) return null;
   if (stored.redirectUri !== redirectUri) return null;
   if (stored.expiresAt < Date.now()) return null;
   if (!verifyPkce(codeVerifier, stored.codeChallenge)) return null;
-  codes.delete(code);
 
   const sessionToken = randomUUID();
   const expiresIn = 30 * 24 * 60 * 60;

--- a/apps/api/src/mcp/schemas.ts
+++ b/apps/api/src/mcp/schemas.ts
@@ -1,0 +1,73 @@
+import * as v from "valibot";
+
+function isValidRedirectUri(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.hash || url.username || url.password) return false;
+    if (["javascript:", "data:", "file:", "vbscript:"].includes(url.protocol)) {
+      return false;
+    }
+    if (url.protocol === "http:") {
+      return ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+    }
+    return (
+      url.protocol === "https:" || /^[a-z][a-z0-9+.-]*:$/.test(url.protocol)
+    );
+  } catch {
+    return false;
+  }
+}
+
+const redirectUriSchema = v.pipe(
+  v.string(),
+  v.maxLength(2048),
+  v.check(isValidRedirectUri, "Invalid redirect URI"),
+);
+
+export const clientRegistrationSchema = v.object({
+  redirect_uris: v.pipe(v.array(redirectUriSchema), v.minLength(1)),
+  client_name: v.optional(v.pipe(v.string(), v.maxLength(100))),
+  token_endpoint_auth_method: v.optional(v.literal("none")),
+  grant_types: v.optional(v.tuple([v.literal("authorization_code")])),
+  response_types: v.optional(v.tuple([v.literal("code")])),
+});
+
+export const authorizationQuerySchema = v.object({
+  response_type: v.literal("code"),
+  client_id: v.string(),
+  redirect_uri: redirectUriSchema,
+  code_challenge: v.pipe(v.string(), v.minLength(1)),
+  code_challenge_method: v.literal("S256"),
+  state: v.optional(v.string()),
+});
+
+export const authorizationRequestParamSchema = v.object({
+  requestId: v.string(),
+});
+
+export const authorizationDecisionSchema = v.object({
+  approved: v.boolean(),
+});
+
+export const oauthErrorSchema = v.object({
+  error: v.string(),
+});
+
+export const clientRegistrationResponseSchema = v.object({
+  client_id: v.string(),
+  client_id_issued_at: v.number(),
+  redirect_uris: v.array(v.string()),
+  client_name: v.optional(v.string()),
+  token_endpoint_auth_method: v.literal("none"),
+  grant_types: v.array(v.literal("authorization_code")),
+  response_types: v.array(v.literal("code")),
+});
+
+export const authorizationRequestResponseSchema = v.object({
+  client_name: v.string(),
+  redirect_uri: v.string(),
+});
+
+export const authorizationDecisionResponseSchema = v.object({
+  redirect: v.string(),
+});

--- a/apps/docs/core/integrations/mcp.mdx
+++ b/apps/docs/core/integrations/mcp.mdx
@@ -20,7 +20,7 @@ Point your MCP client at:
 https://your-kaneo-instance.com/api/mcp
 ```
 
-On first connect, you will be redirected to Kaneo's login page. After you sign in, all MCP tools run as your authenticated user.
+On first connect, you will be redirected to Kaneo to sign in and explicitly approve the MCP client. After approval, all MCP tools run as your authenticated user.
 
 The endpoint implements OAuth 2.1 with PKCE for authentication. Discovery metadata is available at:
 

--- a/apps/web/src/fetchers/mcp/get-authorization-request.ts
+++ b/apps/web/src/fetchers/mcp/get-authorization-request.ts
@@ -1,0 +1,27 @@
+import { getApiUrl } from "@/fetchers/get-api-url";
+
+export type McpAuthorizationRequest = {
+  clientName: string;
+  redirectUri: string;
+};
+
+export async function getMcpAuthorizationRequest(
+  requestId: string,
+): Promise<McpAuthorizationRequest> {
+  const response = await fetch(
+    getApiUrl(`/mcp/authorize/request/${encodeURIComponent(requestId)}`),
+    { credentials: "include" },
+  );
+  if (!response.ok) {
+    throw new Error("This authorization request is invalid or has expired.");
+  }
+
+  const body = (await response.json()) as {
+    client_name: string;
+    redirect_uri: string;
+  };
+  return {
+    clientName: body.client_name,
+    redirectUri: body.redirect_uri,
+  };
+}

--- a/apps/web/src/fetchers/mcp/submit-authorization-decision.ts
+++ b/apps/web/src/fetchers/mcp/submit-authorization-decision.ts
@@ -1,0 +1,22 @@
+import { getApiUrl } from "@/fetchers/get-api-url";
+
+export async function submitMcpAuthorizationDecision(
+  requestId: string,
+  approved: boolean,
+): Promise<string> {
+  const response = await fetch(
+    getApiUrl(`/mcp/authorize/request/${encodeURIComponent(requestId)}`),
+    {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ approved }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error("Could not complete the authorization request.");
+  }
+
+  const body = (await response.json()) as { redirect: string };
+  return body.redirect;
+}

--- a/apps/web/src/hooks/mutations/mcp/use-authorization-decision.ts
+++ b/apps/web/src/hooks/mutations/mcp/use-authorization-decision.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { submitMcpAuthorizationDecision } from "@/fetchers/mcp/submit-authorization-decision";
+import { toast } from "@/lib/toast";
 
 export function useMcpAuthorizationDecision() {
   return useMutation({
@@ -10,5 +11,6 @@ export function useMcpAuthorizationDecision() {
       requestId: string;
       approved: boolean;
     }) => submitMcpAuthorizationDecision(requestId, approved),
+    onError: (error) => toast.error(error.message),
   });
 }

--- a/apps/web/src/hooks/mutations/mcp/use-authorization-decision.ts
+++ b/apps/web/src/hooks/mutations/mcp/use-authorization-decision.ts
@@ -1,0 +1,14 @@
+import { useMutation } from "@tanstack/react-query";
+import { submitMcpAuthorizationDecision } from "@/fetchers/mcp/submit-authorization-decision";
+
+export function useMcpAuthorizationDecision() {
+  return useMutation({
+    mutationFn: ({
+      requestId,
+      approved,
+    }: {
+      requestId: string;
+      approved: boolean;
+    }) => submitMcpAuthorizationDecision(requestId, approved),
+  });
+}

--- a/apps/web/src/hooks/queries/mcp/use-authorization-request.ts
+++ b/apps/web/src/hooks/queries/mcp/use-authorization-request.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMcpAuthorizationRequest } from "@/fetchers/mcp/get-authorization-request";
+
+export function useMcpAuthorizationRequest(requestId: string) {
+  return useQuery({
+    queryKey: ["mcp-authorization-request", requestId],
+    queryFn: () => getMcpAuthorizationRequest(requestId),
+    enabled: Boolean(requestId),
+    retry: false,
+  });
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as DeviceIndexRouteImport } from './routes/device/index'
 import { Route as PublicProjectProjectIdRouteImport } from './routes/public-project.$projectId'
+import { Route as McpAuthorizeRouteImport } from './routes/mcp.authorize'
 import { Route as DeviceApproveRouteImport } from './routes/device/approve'
 import { Route as AuthVerifyOtpRouteImport } from './routes/auth/verify-otp'
 import { Route as AuthSignUpRouteImport } from './routes/auth/sign-up'
@@ -86,6 +87,11 @@ const DeviceIndexRoute = DeviceIndexRouteImport.update({
 const PublicProjectProjectIdRoute = PublicProjectProjectIdRouteImport.update({
   id: '/public-project/$projectId',
   path: '/public-project/$projectId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const McpAuthorizeRoute = McpAuthorizeRouteImport.update({
+  id: '/mcp/authorize',
+  path: '/mcp/authorize',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DeviceApproveRoute = DeviceApproveRouteImport.update({
@@ -337,6 +343,7 @@ export interface FileRoutesByFullPath {
   '/auth/sign-up': typeof AuthSignUpRoute
   '/auth/verify-otp': typeof AuthVerifyOtpRoute
   '/device/approve': typeof DeviceApproveRoute
+  '/mcp/authorize': typeof McpAuthorizeRoute
   '/public-project/$projectId': typeof PublicProjectProjectIdRoute
   '/device/': typeof DeviceIndexRoute
   '/dashboard': typeof LayoutAuthenticatedDashboardRouteWithChildren
@@ -380,6 +387,7 @@ export interface FileRoutesByTo {
   '/auth/sign-up': typeof AuthSignUpRoute
   '/auth/verify-otp': typeof AuthVerifyOtpRoute
   '/device/approve': typeof DeviceApproveRoute
+  '/mcp/authorize': typeof McpAuthorizeRoute
   '/public-project/$projectId': typeof PublicProjectProjectIdRoute
   '/device': typeof DeviceIndexRoute
   '/invitations': typeof LayoutAuthenticatedInvitationsRoute
@@ -425,6 +433,7 @@ export interface FileRoutesById {
   '/auth/sign-up': typeof AuthSignUpRoute
   '/auth/verify-otp': typeof AuthVerifyOtpRoute
   '/device/approve': typeof DeviceApproveRoute
+  '/mcp/authorize': typeof McpAuthorizeRoute
   '/public-project/$projectId': typeof PublicProjectProjectIdRoute
   '/device/': typeof DeviceIndexRoute
   '/_layout/_authenticated/dashboard': typeof LayoutAuthenticatedDashboardRouteWithChildren
@@ -471,6 +480,7 @@ export interface FileRouteTypes {
     | '/auth/sign-up'
     | '/auth/verify-otp'
     | '/device/approve'
+    | '/mcp/authorize'
     | '/public-project/$projectId'
     | '/device/'
     | '/dashboard'
@@ -514,6 +524,7 @@ export interface FileRouteTypes {
     | '/auth/sign-up'
     | '/auth/verify-otp'
     | '/device/approve'
+    | '/mcp/authorize'
     | '/public-project/$projectId'
     | '/device'
     | '/invitations'
@@ -558,6 +569,7 @@ export interface FileRouteTypes {
     | '/auth/sign-up'
     | '/auth/verify-otp'
     | '/device/approve'
+    | '/mcp/authorize'
     | '/public-project/$projectId'
     | '/device/'
     | '/_layout/_authenticated/dashboard'
@@ -599,6 +611,7 @@ export interface RootRouteChildren {
   AuthRoute: typeof AuthRouteWithChildren
   DeviceRoute: typeof DeviceRouteWithChildren
   TestErrorRoute: typeof TestErrorRoute
+  McpAuthorizeRoute: typeof McpAuthorizeRoute
   PublicProjectProjectIdRoute: typeof PublicProjectProjectIdRoute
   InvitationAcceptInviteIdRoute: typeof InvitationAcceptInviteIdRoute
 }
@@ -652,6 +665,13 @@ declare module '@tanstack/react-router' {
       path: '/public-project/$projectId'
       fullPath: '/public-project/$projectId'
       preLoaderRoute: typeof PublicProjectProjectIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mcp/authorize': {
+      id: '/mcp/authorize'
+      path: '/mcp/authorize'
+      fullPath: '/mcp/authorize'
+      preLoaderRoute: typeof McpAuthorizeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/device/approve': {
@@ -1130,6 +1150,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthRoute: AuthRouteWithChildren,
   DeviceRoute: DeviceRouteWithChildren,
   TestErrorRoute: TestErrorRoute,
+  McpAuthorizeRoute: McpAuthorizeRoute,
   PublicProjectProjectIdRoute: PublicProjectProjectIdRoute,
   InvitationAcceptInviteIdRoute: InvitationAcceptInviteIdRoute,
 }

--- a/apps/web/src/routes/mcp.authorize.tsx
+++ b/apps/web/src/routes/mcp.authorize.tsx
@@ -1,0 +1,139 @@
+import {
+  createFileRoute,
+  useNavigate,
+  useSearch,
+} from "@tanstack/react-router";
+import { z } from "zod/v4";
+import { AuthLayout } from "@/components/auth/layout";
+import { Button } from "@/components/ui/button";
+import { useMcpAuthorizationDecision } from "@/hooks/mutations/mcp/use-authorization-decision";
+import { useMcpAuthorizationRequest } from "@/hooks/queries/mcp/use-authorization-request";
+import { authClient } from "@/lib/auth-client";
+import { toast } from "@/lib/toast";
+
+const authorizationSearchSchema = z.object({
+  request_id: z.string().optional(),
+});
+
+export const Route = createFileRoute("/mcp/authorize")({
+  component: McpAuthorizePage,
+  validateSearch: authorizationSearchSchema,
+});
+
+function McpAuthorizePage() {
+  const navigate = useNavigate();
+  const search = useSearch({ from: "/mcp/authorize" });
+  const requestId = search.request_id ?? "";
+  const request = useMcpAuthorizationRequest(requestId);
+  const decision = useMcpAuthorizationDecision();
+  const { data: session, isPending: isSessionPending } =
+    authClient.useSession();
+
+  if (!requestId || request.isError) {
+    return (
+      <AuthLayout
+        title="Authorization failed"
+        subtitle="This authorization request is invalid or has expired."
+      >
+        <p className="text-sm text-muted-foreground">
+          Return to your MCP client and start the connection again.
+        </p>
+      </AuthLayout>
+    );
+  }
+
+  if (request.isLoading || isSessionPending) {
+    return (
+      <AuthLayout title="Authorize MCP client" subtitle="Loading request…">
+        <p className="text-sm text-muted-foreground">
+          Checking the authorization request.
+        </p>
+      </AuthLayout>
+    );
+  }
+
+  if (!session?.user) {
+    const redirectTarget = `/mcp/authorize?request_id=${encodeURIComponent(requestId)}`;
+    return (
+      <AuthLayout
+        title="Sign in to continue"
+        subtitle="Sign in before approving this MCP client."
+      >
+        <Button
+          type="button"
+          className="w-full"
+          onClick={() =>
+            void navigate({
+              to: "/auth/sign-in",
+              search: { redirect: redirectTarget },
+            })
+          }
+        >
+          Sign in
+        </Button>
+      </AuthLayout>
+    );
+  }
+
+  const submitDecision = (approved: boolean) => {
+    decision.mutate(
+      { requestId, approved },
+      {
+        onSuccess: (redirect) => window.location.assign(redirect),
+        onError: (error) => toast.error(error.message),
+      },
+    );
+  };
+
+  return (
+    <AuthLayout
+      title="Authorize MCP client"
+      subtitle="Review this request before granting access to your Kaneo account."
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          This client will be able to act as you and access your workspaces.
+          Only continue if you initiated this connection.
+        </p>
+        <div className="space-y-3 rounded-md border bg-muted/40 p-3">
+          <div>
+            <p className="text-xs font-medium text-muted-foreground">
+              Client name (self-reported)
+            </p>
+            <p className="mt-1 text-sm">
+              {request.data?.clientName ?? "MCP client"}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-medium text-muted-foreground">
+              Redirect URI
+            </p>
+            <p className="mt-1 break-all font-mono text-xs">
+              {request.data?.redirectUri}
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            className="flex-1"
+            loading={decision.isPending && decision.variables?.approved}
+            disabled={decision.isPending}
+            onClick={() => submitDecision(true)}
+          >
+            Approve
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            loading={decision.isPending && !decision.variables?.approved}
+            disabled={decision.isPending}
+            onClick={() => submitDecision(false)}
+          >
+            Deny
+          </Button>
+        </div>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/apps/web/src/routes/mcp.authorize.tsx
+++ b/apps/web/src/routes/mcp.authorize.tsx
@@ -9,7 +9,6 @@ import { Button } from "@/components/ui/button";
 import { useMcpAuthorizationDecision } from "@/hooks/mutations/mcp/use-authorization-decision";
 import { useMcpAuthorizationRequest } from "@/hooks/queries/mcp/use-authorization-request";
 import { authClient } from "@/lib/auth-client";
-import { toast } from "@/lib/toast";
 
 const authorizationSearchSchema = z.object({
   request_id: z.string().optional(),
@@ -80,7 +79,6 @@ function McpAuthorizePage() {
       { requestId, approved },
       {
         onSuccess: (redirect) => window.location.assign(redirect),
-        onError: (error) => toast.error(error.message),
       },
     );
   };

--- a/tests/api/mcp-oauth-security.test.ts
+++ b/tests/api/mcp-oauth-security.test.ts
@@ -35,6 +35,10 @@ vi.mock("../../apps/api/src/mcp/tools", () => ({
 }));
 
 import mcpRoutes from "../../apps/api/src/mcp";
+import {
+  createAuthorizationRequest,
+  getAuthorizationRequest,
+} from "../../apps/api/src/mcp/oauth";
 
 const clientUrl = process.env.KANEO_CLIENT_URL || "http://localhost:5173";
 const clientOrigin = new URL(clientUrl).origin;
@@ -60,6 +64,7 @@ function buildAuthorizeUrl(
   clientId: string,
   redirectUri: string,
   verifier: string,
+  state: string | undefined = "client-state",
 ) {
   const url = new URL("http://api.local/mcp/authorize");
   url.searchParams.set("response_type", "code");
@@ -67,8 +72,46 @@ function buildAuthorizeUrl(
   url.searchParams.set("redirect_uri", redirectUri);
   url.searchParams.set("code_challenge", challengeFor(verifier));
   url.searchParams.set("code_challenge_method", "S256");
-  url.searchParams.set("state", "client-state");
+  if (state !== undefined) url.searchParams.set("state", state);
   return url;
+}
+
+async function decideAuthorization(params: {
+  clientId: string;
+  redirectUri: string;
+  verifier: string;
+  approved: boolean;
+  state?: string;
+}) {
+  const authorizeUrl = buildAuthorizeUrl(
+    params.clientId,
+    params.redirectUri,
+    params.verifier,
+    params.state,
+  );
+  const authorize = await mcpRoutes.request(authorizeUrl.toString(), {
+    redirect: "manual",
+  });
+  expect(authorize.status).toBe(302);
+  const consentUrl = new URL(authorize.headers.get("location") ?? "");
+  const requestId = consentUrl.searchParams.get("request_id");
+  expect(requestId).toBeTruthy();
+
+  const decision = await mcpRoutes.request(
+    `/mcp/authorize/request/${requestId}`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        cookie: "victim_session=1",
+        origin: clientOrigin,
+      },
+      body: JSON.stringify({ approved: params.approved }),
+    },
+  );
+  expect(decision.status).toBe(200);
+  const body = (await decision.json()) as { redirect: string };
+  return new URL(body.redirect);
 }
 
 describe("MCP OAuth security", () => {
@@ -206,5 +249,74 @@ describe("MCP OAuth security", () => {
       },
     );
     expect(replay.status).toBe(404);
+  });
+
+  it("preserves an explicitly empty state value", async () => {
+    const redirectUri = "https://client.example/empty-state";
+    const client = await registerClient(redirectUri);
+    const callback = await decideAuthorization({
+      clientId: client.client_id,
+      redirectUri,
+      verifier: "empty-state-verifier",
+      approved: false,
+      state: "",
+    });
+
+    expect(callback.searchParams.get("error")).toBe("access_denied");
+    expect(callback.searchParams.has("state")).toBe(true);
+    expect(callback.searchParams.get("state")).toBe("");
+  });
+
+  it("consumes an authorization code after a failed redemption attempt", async () => {
+    const redirectUri = "https://client.example/single-use";
+    const verifier = "single-use-verifier";
+    const client = await registerClient(redirectUri);
+    const callback = await decideAuthorization({
+      clientId: client.client_id,
+      redirectUri,
+      verifier,
+      approved: true,
+    });
+    const code = callback.searchParams.get("code") ?? "";
+
+    const redeem = (codeVerifier: string) =>
+      mcpRoutes.request("/mcp/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          client_id: client.client_id,
+          redirect_uri: redirectUri,
+          code_verifier: codeVerifier,
+        }),
+      });
+
+    expect((await redeem("incorrect-verifier")).status).toBe(400);
+    expect((await redeem(verifier)).status).toBe(400);
+  });
+
+  it("sweeps expired authorization requests when creating a new one", () => {
+    const now = Date.now();
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(now);
+      const expiredRequestId = createAuthorizationRequest({
+        clientId: "client-expired",
+        redirectUri: "https://client.example/expired",
+        codeChallenge: "challenge",
+      });
+
+      vi.setSystemTime(now + 10 * 60 * 1000 + 1);
+      createAuthorizationRequest({
+        clientId: "client-current",
+        redirectUri: "https://client.example/current",
+        codeChallenge: "challenge",
+      });
+
+      expect(getAuthorizationRequest(expiredRequestId)).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/api/mcp-oauth-security.test.ts
+++ b/tests/api/mcp-oauth-security.test.ts
@@ -1,0 +1,210 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const insertedSessions: Array<Record<string, unknown>> = [];
+  const getSession = vi.fn(async ({ headers }: { headers: Headers }) => {
+    const cookie = new Headers(headers).get("cookie") ?? "";
+    if (cookie.includes("victim_session=1")) {
+      return {
+        user: { id: "victim-user" },
+        session: { token: "victim-cookie-token" },
+      };
+    }
+    return null;
+  });
+  const insert = vi.fn(() => ({
+    values: vi.fn(async (row: Record<string, unknown>) => {
+      insertedSessions.push(row);
+      return row;
+    }),
+  }));
+  return { getSession, insert, insertedSessions };
+});
+
+vi.mock("../../apps/api/src/auth", () => ({
+  auth: { api: { getSession: mocks.getSession } },
+}));
+
+vi.mock("../../apps/api/src/database", () => ({
+  default: { insert: mocks.insert },
+}));
+
+vi.mock("../../apps/api/src/mcp/tools", () => ({
+  registerMcpTools: vi.fn(),
+}));
+
+import mcpRoutes from "../../apps/api/src/mcp";
+
+const clientUrl = process.env.KANEO_CLIENT_URL || "http://localhost:5173";
+const clientOrigin = new URL(clientUrl).origin;
+
+function challengeFor(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+async function registerClient(redirectUri: string) {
+  const response = await mcpRoutes.request("/mcp/register", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      client_name: "Test MCP client",
+      redirect_uris: [redirectUri],
+    }),
+  });
+  expect(response.status).toBe(200);
+  return (await response.json()) as { client_id: string };
+}
+
+function buildAuthorizeUrl(
+  clientId: string,
+  redirectUri: string,
+  verifier: string,
+) {
+  const url = new URL("http://api.local/mcp/authorize");
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("code_challenge", challengeFor(verifier));
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("state", "client-state");
+  return url;
+}
+
+describe("MCP OAuth security", () => {
+  it("rejects empty and unsafe redirect URI registrations", async () => {
+    const empty = await mcpRoutes.request("/mcp/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ redirect_uris: [] }),
+    });
+    expect(empty.status).toBe(400);
+
+    const remoteHttp = await mcpRoutes.request("/mcp/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        redirect_uris: ["http://attacker.example/callback"],
+      }),
+    });
+    expect(remoteHttp.status).toBe(400);
+  });
+
+  it("requires an exact registered redirect URI", async () => {
+    const registeredRedirect = "https://client.example/callback";
+    const client = await registerClient(registeredRedirect);
+    const authorizeUrl = buildAuthorizeUrl(
+      client.client_id,
+      "https://attacker.example/collect",
+      "verifier-for-redirect-check",
+    );
+
+    const response = await mcpRoutes.request(authorizeUrl.toString(), {
+      redirect: "manual",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "invalid_redirect_uri",
+    });
+  });
+
+  it("requires explicit same-origin approval before issuing a code", async () => {
+    const redirectUri = "https://client.example/callback";
+    const verifier = "attacker-known-verifier-1234567890";
+    const client = await registerClient(redirectUri);
+    const authorizeUrl = buildAuthorizeUrl(
+      client.client_id,
+      redirectUri,
+      verifier,
+    );
+
+    const authorize = await mcpRoutes.request(authorizeUrl.toString(), {
+      headers: { cookie: "victim_session=1" },
+      redirect: "manual",
+    });
+    expect(authorize.status).toBe(302);
+    const consentUrl = new URL(authorize.headers.get("location") ?? "");
+    expect(consentUrl.origin).toBe(clientOrigin);
+    expect(consentUrl.pathname).toBe("/mcp/authorize");
+    expect(consentUrl.searchParams.has("code")).toBe(false);
+    expect(mocks.getSession).not.toHaveBeenCalled();
+
+    const requestId = consentUrl.searchParams.get("request_id");
+    expect(requestId).toBeTruthy();
+
+    const crossOriginDecision = await mcpRoutes.request(
+      `/mcp/authorize/request/${requestId}`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie: "victim_session=1",
+          origin: "https://attacker.example",
+        },
+        body: JSON.stringify({ approved: true }),
+      },
+    );
+    expect(crossOriginDecision.status).toBe(403);
+
+    const unauthenticatedDecision = await mcpRoutes.request(
+      `/mcp/authorize/request/${requestId}`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: clientOrigin,
+        },
+        body: JSON.stringify({ approved: true }),
+      },
+    );
+    expect(unauthenticatedDecision.status).toBe(401);
+
+    const approval = await mcpRoutes.request(
+      `/mcp/authorize/request/${requestId}`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie: "victim_session=1",
+          origin: clientOrigin,
+        },
+        body: JSON.stringify({ approved: true }),
+      },
+    );
+    expect(approval.status).toBe(200);
+    const approvalBody = (await approval.json()) as { redirect: string };
+    const callback = new URL(approvalBody.redirect);
+    expect(callback.origin + callback.pathname).toBe(redirectUri);
+    expect(callback.searchParams.get("state")).toBe("client-state");
+    const code = callback.searchParams.get("code");
+    expect(code).toBeTruthy();
+
+    const token = await mcpRoutes.request("/mcp/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code: code ?? "",
+        client_id: client.client_id,
+        redirect_uri: redirectUri,
+        code_verifier: verifier,
+      }),
+    });
+    expect(token.status).toBe(200);
+    expect(mocks.insertedSessions.at(-1)?.userId).toBe("victim-user");
+
+    const replay = await mcpRoutes.request(
+      `/mcp/authorize/request/${requestId}`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie: "victim_session=1",
+          origin: clientOrigin,
+        },
+        body: JSON.stringify({ approved: true }),
+      },
+    );
+    expect(replay.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

- validate dynamic OAuth client metadata and require non-empty, safe redirect URI registrations
- enforce exact redirect URI matching plus the `code` response type and PKCE `S256`
- replace the cookie-driven authorization auto-grant with a short-lived, server-bound consent request
- add an authenticated, same-origin Approve/Deny page that shows the self-reported client name and redirect URI
- add regression coverage for redirect injection, cross-origin approval, unauthenticated approval, request replay, and the complete approved code exchange
- update the MCP documentation to describe explicit client approval

## Root cause

The authorization endpoint immediately issued an authorization code whenever the browser already had a valid Kaneo session. Because dynamic client registration was public and redirect URI validation could be bypassed, an untrusted client could choose its own PKCE challenge and redirect URI, navigate a signed-in user to the authorization endpoint, then exchange the returned code for a 30-day Better Auth bearer session.

The approval callback also accepted client and redirect parameters without binding them to a validated authorization request.

## Impact

Authorization now requires an explicit user decision. Client ID, redirect URI, PKCE challenge, and state are bound server-side to a random, single-use request that expires after ten minutes. The decision endpoint requires both a valid Kaneo session and the configured web-client origin.

## Validation

- `pnpm --filter @kaneo/api test:unit` — 161 tests passed
- `pnpm --filter @kaneo/api build`
- `pnpm --filter @kaneo/web build`
- pre-commit `biome ci .`
- pre-commit full monorepo `pnpm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new MCP authorization page where signed-in users can view client details and approve or deny access.
  * Added a secure request/consent flow for MCP authorization outcomes.
  * Added sign-in redirection when authorization requires authentication.
* **Bug Fixes**
  * Strengthened validation of registered redirect URIs and authorization parameters.
  * Ensured authorization decisions are origin-protected and codes are single-use.
  * Expired authorization requests are now rejected.
* **Documentation**
  * Clarified the MCP client approval step during connection.
* **Tests**
  * Added end-to-end coverage for the secure registration/consent, redirect validation, and token exchange flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->