### PR TITLE
fix(api): prioritize project workspace lookup

### DIFF
--- a/apps/api/src/utils/workspace-access-middleware.ts
+++ b/apps/api/src/utils/workspace-access-middleware.ts
@@ -245,10 +245,7 @@ export const workspaceAccess = {
 
   fromProject: (idKey = "id") =>
     workspaceAccessMiddleware({
-      sources: [
-        { type: "lookup", resource: "project", idKey },
-        { type: "query", key: "workspaceId" },
-      ],
+      sources: [{ type: "lookup", resource: "project", idKey }],
     }),
 
   fromTask: (idKey = "id") =>

--- a/apps/api/src/utils/workspace-access-middleware.ts
+++ b/apps/api/src/utils/workspace-access-middleware.ts
@@ -246,8 +246,8 @@ export const workspaceAccess = {
   fromProject: (idKey = "id") =>
     workspaceAccessMiddleware({
       sources: [
-        { type: "query", key: "workspaceId" },
         { type: "lookup", resource: "project", idKey },
+        { type: "query", key: "workspaceId" },
       ],
     }),
 

--- a/tests/api-integration/workspace-rbac.test.ts
+++ b/tests/api-integration/workspace-rbac.test.ts
@@ -188,6 +188,33 @@ describe("API integration: workspace RBAC enforcement", () => {
       // workspaceAccess.fromProject runs first and rejects with its own message
       expect(response.status).toBe(403);
     });
+
+    it("does not authorize a project through a conflicting workspaceId query", async () => {
+      const attacker = await createWorkspaceMember({ role: "admin" });
+      const victim = await createWorkspaceMember({ role: "admin" });
+      const { project } = await createProjectFixture({
+        workspaceId: victim.workspace.id,
+      });
+
+      mockAuthenticatedSession(attacker.user);
+      const { app } = createApp();
+
+      const response = await app.request(
+        `/api/task/${project.id}?workspaceId=${attacker.workspace.id}`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            title: "Cross-workspace probe",
+            description: "",
+            priority: "low",
+            status: "to-do",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(403);
+    });
   });
 
   describe("custom workspace roles", () => {


### PR DESCRIPTION
## Description
Makes `workspaceAccess.fromProject()` derive the workspace from the project before considering a query-string fallback.

Root cause: A caller-controlled `workspaceId` query parameter was evaluated before the path project ID.

Impact: Discord integrations, project columns, workflow rules, and other project routes can no longer be authorized against an unrelated workspace.

## Related Issue(s)
Security finding; no public issue.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other: `pnpm --filter @kaneo/api build` and Biome check

## Screenshots (if applicable)
Not applicable.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published