### PR TITLE
fix(auth): protect invitation acceptance from unverified accounts

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -52,6 +52,13 @@ const isRegistrationDisabled = process.env.DISABLE_REGISTRATION === "true";
 const isPasswordRegistrationDisabled =
   process.env.DISABLE_PASSWORD_REGISTRATION === "true";
 
+function normalizeInvitationId(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  if (!/^[a-z0-9_-]{1,128}$/i.test(normalized)) return undefined;
+  return normalized;
+}
+
 const apiUrl = process.env.KANEO_API_URL || "http://localhost:1337";
 const clientUrl = process.env.KANEO_CLIENT_URL || "http://localhost:5173";
 const isHttps = apiUrl.startsWith("https://");
@@ -486,10 +493,11 @@ export const auth = betterAuth({
             return;
           }
 
-          const invitationId =
+          const invitationId = normalizeInvitationId(
             ctx?.body?.invitationId ||
-            ctx?.query?.invitationId ||
-            ctx?.headers?.get("x-invitation-id");
+              ctx?.query?.invitationId ||
+              ctx?.headers?.get("x-invitation-id"),
+          );
           const result = await checkRegistrationAllowed(
             user.email,
             invitationId,
@@ -638,10 +646,11 @@ export const auth = betterAuth({
         ctx.body?.email ||
         ctx.query?.email ||
         ctx.headers?.get("x-invitation-email");
-      const invitationId =
+      const invitationId = normalizeInvitationId(
         ctx.body?.invitationId ||
-        ctx.query?.invitationId ||
-        ctx.headers?.get("x-invitation-id");
+          ctx.query?.invitationId ||
+          ctx.headers?.get("x-invitation-id"),
+      );
 
       if (ctx.path === "/sign-up/email") {
         const result = await checkRegistrationAllowed(email, invitationId);

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -473,7 +473,7 @@ export const auth = betterAuth({
   databaseHooks: {
     user: {
       create: {
-        before: async (user) => {
+        before: async (user, ctx) => {
           // Allow the very first signup through even when registration
           // is disabled — that's the instance-admin bootstrap flow.
           // Otherwise a fresh instance with DISABLE_REGISTRATION=true
@@ -486,7 +486,14 @@ export const auth = betterAuth({
             return;
           }
 
-          const result = await checkRegistrationAllowed(user.email);
+          const invitationId =
+            ctx?.body?.invitationId ||
+            ctx?.query?.invitationId ||
+            ctx?.headers?.get("x-invitation-id");
+          const result = await checkRegistrationAllowed(
+            user.email,
+            invitationId,
+          );
           if (!result.allowed) {
             throw new APIError("FORBIDDEN", {
               message: result.reason,

--- a/apps/api/src/invitation/index.ts
+++ b/apps/api/src/invitation/index.ts
@@ -1,3 +1,4 @@
+import type { User } from "better-auth/types";
 import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import * as v from "valibot";
@@ -6,6 +7,7 @@ import getUserPendingInvitations from "./controllers/get-user-pending-invitation
 
 const invitation = new Hono<{
   Variables: {
+    user: User | null;
     userId: string;
     userEmail: string;
   };
@@ -41,6 +43,11 @@ const invitation = new Hono<{
       },
     }),
     async (c) => {
+      const user = c.get("user");
+      if (!user?.emailVerified) {
+        return c.json([]);
+      }
+
       const userEmail = c.get("userEmail");
       const invitations = await getUserPendingInvitations(userEmail);
       return c.json(invitations);

--- a/apps/api/src/utils/check-registration-allowed.ts
+++ b/apps/api/src/utils/check-registration-allowed.ts
@@ -29,11 +29,11 @@ export async function checkRegistrationAllowed(
     };
   }
 
-  if (!invitationId && !email) {
+  if (!invitationId) {
     return {
       allowed: false,
       reason:
-        "Registration is currently disabled. Please contact your administrator for an invitation.",
+        "Registration is currently disabled. Please use a valid invitation link to create an account.",
     };
   }
 
@@ -73,7 +73,7 @@ async function findValidInvitation(
     conditions.push(eq(invitationTable.email, email.toLowerCase()));
   }
 
-  if (!invitationId && !email) {
+  if (!invitationId) {
     return null;
   }
 

--- a/apps/web/src/components/auth/sign-up-form.tsx
+++ b/apps/web/src/components/auth/sign-up-form.tsx
@@ -71,15 +71,21 @@ export function SignUpForm({
   const onSubmit = async (data: SignUpFormValues) => {
     setIsPending(true);
     try {
+      const headers: Record<string, string> = {};
+      if (turnstileToken) {
+        headers["x-turnstile-token"] = turnstileToken;
+      }
+      if (invitationId) {
+        headers["x-invitation-id"] = invitationId;
+      }
+
       const result = await authClient.signUp.email(
         {
           email: data.email,
           name: data.name,
           password: data.password,
         },
-        turnstileToken
-          ? { headers: { "x-turnstile-token": turnstileToken } }
-          : undefined,
+        Object.keys(headers).length > 0 ? { headers } : undefined,
       );
 
       if (result.error) {


### PR DESCRIPTION
## Description
Requires a verified session before exposing pending invitation IDs and requires the invitation ID when disabled registration is bypassed through an invitation.

Root cause: An unverified password account could enumerate invitations by email and use the email-only registration exception without proving mailbox ownership.

Impact: Attackers can no longer claim workspace invitations addressed to an email account they do not control.

## Related Issue(s)
Security finding; no public issue.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other: API build, Biome check, and 158 API unit tests

## Screenshots (if applicable)
Not applicable.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published