### PR TITLE
fix(gitea): bind webhooks to signed integration

### DIFF
--- a/apps/api/src/plugins/gitea/services/integration-lookup.ts
+++ b/apps/api/src/plugins/gitea/services/integration-lookup.ts
@@ -11,28 +11,34 @@ export async function findAllIntegrationsByGiteaRepo(
   integrationId?: string,
 ) {
   const normalized = normalizeGiteaBaseUrl(baseUrl);
+  const conditions = [
+    eq(integrationTable.type, "gitea"),
+    eq(integrationTable.isActive, true),
+  ];
+  if (integrationId) {
+    conditions.push(eq(integrationTable.id, integrationId));
+  }
+
   const integrations = await db.query.integrationTable.findMany({
-    where: and(
-      eq(integrationTable.type, "gitea"),
-      eq(integrationTable.isActive, true),
-    ),
+    where: and(...conditions),
     with: {
       project: true,
     },
   });
 
   return integrations.filter((integration) => {
-    if (integrationId && integration.id !== integrationId) {
-      return false;
-    }
-
     try {
       const config = JSON.parse(integration.config) as GiteaConfig;
-      return (
+      const matches =
         normalizeGiteaBaseUrl(config.baseUrl) === normalized &&
         config.repositoryOwner === owner &&
-        config.repositoryName === repo
-      );
+        config.repositoryName === repo;
+      if (integrationId && !matches) {
+        console.warn("[Gitea Webhook] Signed integration repository mismatch", {
+          integrationId,
+        });
+      }
+      return matches;
     } catch {
       return false;
     }

--- a/apps/api/src/plugins/gitea/services/integration-lookup.ts
+++ b/apps/api/src/plugins/gitea/services/integration-lookup.ts
@@ -8,6 +8,7 @@ export async function findAllIntegrationsByGiteaRepo(
   baseUrl: string,
   owner: string,
   repo: string,
+  integrationId?: string,
 ) {
   const normalized = normalizeGiteaBaseUrl(baseUrl);
   const integrations = await db.query.integrationTable.findMany({
@@ -21,6 +22,10 @@ export async function findAllIntegrationsByGiteaRepo(
   });
 
   return integrations.filter((integration) => {
+    if (integrationId && integration.id !== integrationId) {
+      return false;
+    }
+
     try {
       const config = JSON.parse(integration.config) as GiteaConfig;
       return (

--- a/apps/api/src/plugins/gitea/webhook-handler.ts
+++ b/apps/api/src/plugins/gitea/webhook-handler.ts
@@ -115,7 +115,7 @@ export async function handleGiteaWebhookRequest(
   }
 
   try {
-    await dispatchGiteaEvent(event, payload);
+    await dispatchGiteaEvent(event, payload, integration.id);
     return { success: true };
   } catch (error) {
     console.error("[Gitea Webhook] Handler error:", error);
@@ -129,13 +129,14 @@ export async function handleGiteaWebhookRequest(
 async function dispatchGiteaEvent(
   event: string,
   payload: Record<string, unknown>,
+  integrationId: string,
 ) {
   console.log(`[Gitea Webhook] Event: ${event}`);
 
   switch (event) {
     case "push":
       if (isPushPayload(payload)) {
-        await handleGiteaPush(payload);
+        await handleGiteaPush(payload, integrationId);
       }
       return;
     case "pull_request": {
@@ -146,11 +147,12 @@ async function dispatchGiteaEvent(
         action === "ready_for_review"
       ) {
         if (isPullRequestPayload(payload)) {
-          await handleGiteaPullRequestOpened(payload);
+          await handleGiteaPullRequestOpened(payload, integrationId);
         }
       } else if (action === "closed" && isPullRequestPayload(payload)) {
         await handleGiteaPullRequestClosed(
           payload as unknown as GiteaPullRequestClosedPayload,
+          integrationId,
         );
       }
       return;
@@ -162,40 +164,45 @@ async function dispatchGiteaEvent(
         (action === "opened" || action === "created") &&
         isIssuePayload(payload)
       ) {
-        await handleGiteaIssueOpened(payload);
+        await handleGiteaIssueOpened(payload, integrationId);
       } else if (action === "reopened" && isIssuePayload(payload)) {
         await handleGiteaIssueReopened(
           payload as unknown as GiteaIssueReopenedPayload,
+          integrationId,
         );
       } else if (action === "closed" && isIssuePayload(payload)) {
         await handleGiteaIssueClosed(
           payload as unknown as GiteaIssueClosedPayload,
+          integrationId,
         );
       } else if (action === "edited" && isIssuePayload(payload)) {
-        await handleGiteaIssueEdited(payload);
+        await handleGiteaIssueEdited(payload, integrationId);
       } else if (
         isIssuePayload(payload) &&
         (action === "labeled" ||
           action === "unlabeled" ||
           action === "label_updated")
       ) {
-        await handleGiteaIssueLabeled({
-          ...payload,
-          action: action ?? "",
-        });
+        await handleGiteaIssueLabeled(
+          {
+            ...payload,
+            action: action ?? "",
+          },
+          integrationId,
+        );
       }
       return;
     }
     case "issue_comment": {
       const action = payload.action as string | undefined;
       if (action === "created" && isIssueCommentPayload(payload)) {
-        await handleGiteaIssueCommentCreated(payload);
+        await handleGiteaIssueCommentCreated(payload, integrationId);
       }
       return;
     }
     case "issue_label": {
       if (isLabelPayload(payload)) {
-        await handleGiteaLabelCreated(payload);
+        await handleGiteaLabelCreated(payload, integrationId);
       }
       return;
     }

--- a/apps/api/src/plugins/gitea/webhooks/issue-closed.ts
+++ b/apps/api/src/plugins/gitea/webhooks/issue-closed.ts
@@ -31,7 +31,10 @@ type IssueClosedPayload = {
   };
 };
 
-export async function handleGiteaIssueClosed(payload: IssueClosedPayload) {
+export async function handleGiteaIssueClosed(
+  payload: IssueClosedPayload,
+  integrationId?: string,
+) {
   if (payload.action !== "closed") {
     return;
   }
@@ -46,6 +49,7 @@ export async function handleGiteaIssueClosed(payload: IssueClosedPayload) {
     baseUrl,
     owner,
     repository.name,
+    integrationId,
   );
 
   for (const integration of integrations) {

--- a/apps/api/src/plugins/gitea/webhooks/issue-comment-created.ts
+++ b/apps/api/src/plugins/gitea/webhooks/issue-comment-created.ts
@@ -32,6 +32,7 @@ type IssueCommentCreatedPayload = {
 
 export async function handleGiteaIssueCommentCreated(
   payload: IssueCommentCreatedPayload,
+  integrationId?: string,
 ) {
   const { issue, comment, repository } = payload;
 
@@ -52,6 +53,7 @@ export async function handleGiteaIssueCommentCreated(
     baseUrl,
     owner,
     repository.name,
+    integrationId,
   );
 
   for (const integration of integrations) {

--- a/apps/api/src/plugins/gitea/webhooks/issue-edited.ts
+++ b/apps/api/src/plugins/gitea/webhooks/issue-edited.ts
@@ -31,7 +31,10 @@ type IssueEditedPayload = {
   };
 };
 
-export async function handleGiteaIssueEdited(payload: IssueEditedPayload) {
+export async function handleGiteaIssueEdited(
+  payload: IssueEditedPayload,
+  integrationId?: string,
+) {
   const { issue, repository, changes } = payload;
 
   if (!changes?.title && !changes?.body) {
@@ -46,6 +49,7 @@ export async function handleGiteaIssueEdited(payload: IssueEditedPayload) {
     baseUrl,
     owner,
     repository.name,
+    integrationId,
   );
 
   for (const integration of integrations) {

--- a/apps/api/src/plugins/gitea/webhooks/issue-labeled.ts
+++ b/apps/api/src/plugins/gitea/webhooks/issue-labeled.ts
@@ -112,7 +112,10 @@ async function syncGiteaLabelsToTask(
   }
 }
 
-export async function handleGiteaIssueLabeled(payload: IssueLabeledPayload) {
+export async function handleGiteaIssueLabeled(
+  payload: IssueLabeledPayload,
+  integrationId?: string,
+) {
   const { issue, repository, label: addedLabel } = payload;
 
   const baseUrl = baseUrlFromRepositoryHtmlUrl(repository.html_url);
@@ -123,6 +126,7 @@ export async function handleGiteaIssueLabeled(payload: IssueLabeledPayload) {
     baseUrl,
     owner,
     repository.name,
+    integrationId,
   );
 
   for (const integration of integrations) {

--- a/apps/api/src/plugins/gitea/webhooks/issue-opened.ts
+++ b/apps/api/src/plugins/gitea/webhooks/issue-opened.ts
@@ -39,7 +39,10 @@ type IssueOpenedPayload = {
   };
 };
 
-export async function handleGiteaIssueOpened(payload: IssueOpenedPayload) {
+export async function handleGiteaIssueOpened(
+  payload: IssueOpenedPayload,
+  integrationId?: string,
+) {
   const { issue, repository } = payload;
 
   const baseUrl = baseUrlFromRepositoryHtmlUrl(repository.html_url);
@@ -52,6 +55,7 @@ export async function handleGiteaIssueOpened(payload: IssueOpenedPayload) {
     baseUrl,
     owner,
     repository.name,
+    integrationId,
   );
 
   if (integrations.length === 0) {

--- a/apps/api/src/plugins/gitea/webhooks/issue-reopened.ts
+++ b/apps/api/src/plugins/gitea/webhooks/issue-reopened.ts
@@ -31,7 +31,10 @@ type IssueReopenedPayload = {
   };
 };
 
-export async function handleGiteaIssueReopened(payload: IssueReopenedPayload) {
+export async function handleGiteaIssueReopened(
+  payload: IssueReopenedPayload,
+  integrationId?: string,
+) {
   if (payload.action !== "reopened") {
     return;
   }
@@ -46,6 +49,7 @@ export async function handleGiteaIssueReopened(payload: IssueReopenedPayload) {
     baseUrl,
     owner,
     repository.name,
+    integrationId,
   );
 
   for (const integration of integrations) {

--- a/apps/api/src/plugins/gitea/webhooks/label-created.ts
+++ b/apps/api/src/plugins/gitea/webhooks/label-created.ts
@@ -23,7 +23,10 @@ type LabelCreatePayload = {
   };
 };
 
-export async function handleGiteaLabelCreated(payload: LabelCreatePayload) {
+export async function handleGiteaLabelCreated(
+  payload: LabelCreatePayload,
+  integrationId?: string,
+) {
   if ((payload.ref_type && payload.ref_type !== "label") || !payload.label) {
     return;
   }
@@ -38,6 +41,7 @@ export async function handleGiteaLabelCreated(payload: LabelCreatePayload) {
     baseUrl,
     owner,
     repository.name,
+    integrationId,
   );
 
   for (const integration of integrations) {

--- a/apps/api/src/plugins/gitea/webhooks/pull-request-closed.ts
+++ b/apps/api/src/plugins/gitea/webhooks/pull-request-closed.ts
@@ -35,7 +35,10 @@ type PRClosedPayload = {
   };
 };
 
-export async function handleGiteaPullRequestClosed(payload: PRClosedPayload) {
+export async function handleGiteaPullRequestClosed(
+  payload: PRClosedPayload,
+  integrationId?: string,
+) {
   const { pull_request, repository } = payload;
 
   const baseUrl = baseUrlFromRepositoryHtmlUrl(repository.html_url);
@@ -46,6 +49,7 @@ export async function handleGiteaPullRequestClosed(payload: PRClosedPayload) {
     baseUrl,
     owner,
     repository.name,
+    integrationId,
   );
 
   for (const integration of integrations) {

--- a/apps/api/src/plugins/gitea/webhooks/pull-request-opened.ts
+++ b/apps/api/src/plugins/gitea/webhooks/pull-request-opened.ts
@@ -39,7 +39,10 @@ type PROpenedPayload = {
   };
 };
 
-export async function handleGiteaPullRequestOpened(payload: PROpenedPayload) {
+export async function handleGiteaPullRequestOpened(
+  payload: PROpenedPayload,
+  integrationId?: string,
+) {
   const { pull_request, repository } = payload;
 
   const baseUrl = baseUrlFromRepositoryHtmlUrl(repository.html_url);
@@ -50,6 +53,7 @@ export async function handleGiteaPullRequestOpened(payload: PROpenedPayload) {
     baseUrl,
     owner,
     repository.name,
+    integrationId,
   );
 
   for (const integration of integrations) {

--- a/apps/api/src/plugins/gitea/webhooks/push.ts
+++ b/apps/api/src/plugins/gitea/webhooks/push.ts
@@ -43,7 +43,10 @@ const PROTECTED_BRANCHES = [
   "production",
 ];
 
-export async function handleGiteaPush(payload: PushPayload) {
+export async function handleGiteaPush(
+  payload: PushPayload,
+  integrationId?: string,
+) {
   const { ref, repository } = payload;
 
   if (!ref.startsWith("refs/heads/")) {
@@ -68,6 +71,7 @@ export async function handleGiteaPush(payload: PushPayload) {
     origin,
     owner,
     repository.name,
+    integrationId,
   );
 
   if (integrations.length === 0) {


### PR DESCRIPTION
## Description
Carries the URL integration ID through every Gitea webhook handler and restricts repository lookup to that exact integration.

Root cause: Signature verification used the URL integration, but event handlers independently selected integrations from attacker-controlled repository fields.

Impact: A valid secret for one integration can no longer authorize events against another workspace's integration.

## Related Issue(s)
Security finding; no public issue.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other: `pnpm --filter @kaneo/api build` and Biome check

## Screenshots (if applicable)
Not applicable.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gitea webhook processing by ensuring events are applied only to the matching integration.
  * Prevented cross-integration updates when multiple integrations reference the same repository.
  * Added warnings when a signed repository configuration does not match the incoming event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->