### PR TITLE
fix(tasks): prevent cross-workspace relations

### DIFF
--- a/apps/api/src/task-relation/controllers/create-task-relation.ts
+++ b/apps/api/src/task-relation/controllers/create-task-relation.ts
@@ -13,11 +13,13 @@ async function createTaskRelation({
   targetTaskId,
   relationType,
   userId,
+  workspaceId,
 }: {
   sourceTaskId: string;
   targetTaskId: string;
   relationType: string;
   userId: string;
+  workspaceId: string;
 }) {
   if (sourceTaskId === targetTaskId) {
     throw new HTTPException(400, {
@@ -33,7 +35,12 @@ async function createTaskRelation({
     })
     .from(taskTable)
     .innerJoin(projectTable, eq(taskTable.projectId, projectTable.id))
-    .where(eq(taskTable.id, sourceTaskId))
+    .where(
+      and(
+        eq(taskTable.id, sourceTaskId),
+        eq(projectTable.workspaceId, workspaceId),
+      ),
+    )
     .limit(1);
 
   if (!sourceTask) {
@@ -48,17 +55,16 @@ async function createTaskRelation({
     })
     .from(taskTable)
     .innerJoin(projectTable, eq(taskTable.projectId, projectTable.id))
-    .where(eq(taskTable.id, targetTaskId))
+    .where(
+      and(
+        eq(taskTable.id, targetTaskId),
+        eq(projectTable.workspaceId, workspaceId),
+      ),
+    )
     .limit(1);
 
   if (!targetTask) {
     throw new HTTPException(404, { message: "Target task not found" });
-  }
-
-  if (sourceTask.workspaceId !== targetTask.workspaceId) {
-    throw new HTTPException(400, {
-      message: "Tasks from different workspaces cannot be related",
-    });
   }
 
   const existing = await db

--- a/apps/api/src/task-relation/controllers/create-task-relation.ts
+++ b/apps/api/src/task-relation/controllers/create-task-relation.ts
@@ -1,7 +1,11 @@
 import { and, eq, or } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import db from "../../database";
-import { taskRelationTable, taskTable } from "../../database/schema";
+import {
+  projectTable,
+  taskRelationTable,
+  taskTable,
+} from "../../database/schema";
 import { publishEvent } from "../../events";
 
 async function createTaskRelation({
@@ -22,8 +26,13 @@ async function createTaskRelation({
   }
 
   const [sourceTask] = await db
-    .select({ id: taskTable.id, projectId: taskTable.projectId })
+    .select({
+      id: taskTable.id,
+      projectId: taskTable.projectId,
+      workspaceId: projectTable.workspaceId,
+    })
     .from(taskTable)
+    .innerJoin(projectTable, eq(taskTable.projectId, projectTable.id))
     .where(eq(taskTable.id, sourceTaskId))
     .limit(1);
 
@@ -32,13 +41,24 @@ async function createTaskRelation({
   }
 
   const [targetTask] = await db
-    .select({ id: taskTable.id, projectId: taskTable.projectId })
+    .select({
+      id: taskTable.id,
+      projectId: taskTable.projectId,
+      workspaceId: projectTable.workspaceId,
+    })
     .from(taskTable)
+    .innerJoin(projectTable, eq(taskTable.projectId, projectTable.id))
     .where(eq(taskTable.id, targetTaskId))
     .limit(1);
 
   if (!targetTask) {
     throw new HTTPException(404, { message: "Target task not found" });
+  }
+
+  if (sourceTask.workspaceId !== targetTask.workspaceId) {
+    throw new HTTPException(400, {
+      message: "Tasks from different workspaces cannot be related",
+    });
   }
 
   const existing = await db

--- a/apps/api/src/task-relation/controllers/get-task-relations.ts
+++ b/apps/api/src/task-relation/controllers/get-task-relations.ts
@@ -1,8 +1,24 @@
-import { eq, inArray, or } from "drizzle-orm";
+import { and, eq, inArray, or } from "drizzle-orm";
 import db from "../../database";
-import { taskRelationTable, taskTable, userTable } from "../../database/schema";
+import {
+  projectTable,
+  taskRelationTable,
+  taskTable,
+  userTable,
+} from "../../database/schema";
 
 async function getTaskRelations(taskId: string) {
+  const [requestedTask] = await db
+    .select({ workspaceId: projectTable.workspaceId })
+    .from(taskTable)
+    .innerJoin(projectTable, eq(taskTable.projectId, projectTable.id))
+    .where(eq(taskTable.id, taskId))
+    .limit(1);
+
+  if (!requestedTask) {
+    return [];
+  }
+
   const relations = await db
     .select({
       id: taskRelationTable.id,
@@ -52,19 +68,27 @@ async function getTaskRelations(taskId: string) {
         assigneeName: userTable.name,
       })
       .from(taskTable)
+      .innerJoin(projectTable, eq(taskTable.projectId, projectTable.id))
       .leftJoin(userTable, eq(taskTable.userId, userTable.id))
-      .where(inArray(taskTable.id, [...taskIds]));
+      .where(
+        and(
+          inArray(taskTable.id, [...taskIds]),
+          eq(projectTable.workspaceId, requestedTask.workspaceId),
+        ),
+      );
 
     for (const task of taskRows) {
       tasks.set(task.id, task);
     }
   }
 
-  return relations.map((rel) => ({
-    ...rel,
-    sourceTask: tasks.get(rel.sourceTaskId) ?? null,
-    targetTask: tasks.get(rel.targetTaskId) ?? null,
-  }));
+  return relations
+    .filter((rel) => tasks.has(rel.sourceTaskId) && tasks.has(rel.targetTaskId))
+    .map((rel) => ({
+      ...rel,
+      sourceTask: tasks.get(rel.sourceTaskId) ?? null,
+      targetTask: tasks.get(rel.targetTaskId) ?? null,
+    }));
 }
 
 export default getTaskRelations;

--- a/apps/api/src/task-relation/controllers/get-task-relations.ts
+++ b/apps/api/src/task-relation/controllers/get-task-relations.ts
@@ -7,18 +7,7 @@ import {
   userTable,
 } from "../../database/schema";
 
-async function getTaskRelations(taskId: string) {
-  const [requestedTask] = await db
-    .select({ workspaceId: projectTable.workspaceId })
-    .from(taskTable)
-    .innerJoin(projectTable, eq(taskTable.projectId, projectTable.id))
-    .where(eq(taskTable.id, taskId))
-    .limit(1);
-
-  if (!requestedTask) {
-    return [];
-  }
-
+async function getTaskRelations(taskId: string, workspaceId: string) {
   const relations = await db
     .select({
       id: taskRelationTable.id,
@@ -73,7 +62,7 @@ async function getTaskRelations(taskId: string) {
       .where(
         and(
           inArray(taskTable.id, [...taskIds]),
-          eq(projectTable.workspaceId, requestedTask.workspaceId),
+          eq(projectTable.workspaceId, workspaceId),
         ),
       );
 

--- a/apps/api/src/task-relation/index.ts
+++ b/apps/api/src/task-relation/index.ts
@@ -45,7 +45,7 @@ const taskRelation = new Hono<{
     workspaceAccess.fromTaskId("taskId"),
     async (c) => {
       const { taskId } = c.req.valid("param");
-      const relations = await getTaskRelations(taskId);
+      const relations = await getTaskRelations(taskId, c.get("workspaceId"));
       return c.json(relations);
     },
   )
@@ -100,6 +100,7 @@ const taskRelation = new Hono<{
         targetTaskId,
         relationType,
         userId,
+        workspaceId: c.get("workspaceId"),
       });
       return c.json(relation);
     },


### PR DESCRIPTION
## Description
Requires both related tasks to share a workspace and filters legacy cross-workspace relation rows from reads.

Root cause: Relation creation authorized only the source task and fetched the target task by ID without checking its workspace.

Impact: Users can no longer create cross-tenant relation state or retrieve private task metadata through relations.

## Related Issue(s)
Security finding; no public issue.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other: `pnpm --filter @kaneo/api build` and Biome check

## Screenshots (if applicable)
Not applicable.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published