### PR TITLE
fix(docker): allow nginx revision rebuilds in apk pin

### DIFF
--- a/Dockerfile.kaneo
+++ b/Dockerfile.kaneo
@@ -83,7 +83,7 @@ RUN pnpm run build
 
 FROM node:20.20.2-alpine AS runtime
 
-RUN apk add --no-cache nginx=1.28.3-r4 && \
+RUN apk add --no-cache nginx=~1.28.3 && \
   addgroup -g 1001 appuser && \
   adduser -u 1001 -G appuser -D appuser && \
   mkdir -p /app /app/apps/api/data /var/cache/nginx /var/run/nginx /var/log/nginx /var/lib/nginx/logs /var/lib/nginx/tmp /usr/share/nginx/html /docker-entrypoint.d && \


### PR DESCRIPTION
## Summary
Alpine removed nginx 1.28.3-r4 from its package repository when it published the r5 rebuild, so the exact pin in Dockerfile.kaneo now fails apk resolution and every docker-build job in the repo fails (first seen on #1404, but any build after today hits it).

## Changes
- Pin nginx with =~1.28.3 instead of =1.28.3-r4, keeping the upstream version fixed while allowing Alpine -rN revision rebuilds to resolve

## Test Plan
- CI docker-build on this PR is the authoritative test of the pin syntax and resolution; the previous failure reproduced in 19s, so a green docker-build here confirms the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build to use a compatible nginx version range, improving flexibility when applying matching package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->