### PR TITLE
docs(security): remove public default MinIO credentials

### DIFF
--- a/apps/docs/core/installation/object-storage-and-image-uploads.mdx
+++ b/apps/docs/core/installation/object-storage-and-image-uploads.mdx
@@ -38,13 +38,13 @@ It gives you:
 Example `.env` values:
 
 ```env
-MINIO_ROOT_USER=minioadmin
-MINIO_ROOT_PASSWORD=minioadmin
+MINIO_ROOT_USER=kaneo-local
+MINIO_ROOT_PASSWORD=<choose-a-local-development-password>
 
 S3_ENDPOINT=http://minio:9000
 S3_BUCKET=kaneo-uploads
-S3_ACCESS_KEY_ID=minioadmin
-S3_SECRET_ACCESS_KEY=minioadmin
+S3_ACCESS_KEY_ID=kaneo-local
+S3_SECRET_ACCESS_KEY=<choose-a-local-development-password>
 S3_REGION=us-east-1
 S3_FORCE_PATH_STYLE=true
 ```

--- a/apps/docs/core/installation/object-storage-and-image-uploads.mdx
+++ b/apps/docs/core/installation/object-storage-and-image-uploads.mdx
@@ -71,11 +71,17 @@ Use a public MinIO hostname instead, for example:
 ```env
 S3_ENDPOINT=https://files.cloud.kaneo.app
 S3_BUCKET=kaneo-uploads
-S3_ACCESS_KEY_ID=minioadmin
-S3_SECRET_ACCESS_KEY=minioadmin
+S3_ACCESS_KEY_ID=kaneo
+S3_SECRET_ACCESS_KEY=<generate-a-strong-random-secret>
 S3_REGION=us-east-1
 S3_FORCE_PATH_STYLE=true
 ```
+
+<Warning>
+  Never expose MinIO with its default `minioadmin` root credentials. Create a
+  dedicated, bucket-scoped user and generate unique credentials for every
+  deployment.
+</Warning>
 
 ## Recommended public setup
 

--- a/apps/docs/core/installation/storage-backends.mdx
+++ b/apps/docs/core/installation/storage-backends.mdx
@@ -81,8 +81,8 @@ Then use:
 ```env
 S3_ENDPOINT=https://files.cloud.kaneo.app
 S3_BUCKET=kaneo-uploads
-S3_ACCESS_KEY_ID=minioadmin
-S3_SECRET_ACCESS_KEY=minioadmin
+S3_ACCESS_KEY_ID=kaneo
+S3_SECRET_ACCESS_KEY=<generate-a-strong-random-secret>
 S3_REGION=us-east-1
 S3_FORCE_PATH_STYLE=true
 ```
@@ -90,8 +90,14 @@ S3_FORCE_PATH_STYLE=true
 You also need:
 
 - a created bucket
+- a dedicated, non-root MinIO user with access limited to that bucket
 - MinIO CORS allowing your Kaneo origin
 - no anonymous bucket read policy is required
+
+<Warning>
+  Never expose MinIO with its default `minioadmin` root credentials. Generate
+  unique credentials for every deployment and keep the MinIO Console private.
+</Warning>
 
 ## AWS S3
 

--- a/apps/docs/core/installation/storage-backends.mdx
+++ b/apps/docs/core/installation/storage-backends.mdx
@@ -52,13 +52,13 @@ MinIO is the recommended self-hosted option.
 For local development, this is fine:
 
 ```env
-MINIO_ROOT_USER=minioadmin
-MINIO_ROOT_PASSWORD=minioadmin
+MINIO_ROOT_USER=kaneo-local
+MINIO_ROOT_PASSWORD=<choose-a-local-development-password>
 
 S3_ENDPOINT=http://minio:9000
 S3_BUCKET=kaneo-uploads
-S3_ACCESS_KEY_ID=minioadmin
-S3_SECRET_ACCESS_KEY=minioadmin
+S3_ACCESS_KEY_ID=kaneo-local
+S3_SECRET_ACCESS_KEY=<choose-a-local-development-password>
 S3_REGION=us-east-1
 S3_FORCE_PATH_STYLE=true
 ```
@@ -229,13 +229,13 @@ Matching `.env`:
 KANEO_CLIENT_URL=https://cloud.kaneo.app
 KANEO_API_URL=https://cloud.kaneo.app/api
 
-MINIO_ROOT_USER=minioadmin
-MINIO_ROOT_PASSWORD=change-me
+MINIO_ROOT_USER=<generate-a-unique-admin-user>
+MINIO_ROOT_PASSWORD=<generate-a-strong-random-secret>
 
 S3_ENDPOINT=https://files.cloud.kaneo.app
 S3_BUCKET=kaneo-uploads
-S3_ACCESS_KEY_ID=minioadmin
-S3_SECRET_ACCESS_KEY=change-me
+S3_ACCESS_KEY_ID=<generate-a-unique-admin-user>
+S3_SECRET_ACCESS_KEY=<generate-a-strong-random-secret>
 S3_REGION=us-east-1
 S3_FORCE_PATH_STYLE=true
 ```


### PR DESCRIPTION
## Description
Replaces default root credentials in public MinIO examples with dedicated generated credentials and adds an explicit production warning.

Root cause: Production documentation reused MinIO's publicly known `minioadmin` root credentials.

Impact: Operators are directed toward unique, bucket-scoped credentials instead of exposing a known root login.

## Related Issue(s)
Security finding; no public issue.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other: `pnpm --filter @kaneo/site build` and `git diff --check`

## Screenshots (if applicable)
Not applicable.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published