### PR TITLE
fix: load task statuses on direct page visits

### DIFF
--- a/apps/web/src/components/task/task-status-popover.test.tsx
+++ b/apps/web/src/components/task/task-status-popover.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Button } from "@/components/ui/button";
+import type Task from "@/types/task";
+import TaskStatusPopover from "./task-status-popover";
+
+const useGetColumns = vi.fn();
+
+vi.mock("@/hooks/queries/column/use-get-columns", () => ({
+  useGetColumns: (projectId: string) => useGetColumns(projectId),
+}));
+
+vi.mock("@/hooks/mutations/task/use-update-task-status", () => ({
+  useUpdateTaskStatus: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-numbered-shortcuts", () => ({
+  useNumberedShortcuts: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-workspace-permission", () => ({
+  useWorkspacePermission: () => ({ canManageTasks: () => true }),
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const task: Task = {
+  id: "task-1",
+  title: "Directly loaded task",
+  number: 1,
+  description: null,
+  status: "to-do",
+  priority: null,
+  startDate: null,
+  dueDate: null,
+  position: 1,
+  createdAt: "2026-07-17T00:00:00.000Z",
+  userId: null,
+  assigneeId: null,
+  assigneeName: null,
+  projectId: "project-1",
+};
+
+describe("TaskStatusPopover", () => {
+  it("loads status options for the task project without relying on board state", () => {
+    useGetColumns.mockReturnValue({
+      data: [
+        {
+          id: "column-1",
+          slug: "to-do",
+          name: "Ready",
+          icon: null,
+          isFinal: false,
+        },
+      ],
+    });
+
+    render(
+      <TaskStatusPopover task={task}>
+        <Button>Status</Button>
+      </TaskStatusPopover>,
+    );
+
+    expect(useGetColumns).toHaveBeenCalledWith("project-1");
+    expect(screen.getByRole("button", { name: /Ready/ })).toBeVisible();
+  });
+});

--- a/apps/web/src/components/task/task-status-popover.test.tsx
+++ b/apps/web/src/components/task/task-status-popover.test.tsx
@@ -1,10 +1,15 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Button } from "@/components/ui/button";
 import type Task from "@/types/task";
 import TaskStatusPopover from "./task-status-popover";
 
 const useGetColumns = vi.fn();
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+});
 
 vi.mock("@/hooks/queries/column/use-get-columns", () => ({
   useGetColumns: (projectId: string) => useGetColumns(projectId),
@@ -20,16 +25,6 @@ vi.mock("@/hooks/use-numbered-shortcuts", () => ({
 
 vi.mock("@/hooks/use-workspace-permission", () => ({
   useWorkspacePermission: () => ({ canManageTasks: () => true }),
-}));
-
-vi.mock("@/components/ui/popover", () => ({
-  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  PopoverTrigger: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
-  PopoverContent: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -54,7 +49,7 @@ const task: Task = {
 };
 
 describe("TaskStatusPopover", () => {
-  it("loads status options for the task project without relying on board state", () => {
+  it("loads status options for the task project without relying on board state", async () => {
     useGetColumns.mockReturnValue({
       data: [
         {
@@ -65,6 +60,8 @@ describe("TaskStatusPopover", () => {
           isFinal: false,
         },
       ],
+      isLoading: false,
+      isError: false,
     });
 
     render(
@@ -74,6 +71,46 @@ describe("TaskStatusPopover", () => {
     );
 
     expect(useGetColumns).toHaveBeenCalledWith("project-1");
-    expect(screen.getByRole("button", { name: /Ready/ })).toBeVisible();
+    expect(screen.queryByRole("button", { name: /Ready/ })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Status" }));
+
+    expect(await screen.findByRole("button", { name: /Ready/ })).toBeVisible();
+  });
+
+  it("shows loading feedback while status options are loading", async () => {
+    useGetColumns.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    render(
+      <TaskStatusPopover task={task}>
+        <Button>Status</Button>
+      </TaskStatusPopover>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Status" }));
+
+    expect(await screen.findByText("common:empty.loading")).toBeVisible();
+  });
+
+  it("shows error feedback when status options fail to load", async () => {
+    useGetColumns.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    render(
+      <TaskStatusPopover task={task}>
+        <Button>Status</Button>
+      </TaskStatusPopover>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Status" }));
+
+    expect(await screen.findByText("common:error.title")).toBeVisible();
   });
 });

--- a/apps/web/src/components/task/task-status-popover.tsx
+++ b/apps/web/src/components/task/task-status-popover.tsx
@@ -9,12 +9,12 @@ import {
 } from "@/components/ui/popover";
 import { ShortcutNumber } from "@/components/ui/shortcut-number";
 import { useUpdateTaskStatus } from "@/hooks/mutations/task/use-update-task-status";
+import { useGetColumns } from "@/hooks/queries/column/use-get-columns";
 import { useNumberedShortcuts } from "@/hooks/use-numbered-shortcuts";
 import { useWorkspacePermission } from "@/hooks/use-workspace-permission";
 import { getColumnIcon } from "@/lib/column";
 import { getStatusDisplayLabel } from "@/lib/i18n/domain";
 import { toast } from "@/lib/toast";
-import useProjectStore from "@/store/project";
 import type Task from "@/types/task";
 
 type TaskStatusPopoverProps = {
@@ -28,14 +28,13 @@ export default function TaskStatusPopover({
 }: TaskStatusPopoverProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const { project } = useProjectStore();
-  const statusOptions =
-    project?.columns?.map((col) => ({
-      value: col.slug,
-      label: col.name,
-      icon: col.icon,
-      isFinal: col.isFinal,
-    })) ?? [];
+  const { data: columns = [] } = useGetColumns(task.projectId);
+  const statusOptions = columns.map((col) => ({
+    value: col.slug,
+    label: col.name,
+    icon: col.icon,
+    isFinal: col.isFinal,
+  }));
   const { mutateAsync: updateTaskStatus } = useUpdateTaskStatus();
   const { canManageTasks } = useWorkspacePermission();
   const canEdit = canManageTasks();

--- a/apps/web/src/components/task/task-status-popover.tsx
+++ b/apps/web/src/components/task/task-status-popover.tsx
@@ -28,13 +28,21 @@ export default function TaskStatusPopover({
 }: TaskStatusPopoverProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const { data: columns = [] } = useGetColumns(task.projectId);
-  const statusOptions = columns.map((col) => ({
-    value: col.slug,
-    label: col.name,
-    icon: col.icon,
-    isFinal: col.isFinal,
-  }));
+  const {
+    data: columns = [],
+    isLoading,
+    isError,
+  } = useGetColumns(task.projectId);
+  const statusOptions = useMemo(
+    () =>
+      columns.map((col) => ({
+        value: col.slug,
+        label: col.name,
+        icon: col.icon,
+        isFinal: col.isFinal,
+      })),
+    [columns],
+  );
   const { mutateAsync: updateTaskStatus } = useUpdateTaskStatus();
   const { canManageTasks } = useWorkspacePermission();
   const canEdit = canManageTasks();
@@ -75,25 +83,35 @@ export default function TaskStatusPopover({
       <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent className="w-48 p-0" align="start">
         <div>
-          {statusOptions.map((status, index) => (
-            <Button
-              key={status.value}
-              variant="ghost"
-              size="sm"
-              className="w-full justify-start gap-2 h-8 px-2 rounded-none first:rounded-t-md last:rounded-b-md"
-              onClick={() => handleStatusChange(status.value)}
-            >
-              {getColumnIcon(status.value, status.isFinal, status.icon)}
-              <span className="text-sm">
-                {getStatusDisplayLabel(status.value, status.label)}
-              </span>
-              {task.status === status.value ? (
-                <Check className="ml-auto h-4 w-4" />
-              ) : (
-                <ShortcutNumber number={index + 1} />
-              )}
-            </Button>
-          ))}
+          {isLoading ? (
+            <div className="p-3 text-center text-sm text-muted-foreground">
+              {t("common:empty.loading")}
+            </div>
+          ) : isError ? (
+            <div className="p-3 text-center text-sm text-destructive">
+              {t("common:error.title")}
+            </div>
+          ) : (
+            statusOptions.map((status, index) => (
+              <Button
+                key={status.value}
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start gap-2 h-8 px-2 rounded-none first:rounded-t-md last:rounded-b-md"
+                onClick={() => handleStatusChange(status.value)}
+              >
+                {getColumnIcon(status.value, status.isFinal, status.icon)}
+                <span className="text-sm">
+                  {getStatusDisplayLabel(status.value, status.label)}
+                </span>
+                {task.status === status.value ? (
+                  <Check className="ml-auto h-4 w-4" />
+                ) : (
+                  <ShortcutNumber number={index + 1} />
+                )}
+              </Button>
+            ))
+          )}
         </div>
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
## Description

Load task status options from the project columns query instead of board-only state so the status dropdown works after refreshing or directly opening the full-screen task page.

## Related Issue(s)

Fixes #1402

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Task status options now load from the correct project-specific data source.
  * Added clear loading and error states when status options cannot be retrieved.

* **Tests**
  * Added coverage for project scoping, loading feedback, error handling, and available status options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->