### PR TITLE
fix(editor): reject active embed URL schemes

### DIFF
--- a/apps/web/src/components/task/extensions/embed-block.ts
+++ b/apps/web/src/components/task/extensions/embed-block.ts
@@ -5,9 +5,8 @@ type EmbedMode = "embed" | "link";
 
 function isValidUrl(value: string) {
   try {
-    // eslint-disable-next-line no-new
-    new URL(value);
-    return true;
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
   } catch {
     return false;
   }
@@ -117,6 +116,14 @@ export const EmbedBlock = Node.create({
           { class: "kaneo-embed-unsupported" },
           i18n.t("tasks:detail.editor.embed.onlyYoutubeInline"),
         ],
+      ];
+    }
+
+    if (!isValidUrl(url)) {
+      return [
+        "div",
+        attrs,
+        ["span", { class: "kaneo-embed-invalid-link" }, url],
       ];
     }
 

--- a/apps/web/src/components/task/extensions/embed-block.ts
+++ b/apps/web/src/components/task/extensions/embed-block.ts
@@ -88,6 +88,14 @@ export const EmbedBlock = Node.create({
       contenteditable: "false",
     });
 
+    if (!isValidUrl(url)) {
+      return [
+        "div",
+        attrs,
+        ["span", { class: "kaneo-embed-invalid-link" }, url],
+      ];
+    }
+
     if (embedSource) {
       return [
         "div",
@@ -119,14 +127,6 @@ export const EmbedBlock = Node.create({
       ];
     }
 
-    if (!isValidUrl(url)) {
-      return [
-        "div",
-        attrs,
-        ["span", { class: "kaneo-embed-invalid-link" }, url],
-      ];
-    }
-
     return [
       "div",
       attrs,
@@ -149,7 +149,9 @@ export const EmbedBlock = Node.create({
   ) {
     const url = String(node.attrs?.url || "");
     const mode = node.attrs?.mode === "link" ? "link" : "embed";
-    if (!isValidUrl(url)) return "";
+    if (!isValidUrl(url)) {
+      return `\n<span class="kaneo-embed-invalid-link">${escapeHtml(url)}</span>\n`;
+    }
     return `\n<kaneo-embed url="${escapeHtml(url)}" mode="${mode}" />\n`;
   },
 });


### PR DESCRIPTION
## Description
Restricts custom embed links to HTTP and HTTPS and renders unsafe stored values as inert text.

Root cause: URL validation accepted every scheme supported by `new URL()`, including `javascript:`.

Impact: Stored task descriptions and comments can no longer create script-executing embed links.

## Related Issue(s)
Security finding; no public issue.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other: `pnpm --filter @kaneo/web build` and Biome check

## Screenshots (if applicable)
Not applicable.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embed URL validation to accept only HTTP and HTTPS links.
  * Invalid embed URLs now display a clear fallback message instead of rendering unsupported embed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->