### PR TITLE
fix(assets): prevent active content execution

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -111,9 +111,13 @@ type ApiVariables = {
 };
 
 const SAFE_INLINE_ASSET_TYPES = new Set([
+  "image/apng",
   "image/avif",
   "image/gif",
+  "image/heic",
+  "image/heif",
   "image/jpeg",
+  "image/jpg",
   "image/png",
   "image/webp",
 ]);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -110,7 +110,15 @@ type ApiVariables = {
   };
 };
 
-function buildContentDisposition(filename: string) {
+const SAFE_INLINE_ASSET_TYPES = new Set([
+  "image/avif",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
+function buildContentDisposition(filename: string, inline: boolean) {
   const normalized = filename
     .normalize("NFC")
     .replace(/[\r\n"]/g, "")
@@ -129,7 +137,8 @@ function buildContentDisposition(filename: string) {
     (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
   );
 
-  return `inline; filename="${asciiFallback}"; filename*=UTF-8''${encodedFilename}`;
+  const disposition = inline ? "inline" : "attachment";
+  return `${disposition}; filename="${asciiFallback}"; filename*=UTF-8''${encodedFilename}`;
 }
 
 export function createApp() {
@@ -291,15 +300,27 @@ export function createApp() {
 
       try {
         const object = await getPrivateObject(asset.objectKey);
+        const storedContentType =
+          (object.contentType || asset.mimeType)
+            .toLowerCase()
+            .split(";")[0]
+            ?.trim() ?? "";
+        const inline = SAFE_INLINE_ASSET_TYPES.has(storedContentType);
 
         return new Response(object.body as BodyInit, {
           headers: {
             "Cache-Control": asset.isPublic
               ? "public, max-age=300"
               : "private, max-age=120",
-            "Content-Disposition": buildContentDisposition(asset.filename),
+            "Content-Disposition": buildContentDisposition(
+              asset.filename,
+              inline,
+            ),
             "Content-Length": object.contentLength?.toString() || "",
-            "Content-Type": object.contentType || asset.mimeType,
+            "Content-Type": inline
+              ? storedContentType
+              : "application/octet-stream",
+            "X-Content-Type-Options": "nosniff",
             ETag: object.etag || "",
             "Last-Modified": object.lastModified?.toUTCString() || "",
           },

--- a/apps/api/src/storage/s3.ts
+++ b/apps/api/src/storage/s3.ts
@@ -24,7 +24,6 @@ const allowedImageMimeTypes = new Set([
   "image/jpeg",
   "image/jpg",
   "image/png",
-  "image/svg+xml",
   "image/webp",
 ]);
 

--- a/apps/web/src/lib/upload-task-image.ts
+++ b/apps/web/src/lib/upload-task-image.ts
@@ -11,7 +11,6 @@ const allowedImageMimeTypes = new Set([
   "image/jpeg",
   "image/jpg",
   "image/png",
-  "image/svg+xml",
   "image/webp",
 ]);
 


### PR DESCRIPTION
## Description
Serves only safe raster image types inline. Other uploaded assets are forced to download as `application/octet-stream`, with MIME sniffing disabled.

Root cause: The asset endpoint trusted the stored MIME type and used `Content-Disposition: inline` for attacker-controlled HTML, SVG, and other active formats.

Impact: Opening an uploaded attachment can no longer execute attacker-controlled content in Kaneo's application origin.

## Related Issue(s)
Security finding; no public issue.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other: `pnpm --filter @kaneo/api build` and Biome check

## Screenshots (if applicable)
Not applicable.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset downloads by displaying safe file types directly in the browser.
  * Downloads of potentially unsafe file types are now forced to download as attachments.
  * Added more consistent content type handling for downloaded assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->