### PR TITLE
fix(board): reflect disabled card dragging

### DIFF
--- a/apps/web/src/components/kanban-board/column/column-dropzone.tsx
+++ b/apps/web/src/components/kanban-board/column/column-dropzone.tsx
@@ -9,11 +9,13 @@ import TaskCard from "../task-card";
 
 type ColumnDropzoneProps = {
   column: ProjectWithTasks["columns"][number];
+  disableDragDrop?: boolean;
   onIsOverChange?: (isOver: boolean) => void;
 };
 
 export function ColumnDropzone({
   column,
+  disableDragDrop = false,
   onIsOverChange,
 }: ColumnDropzoneProps) {
   const { setNodeRef, isOver } = useDroppable({
@@ -36,7 +38,11 @@ export function ColumnDropzone({
       >
         <div className="flex flex-col gap-2">
           {column.tasks.map((task) => (
-            <TaskCard key={task.id} task={task} />
+            <TaskCard
+              key={task.id}
+              task={task}
+              disableDragDrop={disableDragDrop}
+            />
           ))}
         </div>
       </SortableContext>

--- a/apps/web/src/components/kanban-board/column/index.tsx
+++ b/apps/web/src/components/kanban-board/column/index.tsx
@@ -5,9 +5,10 @@ import { ColumnHeader } from "./column-header";
 
 type ColumnProps = {
   column: ProjectWithTasks["columns"][number];
+  disableDragDrop?: boolean;
 };
 
-function Column({ column }: ColumnProps) {
+function Column({ column, disableDragDrop = false }: ColumnProps) {
   const [isDropzoneOver, setIsDropzoneOver] = useState(false);
 
   return (
@@ -22,7 +23,11 @@ function Column({ column }: ColumnProps) {
         <ColumnHeader column={column} />
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-2 py-1 [-webkit-overflow-scrolling:touch]">
-        <ColumnDropzone column={column} onIsOverChange={setIsDropzoneOver} />
+        <ColumnDropzone
+          column={column}
+          disableDragDrop={disableDragDrop}
+          onIsOverChange={setIsDropzoneOver}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/components/kanban-board/index.tsx
+++ b/apps/web/src/components/kanban-board/index.tsx
@@ -253,7 +253,7 @@ function KanbanBoard({ project, disableDragDrop = false }: KanbanBoardProps) {
                 key={column.id}
                 className="h-full max-w-96 min-w-80 shrink-0 flex-1"
               >
-                <Column column={column} />
+                <Column column={column} disableDragDrop={disableDragDrop} />
               </div>
             ))}
           </div>

--- a/apps/web/src/components/kanban-board/task-card.tsx
+++ b/apps/web/src/components/kanban-board/task-card.tsx
@@ -45,9 +45,10 @@ import TaskCardLabels from "./task-labels";
 
 type TaskCardProps = {
   task: Task;
+  disableDragDrop?: boolean;
 };
 
-function TaskCard({ task }: TaskCardProps) {
+function TaskCard({ task, disableDragDrop = false }: TaskCardProps) {
   const { t } = useTranslation();
   const {
     attributes,
@@ -56,7 +57,7 @@ function TaskCard({ task }: TaskCardProps) {
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: task.id });
+  } = useSortable({ id: task.id, disabled: disableDragDrop });
   const { project } = useProjectStore();
   const { data: workspace } = useActiveWorkspace();
   const { mutateAsync: deleteTask } = useDeleteTask();
@@ -179,7 +180,9 @@ function TaskCard({ task }: TaskCardProps) {
           {/** biome-ignore lint/a11y/noStaticElementInteractions: false positive for onClick and onKeyDown */}
           <div
             onClick={handleTaskCardClick}
-            className={`group relative cursor-move rounded-lg border bg-background p-3 shadow-xs/5 transition-all duration-200 ease-out ${
+            className={`group relative rounded-lg border bg-background p-3 shadow-xs/5 transition-all duration-200 ease-out ${
+              disableDragDrop ? "cursor-default" : "cursor-move"
+            } ${
               isDragging
                 ? "border-ring/40 bg-card shadow-lg"
                 : "hover:border-border/90 hover:bg-background hover:shadow-sm"


### PR DESCRIPTION
## Description

Propagate the disabled drag state to Kanban task cards so non-draggable cards use the default cursor and do not initialize sorting behavior.

## Related Issue(s)

Fixes #1356

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other: web production build

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for disabling drag-and-drop interactions on Kanban boards, columns, and task cards.
  * Disabled task cards now display a standard cursor instead of a draggable cursor.
  * Drag-and-drop settings are consistently applied throughout the board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->