### PR TITLE
fix(web): load status options from columns query

### DIFF
--- a/apps/web/src/components/task/task-status-popover.tsx
+++ b/apps/web/src/components/task/task-status-popover.tsx
@@ -9,12 +9,12 @@ import {
 } from "@/components/ui/popover";
 import { ShortcutNumber } from "@/components/ui/shortcut-number";
 import { useUpdateTaskStatus } from "@/hooks/mutations/task/use-update-task-status";
+import { useGetColumns } from "@/hooks/queries/column/use-get-columns";
 import { useNumberedShortcuts } from "@/hooks/use-numbered-shortcuts";
 import { useWorkspacePermission } from "@/hooks/use-workspace-permission";
 import { getColumnIcon } from "@/lib/column";
 import { getStatusDisplayLabel } from "@/lib/i18n/domain";
 import { toast } from "@/lib/toast";
-import useProjectStore from "@/store/project";
 import type Task from "@/types/task";
 
 type TaskStatusPopoverProps = {
@@ -28,14 +28,13 @@ export default function TaskStatusPopover({
 }: TaskStatusPopoverProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const { project } = useProjectStore();
-  const statusOptions =
-    project?.columns?.map((col) => ({
-      value: col.slug,
-      label: col.name,
-      icon: col.icon,
-      isFinal: col.isFinal,
-    })) ?? [];
+  const { data: columns = [] } = useGetColumns(task.projectId);
+  const statusOptions = columns.map((col) => ({
+    value: col.slug,
+    label: col.name,
+    icon: col.icon,
+    isFinal: col.isFinal,
+  }));
   const { mutateAsync: updateTaskStatus } = useUpdateTaskStatus();
   const { canManageTasks } = useWorkspacePermission();
   const canEdit = canManageTasks();

--- a/apps/web/src/components/task/task-status-popover.tsx
+++ b/apps/web/src/components/task/task-status-popover.tsx
@@ -28,13 +28,17 @@ export default function TaskStatusPopover({
 }: TaskStatusPopoverProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const { data: columns = [] } = useGetColumns(task.projectId);
-  const statusOptions = columns.map((col) => ({
-    value: col.slug,
-    label: col.name,
-    icon: col.icon,
-    isFinal: col.isFinal,
-  }));
+  const { data: columns } = useGetColumns(task.projectId);
+  const statusOptions = useMemo(
+    () =>
+      (columns ?? []).map((col) => ({
+        value: col.slug,
+        label: col.name,
+        icon: col.icon,
+        isFinal: col.isFinal,
+      })),
+    [columns],
+  );
   const { mutateAsync: updateTaskStatus } = useUpdateTaskStatus();
   const { canManageTasks } = useWorkspacePermission();
   const canEdit = canManageTasks();


### PR DESCRIPTION
## Summary
The status dropdown in the task properties sidebar rendered zero options on a direct load or refresh of the full-screen task view, making the status impossible to change. TaskStatusPopover read columns from the Zustand project store, which only the board, backlog, and list routes populate; the full-screen route never does.

## Changes
- TaskStatusPopover fetches columns with the useGetColumns query (keyed by task.projectId) instead of reading the project store, matching how SubtaskStatusPopover already works
- Remove the now-unused project store import

## Test Plan
- Root cause confirmed by code inspection: only the board, backlog, and list routes call setProject, so the store is empty on a direct full-screen load; SubtaskStatusPopover uses the query and does not exhibit the bug
- 19 web unit tests pass, Biome clean, full monorepo build passes
- Not manually reproduced in a browser; worth a quick manual check of the repro steps from the issue before merging

Fixes #1402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task status selection by loading available statuses more reliably.
  * Preserved status labels, icons, completion indicators, and keyboard shortcut behavior in the status menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->