### PR TITLE
fix(auth): require verified email for account linking

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -187,15 +187,11 @@ export const auth = betterAuth({
       // providers verify the email on their side, so they are trusted to link.
       enabled: true,
       trustedProviders: ["github", "google", "discord", "custom"],
-      // Kaneo does not require email verification on password signup, so the
-      // existing local account is usually unverified; allow linking to it so
-      // OIDC users are not locked out.
-      // SECURITY: with open password registration this means someone who
-      // pre-registered a victim's email (unverified) could be linked into by
-      // that victim's OIDC login. Instances that allow password signup
-      // alongside OIDC should set DISABLE_PASSWORD_REGISTRATION or require email
-      // verification.
-      requireLocalEmailVerified: false,
+      // Only link to an existing local account after its email has been
+      // verified. Without this check, an attacker could pre-register a victim's
+      // email with a password account and retain access after the victim signs
+      // in through a trusted OAuth/OIDC provider.
+      requireLocalEmailVerified: true,
     },
   },
   emailAndPassword: {

--- a/apps/docs/core/installation/environment-variables.mdx
+++ b/apps/docs/core/installation/environment-variables.mdx
@@ -86,6 +86,10 @@ Name | Description | Default |
 | `DISABLE_LOGIN_FORM` | Hide the email/password login form on the sign-in page. When set to `true`, only SSO/OAuth buttons are shown. Useful when you want to enforce authentication exclusively through an external identity provider. | `false` |
 | `CUSTOM_OAUTH_AUTO_LOGIN` | Automatically redirect to the custom OAuth/OIDC provider instead of showing the sign-in page. When set to `true`, users are immediately redirected to your identity provider without seeing the login page. Requires a custom OAuth provider to be configured. | `false` |
 
+<Warning>
+  Before enabling SSO-only access with `DISABLE_LOGIN_FORM=true` or `CUSTOM_OAUTH_AUTO_LOGIN=true` on an existing installation, make sure existing local accounts have verified email addresses. OAuth/OIDC identities cannot be linked to an unverified local account, and affected users will receive `error=account_not_linked`. Keep the login form available until those users have signed in with an email OTP or magic link. If SSO-only access is already enabled, temporarily set both options to `false`, restart Kaneo, and let affected users complete an email sign-in before restoring the SSO-only settings.
+</Warning>
+
 ### Notifications
 
 Name | Description | Default |

--- a/apps/docs/core/social-providers/custom-oauth.mdx
+++ b/apps/docs/core/social-providers/custom-oauth.mdx
@@ -178,9 +178,11 @@ This will automatically discover the authorization, token, and userinfo endpoint
 
 ## Account linking
 
-When a user signs in with this provider using an email that already belongs to a Kaneo account (for example one created with email and password), Kaneo can link the OIDC identity to that existing account instead of failing with `error=account_not_linked`. GitHub, Google, Discord, and this custom provider are trusted to link because they verify the user's email.
+When a user signs in with this provider using an email that already belongs to a Kaneo account (for example one created with email and password), Kaneo can link the OIDC identity to that existing account instead of failing with `error=account_not_linked`. GitHub, Google, and Discord are trusted because they verify email ownership. Kaneo also treats the configured custom provider as trusted, but it cannot verify the provider's email claims itself. Only use a custom provider that guarantees ownership of every returned email address; otherwise, an attacker-controlled email claim could be linked to an existing verified account.
 
 For safety, Kaneo only links to an existing local account if that account's email has already been verified. This prevents someone from pre-registering another person's email with a password account and retaining access after the real owner signs in through OIDC. If your instance allows password registration alongside OIDC, consider setting `DISABLE_PASSWORD_REGISTRATION=true` or requiring email verification for password users to avoid account-linking surprises.
+
+On existing installations, local accounts created before this requirement may still have an unverified email. Those users will receive `error=account_not_linked` until they verify the local account. Before enforcing SSO-only access, keep the login form available so affected users can sign in with an email OTP or magic link, which verifies the email. If users are already locked out, temporarily set `DISABLE_LOGIN_FORM=false` and `CUSTOM_OAUTH_AUTO_LOGIN=false`, restart Kaneo, and have them complete an email sign-in before enabling SSO-only access again.
 
 ## Security Notes
 
@@ -188,4 +190,3 @@ For safety, Kaneo only links to an existing local account if that account's emai
 - Keep your client secret secure and never commit it to version control
 - Enable PKCE when possible for enhanced security
 - Use the most restrictive scopes necessary for your use case
-

--- a/apps/docs/core/social-providers/custom-oauth.mdx
+++ b/apps/docs/core/social-providers/custom-oauth.mdx
@@ -178,9 +178,9 @@ This will automatically discover the authorization, token, and userinfo endpoint
 
 ## Account linking
 
-When a user signs in with this provider using an email that already belongs to a Kaneo account (for example one created with email and password), Kaneo links the OIDC identity to that existing account instead of failing with `error=account_not_linked`. GitHub, Google, Discord, and this custom provider are trusted to link because they verify the user's email.
+When a user signs in with this provider using an email that already belongs to a Kaneo account (for example one created with email and password), Kaneo can link the OIDC identity to that existing account instead of failing with `error=account_not_linked`. GitHub, Google, Discord, and this custom provider are trusted to link because they verify the user's email.
 
-Because Kaneo does not require email verification on password signup, linking also applies to unverified local accounts so OIDC users are not locked out. If your instance allows password registration alongside OIDC, set `DISABLE_PASSWORD_REGISTRATION=true` (or require email verification) so that nobody can pre-register another person's email and have an OIDC login linked into it.
+For safety, Kaneo only links to an existing local account if that account's email has already been verified. This prevents someone from pre-registering another person's email with a password account and retaining access after the real owner signs in through OIDC. If your instance allows password registration alongside OIDC, consider setting `DISABLE_PASSWORD_REGISTRATION=true` or requiring email verification for password users to avoid account-linking surprises.
 
 ## Security Notes
 

--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -150,7 +150,10 @@
 			"oidcError": "Anmeldung mit OIDC fehlgeschlagen",
 			"googleError": "Anmeldung mit Google fehlgeschlagen",
 			"githubError": "Anmeldung mit GitHub fehlgeschlagen",
-			"discordError": "Anmeldung mit Discord fehlgeschlagen"
+			"discordError": "Anmeldung mit Discord fehlgeschlagen",
+			"errors": {
+				"account_not_linked": "This identity could not be linked to the existing account. Sign in by email to verify the account, then try SSO again. If email sign-in is unavailable, contact your administrator."
+			}
 		},
 		"providers": {
 			"google": "Google",

--- a/i18n/el-GR.json
+++ b/i18n/el-GR.json
@@ -150,7 +150,10 @@
 			"oidcError": "Αποτυχία σύνδεσης με OIDC",
 			"googleError": "Αποτυχία σύνδεσης με Google",
 			"githubError": "Αποτυχία σύνδεσης με GitHub",
-			"discordError": "Αποτυχία σύνδεσης με Discord"
+			"discordError": "Αποτυχία σύνδεσης με Discord",
+			"errors": {
+				"account_not_linked": "This identity could not be linked to the existing account. Sign in by email to verify the account, then try SSO again. If email sign-in is unavailable, contact your administrator."
+			}
 		},
 		"providers": {
 			"google": "Google",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -152,6 +152,7 @@
 			"githubError": "Failed to sign in with GitHub",
 			"discordError": "Failed to sign in with Discord",
 			"errors": {
+				"account_not_linked": "This identity could not be linked to the existing account. Sign in by email to verify the account, then try SSO again. If email sign-in is unavailable, contact your administrator.",
 				"oauth_code_verification_failed": "OAuth verification failed. Please try again.",
 				"registration_is_currently_disabled_you_need_a_valid_invitation_to_create_an_account_": "Registration is currently disabled. You need a valid invitation to create an account."
 			}

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -149,7 +149,10 @@
 			"oidcError": "Error al iniciar sesión con OIDC",
 			"googleError": "Error al iniciar sesión con Google",
 			"githubError": "Error al iniciar sesión con GitHub",
-			"discordError": "Error al iniciar sesión con Discord"
+			"discordError": "Error al iniciar sesión con Discord",
+			"errors": {
+				"account_not_linked": "This identity could not be linked to the existing account. Sign in by email to verify the account, then try SSO again. If email sign-in is unavailable, contact your administrator."
+			}
 		},
 		"providers": {
 			"google": "Google",

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -150,7 +150,10 @@
 			"oidcError": "Échec de la connexion avec OIDC",
 			"googleError": "Échec de la connexion avec Google",
 			"githubError": "Échec de la connexion avec GitHub",
-			"discordError": "Échec de la connexion avec Discord"
+			"discordError": "Échec de la connexion avec Discord",
+			"errors": {
+				"account_not_linked": "This identity could not be linked to the existing account. Sign in by email to verify the account, then try SSO again. If email sign-in is unavailable, contact your administrator."
+			}
 		},
 		"providers": {
 			"google": "Google",

--- a/i18n/id-ID.json
+++ b/i18n/id-ID.json
@@ -152,6 +152,7 @@
 			"githubError": "Gagal masuk dengan GitHub",
 			"discordError": "Gagal masuk dengan Discord",
 			"errors": {
+				"account_not_linked": "This identity could not be linked to the existing account. Sign in by email to verify the account, then try SSO again. If email sign-in is unavailable, contact your administrator.",
 				"oauth_code_verification_failed": "Verifikasi OAuth gagal. Silakan coba lagi.",
 				"registration_is_currently_disabled_you_need_a_valid_invitation_to_create_an_account_": "Pendaftaran saat ini dinonaktifkan. Anda memerlukan undangan yang valid untuk membuat akun."
 			}

--- a/i18n/ko-KR.json
+++ b/i18n/ko-KR.json
@@ -150,7 +150,10 @@
 			"oidcError": "OIDC 로그인에 실패했습니다",
 			"googleError": "Google 로그인에 실패했습니다",
 			"githubError": "GitHub 로그인에 실패했습니다",
-			"discordError": "Discord 로그인에 실패했습니다"
+			"discordError": "Discord 로그인에 실패했습니다",
+			"errors": {
+				"account_not_linked": "This identity could not be linked to the existing account. Sign in by email to verify the account, then try SSO again. If email sign-in is unavailable, contact your administrator."
+			}
 		},
 		"providers": {
 			"google": "Google",

--- a/i18n/mk-MK.json
+++ b/i18n/mk-MK.json
@@ -150,7 +150,10 @@
 			"oidcError": "Неуспешна најава со OIDC",
 			"googleError": "Неуспешна најава со Google",
 			"githubError": "Неуспешна најава со GitHub",
-			"discordError": "Неуспешна најава со Discord"
+			"discordError": "Неуспешна најава со Discord",
+			"errors": {
+				"account_not_linked": "This identity could not be linked to the existing account. Sign in by email to verify the account, then try SSO again. If email sign-in is unavailable, contact your administrator."
+			}
 		},
 		"providers": {
 			"google": "Google",

--- a/i18n/nl-NL.json
+++ b/i18n/nl-NL.json
@@ -149,7 +149,10 @@
 			"oidcError": "Inloggen met OIDC mislukt",
 			"googleError": "Inloggen met Google mislukt",
 			"githubError": "Inloggen met GitHub mislukt",
-			"discordError": "Inloggen met Discord mislukt"
+			"discordError": "Inloggen met Discord mislukt",
+			"errors": {
+				"account_not_linked": "This identity could not be linked to the existing account. Sign in by email to verify the account, then try SSO again. If email sign-in is unavailable, contact your administrator."
+			}
 		},
 		"providers": {
 			"google": "Google",

--- a/i18n/ru-RU.json
+++ b/i18n/ru-RU.json
@@ -150,7 +150,10 @@
 			"oidcError": "Не удалось войти через OIDC",
 			"googleError": "Не удалось войти через Google",
 			"githubError": "Не удалось войти через GitHub",
-			"discordError": "Не удалось войти через Discord"
+			"discordError": "Не удалось войти через Discord",
+			"errors": {
+				"account_not_linked": "This identity could not be linked to the existing account. Sign in by email to verify the account, then try SSO again. If email sign-in is unavailable, contact your administrator."
+			}
 		},
 		"providers": {
 			"google": "Google",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -592,6 +592,9 @@
 							"type": "object",
 							"additionalProperties": false,
 							"properties": {
+								"account_not_linked": {
+									"type": "string"
+								},
 								"oauth_code_verification_failed": {
 									"type": "string"
 								},
@@ -600,6 +603,7 @@
 								}
 							},
 							"required": [
+								"account_not_linked",
 								"oauth_code_verification_failed",
 								"registration_is_currently_disabled_you_need_a_valid_invitation_to_create_an_account_"
 							]

--- a/i18n/uk-UA.json
+++ b/i18n/uk-UA.json
@@ -150,7 +150,10 @@
 			"oidcError": "Не вдалося увійти через OIDC",
 			"googleError": "Не вдалося увійти через Google",
 			"githubError": "Не вдалося увійти через GitHub",
-			"discordError": "Не вдалося увійти через Discord"
+			"discordError": "Не вдалося увійти через Discord",
+			"errors": {
+				"account_not_linked": "This identity could not be linked to the existing account. Sign in by email to verify the account, then try SSO again. If email sign-in is unavailable, contact your administrator."
+			}
 		},
 		"providers": {
 			"google": "Google",


### PR DESCRIPTION
## Description
Requires an existing local account's email to be verified before Better Auth automatically links a trusted OAuth/OIDC provider, and documents the migration behavior.

Root cause: Automatic same-email provider linking explicitly accepted unverified local password accounts.

Impact: An attacker who pre-registers a victim's email can no longer retain password access after the victim signs in through OAuth/OIDC.

## Related Issue(s)
Security finding; no public issue.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other: API build, Biome check, and 158 API unit tests

## Screenshots (if applicable)
Not applicable.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published