### PR TITLE
fix: prevent oversized workflow column drag preview (#1394)

### DIFF
--- a/apps/web/src/components/project/column-editor.tsx
+++ b/apps/web/src/components/project/column-editor.tsx
@@ -143,6 +143,7 @@ export default function ColumnEditor({ projectId }: ColumnEditorProps) {
     const dragPreview = sourceElement.cloneNode(true) as HTMLDivElement;
 
     dragPreview.setAttribute("aria-hidden", "true");
+    dragPreview.inert = true;
 
     Object.assign(dragPreview.style, {
       position: "fixed",

--- a/apps/web/src/components/project/column-editor.tsx
+++ b/apps/web/src/components/project/column-editor.tsx
@@ -1,5 +1,5 @@
 import { CheckCircle2, Circle, GripVertical, Plus, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -43,6 +43,7 @@ export default function ColumnEditor({ projectId }: ColumnEditorProps) {
   const [newIconPickerOpen, setNewIconPickerOpen] = useState(false);
   const [iconSearch, setIconSearch] = useState("");
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const dragPreviewRef = useRef<HTMLDivElement | null>(null);
 
   const handleCreate = async () => {
     if (!newColumnName.trim()) return;
@@ -121,8 +122,46 @@ export default function ColumnEditor({ projectId }: ColumnEditorProps) {
     }
   };
 
-  const handleDragStart = (index: number) => {
+  const handleDragStart = (
+    e: React.DragEvent<HTMLDivElement>,
+    index: number,
+  ) => {
     setDraggedIndex(index);
+
+    dragPreviewRef.current?.remove();
+
+    const sourceElement = e.currentTarget;
+    const sourceRect = sourceElement.getBoundingClientRect();
+
+    // Use an isolated clone so the drag image only captures the selected row.
+    const dragPreview = sourceElement.cloneNode(true) as HTMLDivElement;
+
+    dragPreview.setAttribute("aria-hidden", "true");
+
+    Object.assign(dragPreview.style, {
+      position: "fixed",
+      top: "-10000px",
+      left: "-10000px",
+      width: `${sourceRect.width}px`,
+      height: `${sourceRect.height}px`,
+      margin: "0",
+      boxSizing: "border-box",
+      overflow: "hidden",
+      pointerEvents: "none",
+      transform: "none",
+      contain: "layout paint",
+    });
+
+    document.body.appendChild(dragPreview);
+    dragPreviewRef.current = dragPreview;
+
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("text/plain", String(index));
+    e.dataTransfer.setDragImage(
+      dragPreview,
+      e.clientX - sourceRect.left,
+      e.clientY - sourceRect.top,
+    );
   };
 
   const handleDragOver = (e: React.DragEvent, index: number) => {
@@ -140,6 +179,9 @@ export default function ColumnEditor({ projectId }: ColumnEditorProps) {
 
   const handleDragEnd = () => {
     setDraggedIndex(null);
+
+    dragPreviewRef.current?.remove();
+    dragPreviewRef.current = null;
   };
 
   const filteredIcons = Object.entries(columnIcons).filter(([iconName]) =>
@@ -163,7 +205,7 @@ export default function ColumnEditor({ projectId }: ColumnEditorProps) {
             key={col.id}
             role="listitem"
             draggable={canEdit}
-            onDragStart={() => handleDragStart(index)}
+            onDragStart={(e) => handleDragStart(e, index)}
             onDragOver={(e) => handleDragOver(e, index)}
             onDragEnd={handleDragEnd}
             className="flex items-center gap-2 p-2 border border-border rounded-md bg-sidebar hover:bg-sidebar-accent/50 transition-colors"

--- a/apps/web/src/components/project/column-editor.tsx
+++ b/apps/web/src/components/project/column-editor.tsx
@@ -1,5 +1,5 @@
 import { CheckCircle2, Circle, GripVertical, Plus, Trash2 } from "lucide-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -44,6 +44,12 @@ export default function ColumnEditor({ projectId }: ColumnEditorProps) {
   const [iconSearch, setIconSearch] = useState("");
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const dragPreviewRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    return () => {
+      dragPreviewRef.current?.remove();
+    };
+  }, []);
 
   const handleCreate = async () => {
     if (!newColumnName.trim()) return;


### PR DESCRIPTION
## Description

Fixes the oversized native drag preview shown when reordering workflow columns in project settings.

The browser was capturing part of the surrounding settings layout as the drag image. This change creates an isolated copy of the selected workflow row, preserves its dimensions and pointer offset, and removes it when dragging ends.

The existing column reordering logic remains unchanged.

## Related Issue(s)

Fixes #1394

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Other: Biome check and production web build

Manually tested workflow column reordering in:

- Google Chrome
- Safari

Validation commands:

    pnpm exec biome check apps/web/src/components/project/column-editor.tsx
    pnpm --filter @kaneo/web build

Both commands completed successfully.

The full web typecheck currently reports existing errors in unrelated API and dependency files. None of the reported errors reference the modified `column-editor.tsx` file.

## Screenshots (if applicable)

Before:
<img width="1461" height="785" alt="Broken layout" src="https://github.com/user-attachments/assets/27e8b2f8-24ab-4c60-af6e-b1a1efe834f7" />


After:
<img width="1429" height="704" alt="Fixed" src="https://github.com/user-attachments/assets/1c364d1a-66bc-4d55-8314-ac8675e3a3cc" />



## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

This PR intentionally keeps the existing native drag-and-drop and column reordering behavior unchanged. It only corrects the visual drag preview.

Touch-based column reordering and mobile responsiveness are outside the scope of this fix and can be addressed separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved column drag-and-drop visuals with a more reliable, persistent custom drag preview.
  * Updated drag start handling to create a cloned drag image with correct cursor alignment.
  * Ensured the temporary drag preview is always removed after drag completion and during cleanup when the editor closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->