### PR TITLE
fix(labels): enforce task workspace boundary

### DIFF
--- a/apps/api/src/label/controllers/create-label.ts
+++ b/apps/api/src/label/controllers/create-label.ts
@@ -31,6 +31,12 @@ async function createLabel(
       });
     }
 
+    if (task.workspaceId !== workspaceId) {
+      throw new HTTPException(404, {
+        message: "Task not found",
+      });
+    }
+
     const [inserted] = await db
       .insert(labelTable)
       .values({ name, color, taskId, workspaceId: task.workspaceId })


### PR DESCRIPTION
## Description
Rejects task-scoped label creation unless the selected task belongs to the already-authorized workspace.

Root cause: The route authorized `workspaceId`, but the controller trusted an unrelated `taskId` and switched to the task's workspace.

Impact: Users can no longer create or synchronize labels in another workspace by supplying a foreign task ID.

## Related Issue(s)
Security finding; no public issue.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other: `pnpm --filter @kaneo/api build` and Biome check

## Screenshots (if applicable)
Not applicable.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published