### PR TITLE
fix(helm): app version fix, guard, and trigger added

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,3 +71,24 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  trigger-helm-publish:
+    needs: build-and-push-image
+    if: inputs.version != ''
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Trigger Helm chart publish
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'helm-chart.yml',
+              ref: 'main',
+              inputs: {
+                version: '${{ inputs.version }}'
+              }
+            });
+            console.log('Triggered Helm chart publish for version ${{ inputs.version }}');

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,8 +74,10 @@ jobs:
 
   trigger-helm-publish:
     needs: build-and-push-image
-    if: inputs.version != ''
+    if: inputs.version != '' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
+    permissions:
+      actions: write
     steps:
       - name: Trigger Helm chart publish
         uses: actions/github-script@v8

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,16 +81,19 @@ jobs:
     steps:
       - name: Trigger Helm chart publish
         uses: actions/github-script@v8
+        env:
+          VERSION: ${{ inputs.version }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const version = process.env.VERSION;
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'helm-chart.yml',
               ref: 'main',
               inputs: {
-                version: '${{ inputs.version }}'
+                version: version
               }
             });
-            console.log('Triggered Helm chart publish for version ${{ inputs.version }}');
+            console.log(`Triggered Helm chart publish for version ${version}`);

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Package chart
         run: |
           mkdir -p dist
-          helm package "$CHART_PATH" --version "$CHART_VERSION" --destination dist
+          helm package "$CHART_PATH" --version "$CHART_VERSION" --app-version "$CHART_VERSION" --destination dist
     
       - name: Log in to GHCR
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Enforce dispatch from main
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "::error::release.yml must be dispatched from main (current ref: ${{ github.ref }}). The Chart.yaml bump and tag push will not land on main otherwise."
+            exit 1
+          fi
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Enforce dispatch from main
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
-            echo "::error::release.yml must be dispatched from main (current ref: ${{ github.ref }}). The Chart.yaml bump and tag push will not land on main otherwise."
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::release.yml must be dispatched from main (current ref: $GITHUB_REF). The Chart.yaml bump and tag push will not land on main otherwise."
             exit 1
           fi
 


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->


 Fixes the helm chart publishing pipeline so helm upgrade oci://ghcr.io/usekaneo/charts/kaneo actually pulls the new image on release.        
                                                                                                                                              
 Three changes:                                                                                                                               
                                                                                                                                              
 1. helm-chart.yml — add --app-version "$CHART_VERSION" to helm package. The existing --version flag only set the chart version field;        
    appVersion (which controls the image tag in charts/kaneo/templates/deployment.yaml via .Values.kaneo.image.tag | default                  
    .Chart.AppVersion) stayed frozen at 2.7.7 from Chart.yaml on main. Every published chart was therefore declaring image                    
    ghcr.io/usekaneo/kaneo:2.7.7 regardless of the chart version.                                                                             
                                                                                                                                              
 2. release.yml — fail fast if dispatched from anything other than refs/heads/main. The existing git push origin HEAD:${{ github.ref }}       
    --tags only lands the Chart.yaml bump on main when dispatched from main; dispatching from a feature branch silently drifted Chart.yaml    
    (which is why it was stuck at 0.4.2 / 2.7.7 despite releases going up to v2.9.0).                                                         
                                                                                                                                              
 3. docker.yml — new trigger-helm-publish job with needs: build-and-push-image. Gates the helm chart publish on all three matrix images       
    (kaneo, web, api) pushing successfully, so a failed docker build can never leave a published chart pointing at a missing image tag.       
    Replaces the parallel helm trigger that was previously added directly to release.yml.                                                     
                                                                                                                                              
 After this, the flow is: release.yml → bumps Chart.yaml on main → triggers docker.yml → images build → triggers helm-chart.yml → chart       
 publishes with matching --version and --app-version → helm upgrade pulls the new image.    

## Related Issue(s)
<!-- Link to the related issue(s) this PR addresses -->
Fixes #

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing -- verified helm package --version X does not change appVersion and helm package --version X --app-version X does;       
       confirmed the gate semantics by reading the workflow  
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any other context about the PR here -->

 Workflow-only change; no runtime code, helm templates, or chart manifests touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Automation**
  * Helm chart publishing is now automatically triggered after a versioned container image is built.
  * Helm packages now include the application version in addition to the chart version.
  * Release version bumps and tag pushes are now blocked unless the workflow is running on the `main` branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->