### PR TITLE
feat: webhook events, unicode slugs, board sort

### DIFF
--- a/apps/api/src/column/controllers/create-column.ts
+++ b/apps/api/src/column/controllers/create-column.ts
@@ -5,12 +5,14 @@ import { columnTable } from "../../database/schema";
 import { VIRTUAL_STATUSES } from "../../task/validate-task-fields";
 
 export function toSlug(name: string): string {
-  return name
+  const slug = name
     .normalize("NFKC")
     .toLowerCase()
     .trim()
     .replace(/[^\p{L}\p{M}\p{N}]+/gu, "-")
     .replace(/^-+|-+$/g, "");
+
+  return /[\p{L}\p{N}]/u.test(slug) ? slug : "";
 }
 
 async function createColumn({

--- a/apps/api/src/column/controllers/create-column.ts
+++ b/apps/api/src/column/controllers/create-column.ts
@@ -4,11 +4,12 @@ import db from "../../database";
 import { columnTable } from "../../database/schema";
 import { VIRTUAL_STATUSES } from "../../task/validate-task-fields";
 
-function toSlug(name: string): string {
+export function toSlug(name: string): string {
   return name
+    .normalize("NFKC")
     .toLowerCase()
     .trim()
-    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/[^\p{L}\p{M}\p{N}]+/gu, "-")
     .replace(/^-+|-+$/g, "");
 }
 

--- a/apps/api/src/generic-webhook-integration/index.ts
+++ b/apps/api/src/generic-webhook-integration/index.ts
@@ -85,6 +85,11 @@ const genericWebhookEventsSchema = v.object({
   taskTitleChanged: v.optional(v.boolean()),
   taskDescriptionChanged: v.optional(v.boolean()),
   taskCommentCreated: v.optional(v.boolean()),
+  taskDeleted: v.optional(v.boolean()),
+  taskMoved: v.optional(v.boolean()),
+  taskDueDateChanged: v.optional(v.boolean()),
+  taskAssigneeChanged: v.optional(v.boolean()),
+  taskUnassigned: v.optional(v.boolean()),
   dueDateReminder: v.optional(v.boolean()),
 });
 

--- a/apps/api/src/plugins/generic-webhook/config.ts
+++ b/apps/api/src/plugins/generic-webhook/config.ts
@@ -95,6 +95,11 @@ export const genericWebhookEventKeys = [
   "taskTitleChanged",
   "taskDescriptionChanged",
   "taskCommentCreated",
+  "taskDeleted",
+  "taskMoved",
+  "taskDueDateChanged",
+  "taskAssigneeChanged",
+  "taskUnassigned",
   "dueDateReminder",
 ] as const;
 
@@ -134,6 +139,11 @@ export const genericWebhookConfigSchema = v.object({
       taskTitleChanged: v.optional(v.boolean()),
       taskDescriptionChanged: v.optional(v.boolean()),
       taskCommentCreated: v.optional(v.boolean()),
+      taskDeleted: v.optional(v.boolean()),
+      taskMoved: v.optional(v.boolean()),
+      taskDueDateChanged: v.optional(v.boolean()),
+      taskAssigneeChanged: v.optional(v.boolean()),
+      taskUnassigned: v.optional(v.boolean()),
       dueDateReminder: v.optional(v.boolean()),
     }),
   ),
@@ -156,6 +166,11 @@ export const defaultGenericWebhookEvents: Record<
   taskTitleChanged: false,
   taskDescriptionChanged: false,
   taskCommentCreated: true,
+  taskDeleted: false,
+  taskMoved: false,
+  taskDueDateChanged: false,
+  taskAssigneeChanged: false,
+  taskUnassigned: false,
   dueDateReminder: false,
 };
 

--- a/apps/api/src/plugins/generic-webhook/events.ts
+++ b/apps/api/src/plugins/generic-webhook/events.ts
@@ -10,12 +10,17 @@ import {
 } from "../../database/schema";
 import type {
   PluginContext,
+  TaskAssigneeChangedEvent,
   TaskCommentCreatedEvent,
   TaskCreatedEvent,
+  TaskDeletedEvent,
   TaskDescriptionChangedEvent,
+  TaskDueDateChangedEvent,
+  TaskMovedEvent,
   TaskPriorityChangedEvent,
   TaskStatusChangedEvent,
   TaskTitleChangedEvent,
+  TaskUnassignedEvent,
 } from "../types";
 import { postToGenericWebhook } from "./client";
 import type { GenericWebhookConfig, GenericWebhookEventKey } from "./config";
@@ -142,18 +147,13 @@ async function persistWebhookHealth(
   }
 }
 
-async function sendEvent(
+async function deliverWebhookEvent(
   config: GenericWebhookConfig,
   eventName: string,
   taskId: string,
   projectId: string,
-  userId: string | null,
-  data: Record<string, unknown>,
+  payload: Record<string, unknown>,
 ): Promise<boolean> {
-  const task = await getTaskData(taskId, projectId);
-  if (!task) return false;
-
-  const actor = await getActor(userId);
   const attempt = {
     eventName,
     taskId,
@@ -162,33 +162,7 @@ async function sendEvent(
   };
 
   try {
-    await postToGenericWebhook(
-      config.webhookUrl,
-      {
-        event: eventName,
-        timestamp: new Date().toISOString(),
-        integration: {
-          type: "generic-webhook",
-        },
-        project: {
-          id: task.projectId,
-          name: task.projectName,
-          workspaceId: task.workspaceId,
-        },
-        task: {
-          id: task.id,
-          number: task.number,
-          title: task.title,
-          status: task.status,
-          statusName: task.statusName,
-          priority: task.priority,
-          url: task.taskUrl,
-        },
-        actor,
-        data,
-      },
-      config.secret,
-    );
+    await postToGenericWebhook(config.webhookUrl, payload, config.secret);
 
     void persistWebhookHealth(projectId, (currentConfig) => ({
       ...currentConfig,
@@ -215,7 +189,7 @@ async function sendEvent(
       },
     }));
 
-    console.error("sendEvent postToGenericWebhook failed", {
+    console.error("postToGenericWebhook failed", {
       error,
       eventName,
       taskId,
@@ -224,6 +198,44 @@ async function sendEvent(
     });
     return false;
   }
+}
+
+async function sendEvent(
+  config: GenericWebhookConfig,
+  eventName: string,
+  taskId: string,
+  projectId: string,
+  userId: string | null,
+  data: Record<string, unknown>,
+): Promise<boolean> {
+  const task = await getTaskData(taskId, projectId);
+  if (!task) return false;
+
+  const actor = await getActor(userId);
+
+  return deliverWebhookEvent(config, eventName, taskId, projectId, {
+    event: eventName,
+    timestamp: new Date().toISOString(),
+    integration: {
+      type: "generic-webhook",
+    },
+    project: {
+      id: task.projectId,
+      name: task.projectName,
+      workspaceId: task.workspaceId,
+    },
+    task: {
+      id: task.id,
+      number: task.number,
+      title: task.title,
+      status: task.status,
+      statusName: task.statusName,
+      priority: task.priority,
+      url: task.taskUrl,
+    },
+    actor,
+    data,
+  });
 }
 
 export async function sendDueDateReminder(
@@ -381,6 +393,156 @@ export async function handleTaskCommentCreated(
     event.userId,
     {
       comment: event.comment,
+    },
+  );
+}
+
+async function sendTaskDeletedEvent(
+  config: GenericWebhookConfig,
+  event: TaskDeletedEvent,
+): Promise<boolean> {
+  const [project] = await db
+    .select({
+      id: projectTable.id,
+      name: projectTable.name,
+      workspaceId: projectTable.workspaceId,
+    })
+    .from(projectTable)
+    .where(eq(projectTable.id, event.projectId))
+    .limit(1);
+
+  if (!project) return false;
+
+  const actor = await getActor(event.userId);
+
+  return deliverWebhookEvent(
+    config,
+    "task.deleted",
+    event.taskId,
+    event.projectId,
+    {
+      event: "task.deleted",
+      timestamp: new Date().toISOString(),
+      integration: {
+        type: "generic-webhook",
+      },
+      project: {
+        id: project.id,
+        name: project.name,
+        workspaceId: project.workspaceId,
+      },
+      task: {
+        id: event.taskId,
+        title: event.title,
+      },
+      actor,
+      data: {},
+    },
+  );
+}
+
+export async function handleTaskDeleted(
+  event: TaskDeletedEvent,
+  context: PluginContext,
+): Promise<void> {
+  const config = normalizeGenericWebhookConfig(
+    context.config as GenericWebhookConfig,
+  );
+  if (!isEnabled(config, "taskDeleted")) return;
+
+  await sendTaskDeletedEvent(config, event);
+}
+
+export async function handleTaskMoved(
+  event: TaskMovedEvent,
+  context: PluginContext,
+): Promise<void> {
+  const config = normalizeGenericWebhookConfig(
+    context.config as GenericWebhookConfig,
+  );
+  if (!isEnabled(config, "taskMoved")) return;
+
+  await sendEvent(
+    config,
+    "task.moved",
+    event.taskId,
+    event.projectId,
+    event.userId,
+    {
+      fromProjectId: event.fromProjectId,
+      fromProjectName: event.fromProjectName,
+      toProjectId: event.toProjectId,
+      toProjectName: event.toProjectName,
+      oldStatus: event.oldStatus,
+      newStatus: event.newStatus,
+    },
+  );
+}
+
+export async function handleTaskDueDateChanged(
+  event: TaskDueDateChangedEvent,
+  context: PluginContext,
+): Promise<void> {
+  const config = normalizeGenericWebhookConfig(
+    context.config as GenericWebhookConfig,
+  );
+  if (!isEnabled(config, "taskDueDateChanged")) return;
+
+  await sendEvent(
+    config,
+    "task.due_date_changed",
+    event.taskId,
+    event.projectId,
+    event.userId,
+    {
+      title: event.title,
+      oldDueDate: event.oldDueDate,
+      newDueDate: event.newDueDate,
+    },
+  );
+}
+
+export async function handleTaskAssigneeChanged(
+  event: TaskAssigneeChangedEvent,
+  context: PluginContext,
+): Promise<void> {
+  const config = normalizeGenericWebhookConfig(
+    context.config as GenericWebhookConfig,
+  );
+  if (!isEnabled(config, "taskAssigneeChanged")) return;
+
+  await sendEvent(
+    config,
+    "task.assignee_changed",
+    event.taskId,
+    event.projectId,
+    event.userId,
+    {
+      title: event.title,
+      oldAssigneeId: event.oldAssignee ?? null,
+      newAssigneeId: event.newAssigneeId,
+      newAssignee: event.newAssignee ?? null,
+    },
+  );
+}
+
+export async function handleTaskUnassigned(
+  event: TaskUnassignedEvent,
+  context: PluginContext,
+): Promise<void> {
+  const config = normalizeGenericWebhookConfig(
+    context.config as GenericWebhookConfig,
+  );
+  if (!isEnabled(config, "taskUnassigned")) return;
+
+  await sendEvent(
+    config,
+    "task.unassigned",
+    event.taskId,
+    event.projectId,
+    event.userId,
+    {
+      title: event.title,
     },
   );
 }

--- a/apps/api/src/plugins/generic-webhook/index.ts
+++ b/apps/api/src/plugins/generic-webhook/index.ts
@@ -1,12 +1,17 @@
 import type { IntegrationPlugin } from "../types";
 import { validateGenericWebhookConfig } from "./config";
 import {
+  handleTaskAssigneeChanged,
   handleTaskCommentCreated,
   handleTaskCreated,
+  handleTaskDeleted,
   handleTaskDescriptionChanged,
+  handleTaskDueDateChanged,
+  handleTaskMoved,
   handleTaskPriorityChanged,
   handleTaskStatusChanged,
   handleTaskTitleChanged,
+  handleTaskUnassigned,
 } from "./events";
 
 export const genericWebhookPlugin: IntegrationPlugin = {
@@ -18,5 +23,10 @@ export const genericWebhookPlugin: IntegrationPlugin = {
   onTaskTitleChanged: handleTaskTitleChanged,
   onTaskDescriptionChanged: handleTaskDescriptionChanged,
   onTaskCommentCreated: handleTaskCommentCreated,
+  onTaskDeleted: handleTaskDeleted,
+  onTaskMoved: handleTaskMoved,
+  onTaskDueDateChanged: handleTaskDueDateChanged,
+  onTaskAssigneeChanged: handleTaskAssigneeChanged,
+  onTaskUnassigned: handleTaskUnassigned,
   validateConfig: validateGenericWebhookConfig,
 };

--- a/apps/api/src/plugins/registry.ts
+++ b/apps/api/src/plugins/registry.ts
@@ -5,12 +5,17 @@ import { subscribeToEvent } from "../events";
 import type {
   IntegrationPlugin,
   PluginContext,
+  TaskAssigneeChangedEvent,
   TaskCommentCreatedEvent,
   TaskCreatedEvent,
+  TaskDeletedEvent,
   TaskDescriptionChangedEvent,
+  TaskDueDateChangedEvent,
+  TaskMovedEvent,
   TaskPriorityChangedEvent,
   TaskStatusChangedEvent,
   TaskTitleChangedEvent,
+  TaskUnassignedEvent,
 } from "./types";
 
 const plugins = new Map<string, IntegrationPlugin>();
@@ -130,6 +135,95 @@ export function initializeEventSubscriptions(): void {
       projectId: data.projectId,
       userId: data.userId,
       comment: data.comment,
+    });
+  });
+
+  subscribeToEvent<{
+    taskId: string;
+    userId: string | null;
+    title: string;
+    projectId: string;
+  }>("task.deleted", async (data) => {
+    await broadcastTaskDeleted({
+      taskId: data.taskId,
+      projectId: data.projectId,
+      userId: data.userId,
+      title: data.title,
+    });
+  });
+
+  subscribeToEvent<{
+    taskId: string;
+    userId: string | null;
+    fromProjectId: string;
+    fromProjectName: string;
+    toProjectId: string;
+    toProjectName: string;
+    oldStatus: string;
+    newStatus: string;
+  }>("task.moved", async (data) => {
+    await broadcastTaskMoved({
+      taskId: data.taskId,
+      projectId: data.toProjectId,
+      userId: data.userId,
+      fromProjectId: data.fromProjectId,
+      fromProjectName: data.fromProjectName,
+      toProjectId: data.toProjectId,
+      toProjectName: data.toProjectName,
+      oldStatus: data.oldStatus,
+      newStatus: data.newStatus,
+    });
+  });
+
+  subscribeToEvent<{
+    taskId: string;
+    userId: string | null;
+    oldDueDate: Date | null;
+    newDueDate: Date | null;
+    title: string;
+    projectId: string;
+  }>("task.due_date_changed", async (data) => {
+    await broadcastTaskDueDateChanged({
+      taskId: data.taskId,
+      projectId: data.projectId,
+      userId: data.userId,
+      title: data.title,
+      oldDueDate: data.oldDueDate,
+      newDueDate: data.newDueDate,
+    });
+  });
+
+  subscribeToEvent<{
+    taskId: string;
+    userId: string | null;
+    oldAssignee: string | null;
+    newAssignee: string | undefined;
+    newAssigneeId: string;
+    title: string;
+    projectId: string;
+  }>("task.assignee_changed", async (data) => {
+    await broadcastTaskAssigneeChanged({
+      taskId: data.taskId,
+      projectId: data.projectId,
+      userId: data.userId,
+      title: data.title,
+      oldAssignee: data.oldAssignee,
+      newAssignee: data.newAssignee,
+      newAssigneeId: data.newAssigneeId,
+    });
+  });
+
+  subscribeToEvent<{
+    taskId: string;
+    userId: string | null;
+    title: string;
+    projectId: string;
+  }>("task.unassigned", async (data) => {
+    await broadcastTaskUnassigned({
+      taskId: data.taskId,
+      projectId: data.projectId,
+      userId: data.userId,
+      title: data.title,
     });
   });
 
@@ -291,6 +385,105 @@ export async function broadcastTaskCommentCreated(
       await plugin.onTaskCommentCreated(event, context);
     } catch (error) {
       console.error(`Plugin ${plugin.type} error on comment.created:`, error);
+    }
+  }
+}
+
+export async function broadcastTaskDeleted(
+  event: TaskDeletedEvent,
+): Promise<void> {
+  const integrations = await getActiveIntegrations(event.projectId);
+
+  for (const integration of integrations) {
+    const plugin = getPlugin(integration.type);
+    if (!plugin?.onTaskDeleted) continue;
+
+    const context = createContext(integration);
+
+    try {
+      await plugin.onTaskDeleted(event, context);
+    } catch (error) {
+      console.error(`Plugin ${plugin.type} error on task.deleted:`, error);
+    }
+  }
+}
+
+export async function broadcastTaskMoved(event: TaskMovedEvent): Promise<void> {
+  const integrations = await getActiveIntegrations(event.projectId);
+
+  for (const integration of integrations) {
+    const plugin = getPlugin(integration.type);
+    if (!plugin?.onTaskMoved) continue;
+
+    const context = createContext(integration);
+
+    try {
+      await plugin.onTaskMoved(event, context);
+    } catch (error) {
+      console.error(`Plugin ${plugin.type} error on task.moved:`, error);
+    }
+  }
+}
+
+export async function broadcastTaskDueDateChanged(
+  event: TaskDueDateChangedEvent,
+): Promise<void> {
+  const integrations = await getActiveIntegrations(event.projectId);
+
+  for (const integration of integrations) {
+    const plugin = getPlugin(integration.type);
+    if (!plugin?.onTaskDueDateChanged) continue;
+
+    const context = createContext(integration);
+
+    try {
+      await plugin.onTaskDueDateChanged(event, context);
+    } catch (error) {
+      console.error(
+        `Plugin ${plugin.type} error on task.due_date_changed:`,
+        error,
+      );
+    }
+  }
+}
+
+export async function broadcastTaskAssigneeChanged(
+  event: TaskAssigneeChangedEvent,
+): Promise<void> {
+  const integrations = await getActiveIntegrations(event.projectId);
+
+  for (const integration of integrations) {
+    const plugin = getPlugin(integration.type);
+    if (!plugin?.onTaskAssigneeChanged) continue;
+
+    const context = createContext(integration);
+
+    try {
+      await plugin.onTaskAssigneeChanged(event, context);
+    } catch (error) {
+      console.error(
+        `Plugin ${plugin.type} error on task.assignee_changed:`,
+        error,
+      );
+    }
+  }
+}
+
+export async function broadcastTaskUnassigned(
+  event: TaskUnassignedEvent,
+): Promise<void> {
+  const integrations = await getActiveIntegrations(event.projectId);
+
+  for (const integration of integrations) {
+    const plugin = getPlugin(integration.type);
+    if (!plugin?.onTaskUnassigned) continue;
+
+    const context = createContext(integration);
+
+    try {
+      await plugin.onTaskUnassigned(event, context);
+    } catch (error) {
+      console.error(`Plugin ${plugin.type} error on task.unassigned:`, error);
     }
   }
 }

--- a/apps/api/src/plugins/types.ts
+++ b/apps/api/src/plugins/types.ts
@@ -56,13 +56,63 @@ export type TaskCommentCreatedEvent = {
   comment: string;
 };
 
+export type TaskDeletedEvent = {
+  taskId: string;
+  projectId: string;
+  userId: string | null;
+  title: string;
+};
+
+export type TaskMovedEvent = {
+  taskId: string;
+  projectId: string;
+  userId: string | null;
+  fromProjectId: string;
+  fromProjectName: string;
+  toProjectId: string;
+  toProjectName: string;
+  oldStatus: string;
+  newStatus: string;
+};
+
+export type TaskDueDateChangedEvent = {
+  taskId: string;
+  projectId: string;
+  userId: string | null;
+  title: string;
+  oldDueDate: Date | null;
+  newDueDate: Date | null;
+};
+
+export type TaskAssigneeChangedEvent = {
+  taskId: string;
+  projectId: string;
+  userId: string | null;
+  title: string;
+  oldAssignee: string | null;
+  newAssignee: string | undefined;
+  newAssigneeId: string;
+};
+
+export type TaskUnassignedEvent = {
+  taskId: string;
+  projectId: string;
+  userId: string | null;
+  title: string;
+};
+
 export type TaskEvent =
   | TaskCreatedEvent
   | TaskStatusChangedEvent
   | TaskPriorityChangedEvent
   | TaskTitleChangedEvent
   | TaskDescriptionChangedEvent
-  | TaskCommentCreatedEvent;
+  | TaskCommentCreatedEvent
+  | TaskDeletedEvent
+  | TaskMovedEvent
+  | TaskDueDateChangedEvent
+  | TaskAssigneeChangedEvent
+  | TaskUnassignedEvent;
 
 export type ExternalMetadata = {
   type: "issue" | "pull_request" | "branch";
@@ -103,6 +153,11 @@ export type IntegrationPlugin = {
   onTaskTitleChanged?: TaskEventHandler<TaskTitleChangedEvent>;
   onTaskDescriptionChanged?: TaskEventHandler<TaskDescriptionChangedEvent>;
   onTaskCommentCreated?: TaskEventHandler<TaskCommentCreatedEvent>;
+  onTaskDeleted?: TaskEventHandler<TaskDeletedEvent>;
+  onTaskMoved?: TaskEventHandler<TaskMovedEvent>;
+  onTaskDueDateChanged?: TaskEventHandler<TaskDueDateChangedEvent>;
+  onTaskAssigneeChanged?: TaskEventHandler<TaskAssigneeChangedEvent>;
+  onTaskUnassigned?: TaskEventHandler<TaskUnassignedEvent>;
 
   handleWebhook?: WebhookHandler;
   getTaskMetadata?: MetadataProvider;

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -219,6 +219,11 @@ export const genericWebhookIntegrationSchema = v.object({
   maskedSecret: v.nullable(v.string()),
   events: v.object({
     ...integrationEventsSchema.entries,
+    taskDeleted: v.boolean(),
+    taskMoved: v.boolean(),
+    taskDueDateChanged: v.boolean(),
+    taskAssigneeChanged: v.boolean(),
+    taskUnassigned: v.boolean(),
     dueDateReminder: v.boolean(),
   }),
   dueDateReminderLeadTimeMinutes: v.number(),

--- a/apps/api/src/task/controllers/bulk-update-tasks.ts
+++ b/apps/api/src/task/controllers/bulk-update-tasks.ts
@@ -6,6 +6,7 @@ import {
   labelTable,
   projectTable,
   taskTable,
+  userTable,
   workspaceUserTable,
 } from "../../database/schema";
 import { publishEvent } from "../../events";
@@ -37,7 +38,10 @@ async function bulkUpdateTasks({
   const tasks = await db
     .select({
       id: taskTable.id,
+      title: taskTable.title,
       projectId: taskTable.projectId,
+      userId: taskTable.userId,
+      dueDate: taskTable.dueDate,
       workspaceId: projectTable.workspaceId,
     })
     .from(taskTable)
@@ -158,6 +162,16 @@ async function bulkUpdateTasks({
     }
 
     case "updateAssignee": {
+      const newAssigneeName = value
+        ? (
+            await db
+              .select({ name: userTable.name })
+              .from(userTable)
+              .where(eq(userTable.id, value))
+              .limit(1)
+          )[0]?.name
+        : undefined;
+
       const result = await db
         .update(taskTable)
         .set({ userId: value || null })
@@ -171,7 +185,10 @@ async function bulkUpdateTasks({
           taskId: task.id,
           projectId: task.projectId,
           userId,
+          oldAssignee: task.userId,
+          newAssignee: newAssigneeName,
           newAssigneeId: value || null,
+          title: task.title,
           type: value ? "assignee_changed" : "unassigned",
         });
       }
@@ -179,19 +196,20 @@ async function bulkUpdateTasks({
     }
 
     case "delete": {
-      for (const task of tasks) {
-        await publishEvent("task.deleted", {
-          taskId: task.id,
-          projectId: task.projectId,
-          userId,
-        });
-      }
-
       const result = await db
         .delete(taskTable)
         .where(inArray(taskTable.id, foundIds));
 
       updatedCount = result.rowCount ?? foundIds.length;
+
+      for (const task of tasks) {
+        await publishEvent("task.deleted", {
+          taskId: task.id,
+          projectId: task.projectId,
+          userId,
+          title: task.title,
+        });
+      }
       break;
     }
 
@@ -288,7 +306,9 @@ async function bulkUpdateTasks({
           taskId: task.id,
           projectId: task.projectId,
           userId,
+          oldDueDate: task.dueDate,
           newDueDate: parsedDate,
+          title: task.title,
           type: "due_date_changed",
         });
       }

--- a/apps/api/src/task/controllers/delete-task.ts
+++ b/apps/api/src/task/controllers/delete-task.ts
@@ -38,6 +38,7 @@ async function deleteTask(taskId: string, currentUserId: string) {
     taskId: task.id,
     projectId: task.projectId,
     userId: currentUserId,
+    title: task.title,
   });
 
   for (const relation of relations) {

--- a/apps/web/src/components/project/generic-webhook-integration-settings.test.tsx
+++ b/apps/web/src/components/project/generic-webhook-integration-settings.test.tsx
@@ -79,7 +79,56 @@ describe("GenericWebhookIntegrationSettings", () => {
         data: expect.objectContaining({
           webhookUrl: "https://example.com/hooks/kaneo",
           dueDateReminderLeadTimeMinutes: 2880,
-          events: expect.objectContaining({ dueDateReminder: true }),
+          events: expect.objectContaining({
+            dueDateReminder: true,
+            taskDeleted: false,
+            taskMoved: false,
+            taskDueDateChanged: false,
+            taskAssigneeChanged: false,
+            taskUnassigned: false,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("creates a webhook with the opt-in task lifecycle events enabled", async () => {
+    render(<GenericWebhookIntegrationSettings projectId="project-1" />);
+
+    fireEvent.change(
+      screen.getByLabelText("settings:genericWebhookIntegration.webhookLabel"),
+      { target: { value: "https://example.com/hooks/kaneo" } },
+    );
+    for (const event of [
+      "taskDeleted",
+      "taskMoved",
+      "taskDueDateChanged",
+      "taskAssigneeChanged",
+      "taskUnassigned",
+    ]) {
+      fireEvent.click(
+        screen.getByLabelText(
+          `settings:genericWebhookIntegration.events.${event}`,
+        ),
+      );
+    }
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "settings:genericWebhookIntegration.connect",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(createIntegration).toHaveBeenCalledWith({
+        projectId: "project-1",
+        data: expect.objectContaining({
+          events: expect.objectContaining({
+            taskDeleted: true,
+            taskMoved: true,
+            taskDueDateChanged: true,
+            taskAssigneeChanged: true,
+            taskUnassigned: true,
+          }),
         }),
       }),
     );

--- a/apps/web/src/components/project/generic-webhook-integration-settings.tsx
+++ b/apps/web/src/components/project/generic-webhook-integration-settings.tsx
@@ -32,6 +32,11 @@ type GenericWebhookIntegrationFormValues = {
   taskTitleChanged: boolean;
   taskDescriptionChanged: boolean;
   taskCommentCreated: boolean;
+  taskDeleted: boolean;
+  taskMoved: boolean;
+  taskDueDateChanged: boolean;
+  taskAssigneeChanged: boolean;
+  taskUnassigned: boolean;
   dueDateReminder: boolean;
   dueDateReminderLeadTimeHours: number;
 };
@@ -52,6 +57,11 @@ function EventToggle({
     | "taskTitleChanged"
     | "taskDescriptionChanged"
     | "taskCommentCreated"
+    | "taskDeleted"
+    | "taskMoved"
+    | "taskDueDateChanged"
+    | "taskAssigneeChanged"
+    | "taskUnassigned"
     | "dueDateReminder"
   >;
   label: string;
@@ -93,6 +103,11 @@ export function GenericWebhookIntegrationSettings({
           taskTitleChanged: z.boolean(),
           taskDescriptionChanged: z.boolean(),
           taskCommentCreated: z.boolean(),
+          taskDeleted: z.boolean(),
+          taskMoved: z.boolean(),
+          taskDueDateChanged: z.boolean(),
+          taskAssigneeChanged: z.boolean(),
+          taskUnassigned: z.boolean(),
           dueDateReminder: z.boolean(),
           dueDateReminderLeadTimeHours: z.number(),
         })
@@ -126,6 +141,11 @@ export function GenericWebhookIntegrationSettings({
       taskDescriptionChanged:
         integration?.events?.taskDescriptionChanged ?? false,
       taskCommentCreated: integration?.events?.taskCommentCreated ?? true,
+      taskDeleted: integration?.events?.taskDeleted ?? false,
+      taskMoved: integration?.events?.taskMoved ?? false,
+      taskDueDateChanged: integration?.events?.taskDueDateChanged ?? false,
+      taskAssigneeChanged: integration?.events?.taskAssigneeChanged ?? false,
+      taskUnassigned: integration?.events?.taskUnassigned ?? false,
       dueDateReminder: integration?.events?.dueDateReminder ?? false,
       dueDateReminderLeadTimeHours:
         (integration?.dueDateReminderLeadTimeMinutes ?? 1440) / 60,
@@ -157,6 +177,11 @@ export function GenericWebhookIntegrationSettings({
         taskTitleChanged: values.taskTitleChanged,
         taskDescriptionChanged: values.taskDescriptionChanged,
         taskCommentCreated: values.taskCommentCreated,
+        taskDeleted: values.taskDeleted,
+        taskMoved: values.taskMoved,
+        taskDueDateChanged: values.taskDueDateChanged,
+        taskAssigneeChanged: values.taskAssigneeChanged,
+        taskUnassigned: values.taskUnassigned,
         dueDateReminder: values.dueDateReminder,
       };
 
@@ -250,6 +275,11 @@ export function GenericWebhookIntegrationSettings({
         taskTitleChanged: false,
         taskDescriptionChanged: false,
         taskCommentCreated: true,
+        taskDeleted: false,
+        taskMoved: false,
+        taskDueDateChanged: false,
+        taskAssigneeChanged: false,
+        taskUnassigned: false,
         dueDateReminder: false,
         dueDateReminderLeadTimeHours: 24,
       });
@@ -416,6 +446,37 @@ export function GenericWebhookIntegrationSettings({
                 "settings:genericWebhookIntegration.events.taskCommentCreated",
               )}
               name="taskCommentCreated"
+            />
+            <EventToggle
+              control={form.control}
+              label={t("settings:genericWebhookIntegration.events.taskDeleted")}
+              name="taskDeleted"
+            />
+            <EventToggle
+              control={form.control}
+              label={t("settings:genericWebhookIntegration.events.taskMoved")}
+              name="taskMoved"
+            />
+            <EventToggle
+              control={form.control}
+              label={t(
+                "settings:genericWebhookIntegration.events.taskDueDateChanged",
+              )}
+              name="taskDueDateChanged"
+            />
+            <EventToggle
+              control={form.control}
+              label={t(
+                "settings:genericWebhookIntegration.events.taskAssigneeChanged",
+              )}
+              name="taskAssigneeChanged"
+            />
+            <EventToggle
+              control={form.control}
+              label={t(
+                "settings:genericWebhookIntegration.events.taskUnassigned",
+              )}
+              name="taskUnassigned"
             />
             <EventToggle
               control={form.control}

--- a/apps/web/src/fetchers/generic-webhook-integration/create-generic-webhook-integration.ts
+++ b/apps/web/src/fetchers/generic-webhook-integration/create-generic-webhook-integration.ts
@@ -11,6 +11,11 @@ export type CreateGenericWebhookIntegrationRequest = {
     taskTitleChanged?: boolean;
     taskDescriptionChanged?: boolean;
     taskCommentCreated?: boolean;
+    taskDeleted?: boolean;
+    taskMoved?: boolean;
+    taskDueDateChanged?: boolean;
+    taskAssigneeChanged?: boolean;
+    taskUnassigned?: boolean;
     dueDateReminder?: boolean;
   };
   dueDateReminderLeadTimeMinutes?: number;

--- a/apps/web/src/fetchers/generic-webhook-integration/get-generic-webhook-integration.ts
+++ b/apps/web/src/fetchers/generic-webhook-integration/get-generic-webhook-integration.ts
@@ -14,6 +14,11 @@ export type GenericWebhookIntegration = {
     taskTitleChanged: boolean;
     taskDescriptionChanged: boolean;
     taskCommentCreated: boolean;
+    taskDeleted: boolean;
+    taskMoved: boolean;
+    taskDueDateChanged: boolean;
+    taskAssigneeChanged: boolean;
+    taskUnassigned: boolean;
     dueDateReminder: boolean;
   };
   dueDateReminderLeadTimeMinutes: number;

--- a/apps/web/src/fetchers/generic-webhook-integration/update-generic-webhook-integration.ts
+++ b/apps/web/src/fetchers/generic-webhook-integration/update-generic-webhook-integration.ts
@@ -12,6 +12,11 @@ export type UpdateGenericWebhookIntegrationRequest = {
     taskTitleChanged?: boolean;
     taskDescriptionChanged?: boolean;
     taskCommentCreated?: boolean;
+    taskDeleted?: boolean;
+    taskMoved?: boolean;
+    taskDueDateChanged?: boolean;
+    taskAssigneeChanged?: boolean;
+    taskUnassigned?: boolean;
     dueDateReminder?: boolean;
   };
   dueDateReminderLeadTimeMinutes?: number;

--- a/apps/web/src/hooks/use-board-sort.test.tsx
+++ b/apps/web/src/hooks/use-board-sort.test.tsx
@@ -1,0 +1,74 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useBoardSort } from "./use-board-sort";
+
+describe("useBoardSort", () => {
+  const storageKey = "kaneo:board-sort:project-1";
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("restores persisted sort from storage", async () => {
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({ field: "priority", direction: "desc" }),
+    );
+
+    const { result } = renderHook(() => useBoardSort("project-1"));
+
+    await waitFor(() => {
+      expect(result.current.sort).toEqual({
+        field: "priority",
+        direction: "desc",
+      });
+    });
+  });
+
+  it("falls back to the default sort when stored JSON is invalid", async () => {
+    window.localStorage.setItem(storageKey, "not-json{");
+
+    const { result } = renderHook(() => useBoardSort("project-1"));
+
+    await waitFor(() => {
+      expect(result.current.sort).toEqual({
+        field: "position",
+        direction: "asc",
+      });
+    });
+  });
+
+  it("writes sort changes to storage", async () => {
+    const { result } = renderHook(() => useBoardSort("project-1"));
+
+    act(() => {
+      result.current.setSort({ field: "dueDate", direction: "desc" });
+    });
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(storageKey)).toBe(
+        JSON.stringify({ field: "dueDate", direction: "desc" }),
+      );
+    });
+  });
+
+  it("falls back to the default sort when the stored field is invalid", async () => {
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({ field: "not-a-field", direction: "desc" }),
+    );
+
+    const { result } = renderHook(() => useBoardSort("project-1"));
+
+    await waitFor(() => {
+      expect(result.current.sort).toEqual({
+        field: "position",
+        direction: "asc",
+      });
+    });
+  });
+});

--- a/apps/web/src/hooks/use-board-sort.ts
+++ b/apps/web/src/hooks/use-board-sort.ts
@@ -71,7 +71,11 @@ export function useBoardSort(projectId: string | undefined) {
 
   useEffect(() => {
     if (!storageKey || typeof window === "undefined") return;
-    window.localStorage.setItem(storageKey, JSON.stringify(sort));
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(sort));
+    } catch {
+      // persistence is best-effort; private mode or quota can block writes
+    }
   }, [sort, storageKey]);
 
   return { sort, setSort };

--- a/apps/web/src/hooks/use-board-sort.ts
+++ b/apps/web/src/hooks/use-board-sort.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import type { SortConfig, SortDirection, SortField } from "@/lib/sort-tasks";
+
+const DEFAULT_SORT: SortConfig = {
+  field: "position",
+  direction: "asc",
+};
+
+const SORT_FIELD_MAP: Record<SortField, true> = {
+  position: true,
+  createdAt: true,
+  priority: true,
+  dueDate: true,
+  title: true,
+  number: true,
+};
+
+const SORT_FIELDS = Object.keys(SORT_FIELD_MAP) as readonly SortField[];
+
+const SORT_DIRECTION_MAP: Record<SortDirection, true> = {
+  asc: true,
+  desc: true,
+};
+
+const SORT_DIRECTIONS = Object.keys(
+  SORT_DIRECTION_MAP,
+) as readonly SortDirection[];
+
+function isSortField(value: unknown): value is SortField {
+  return SORT_FIELDS.includes(value as SortField);
+}
+
+function isSortDirection(value: unknown): value is SortDirection {
+  return SORT_DIRECTIONS.includes(value as SortDirection);
+}
+
+function normalizeSort(value: unknown): SortConfig {
+  if (!value || typeof value !== "object") {
+    return DEFAULT_SORT;
+  }
+
+  const candidate = value as Partial<Record<keyof SortConfig, unknown>>;
+
+  if (!isSortField(candidate.field) || !isSortDirection(candidate.direction)) {
+    return DEFAULT_SORT;
+  }
+
+  return { field: candidate.field, direction: candidate.direction };
+}
+
+export function useBoardSort(projectId: string | undefined) {
+  const storageKey = projectId ? `kaneo:board-sort:${projectId}` : null;
+  const [sort, setSort] = useState<SortConfig>(DEFAULT_SORT);
+
+  useEffect(() => {
+    if (!storageKey || typeof window === "undefined") return;
+
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (!stored) {
+        setSort(DEFAULT_SORT);
+        return;
+      }
+
+      const parsed = JSON.parse(stored) as unknown;
+      setSort(normalizeSort(parsed));
+    } catch {
+      setSort(DEFAULT_SORT);
+    }
+  }, [storageKey]);
+
+  useEffect(() => {
+    if (!storageKey || typeof window === "undefined") return;
+    window.localStorage.setItem(storageKey, JSON.stringify(sort));
+  }, [sort, storageKey]);
+
+  return { sort, setSort };
+}

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board.tsx
@@ -14,9 +14,9 @@ import { shortcuts } from "@/constants/shortcuts";
 import useGetLabelsByWorkspace from "@/hooks/queries/label/use-get-labels-by-workspace";
 import { useGetTasks } from "@/hooks/queries/task/use-get-tasks";
 import { useGetActiveWorkspaceUsers } from "@/hooks/queries/workspace-users/use-get-active-workspace-users";
+import { useBoardSort } from "@/hooks/use-board-sort";
 import { useRegisterShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { useTaskFiltersWithLabelsSupport } from "@/hooks/use-task-filters-with-labels-support";
-import type { SortConfig } from "@/lib/sort-tasks";
 import { sortTasks } from "@/lib/sort-tasks";
 import useProjectStore from "@/store/project";
 import { useUserPreferencesStore } from "@/store/user-preferences";
@@ -88,10 +88,7 @@ function RouteComponent() {
   const [isBoardSearchVisible, setIsBoardSearchVisible] = useState(false);
   const [boardSearchInput, setBoardSearchInput] =
     useState<HTMLInputElement | null>(null);
-  const [sort, setSort] = useState<SortConfig>({
-    field: "position",
-    direction: "asc",
-  });
+  const { sort, setSort } = useBoardSort(projectId);
 
   const { data: users } = useGetActiveWorkspaceUsers(workspaceId);
   const { data: workspaceLabels = [] } = useGetLabelsByWorkspace(workspaceId);

--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -914,6 +914,11 @@
 				"taskTitleChanged": "Titeländerungen",
 				"taskDescriptionChanged": "Beschreibungsänderungen",
 				"taskCommentCreated": "Neue Kommentare",
+				"taskDeleted": "Aufgabe gelöscht",
+				"taskMoved": "Aufgabe verschoben",
+				"taskDueDateChanged": "Fälligkeitsdatum geändert",
+				"taskAssigneeChanged": "Zuweisung geändert",
+				"taskUnassigned": "Zuweisung entfernt",
 				"dueDateReminder": "Erinnerungen an Fälligkeitstermine"
 			},
 			"reminderLeadTimeLabel": "Webhook so viele Stunden vorher senden",

--- a/i18n/el-GR.json
+++ b/i18n/el-GR.json
@@ -874,12 +874,17 @@
 			"connectionTitle": "Σύνδεση εξερχόμενου webhook",
 			"disconnect": "Αποσύνδεση",
 			"events": {
+				"taskAssigneeChanged": "Αλλαγή ανάθεσης",
 				"taskCommentCreated": "Νέα σχόλια",
 				"taskCreated": "Νέες εργασίες",
+				"taskDeleted": "Διαγραφή εργασίας",
 				"taskDescriptionChanged": "Αλλαγές περιγραφής",
+				"taskDueDateChanged": "Αλλαγή ημερομηνίας λήξης",
+				"taskMoved": "Μετακίνηση εργασίας",
 				"taskPriorityChanged": "Αλλαγές προτεραιότητας",
 				"taskStatusChanged": "Αλλαγές κατάστασης",
-				"taskTitleChanged": "Αλλαγές τίτλου"
+				"taskTitleChanged": "Αλλαγές τίτλου",
+				"taskUnassigned": "Αφαίρεση ανάθεσης"
 			},
 			"eventsHint": "Επιλέξτε ποιες αλλαγές έργου θα ενεργοποιούν εξερχόμενα webhooks.",
 			"eventsTitle": "Ειδοποιήσεις γεγονότων",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1078,6 +1078,11 @@
 				"taskTitleChanged": "Title changes",
 				"taskDescriptionChanged": "Description changes",
 				"taskCommentCreated": "New comments",
+				"taskDeleted": "Task deleted",
+				"taskMoved": "Task moved",
+				"taskDueDateChanged": "Due date changed",
+				"taskAssigneeChanged": "Assignee changed",
+				"taskUnassigned": "Task unassigned",
 				"dueDateReminder": "Due-date reminders"
 			},
 			"reminderLeadTimeLabel": "Send the webhook this many hours before",

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -731,7 +731,12 @@
 				"taskPriorityChanged": "Cambios de prioridad",
 				"taskTitleChanged": "Cambios en el título",
 				"taskDescriptionChanged": "Cambios en la descripción",
-				"taskCommentCreated": "Nuevos comentarios"
+				"taskCommentCreated": "Nuevos comentarios",
+				"taskDeleted": "Tarea eliminada",
+				"taskMoved": "Tarea movida",
+				"taskDueDateChanged": "Cambio de fecha de vencimiento",
+				"taskAssigneeChanged": "Cambio de asignado",
+				"taskUnassigned": "Tarea desasignada"
 			},
 			"connect": "Conectar al webhook",
 			"saveChanges": "Guardar cambios",

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -901,7 +901,12 @@
 				"taskPriorityChanged": "Changements de priorité",
 				"taskTitleChanged": "Changements de titre",
 				"taskDescriptionChanged": "Changements de description",
-				"taskCommentCreated": "Nouveaux commentaires"
+				"taskCommentCreated": "Nouveaux commentaires",
+				"taskDeleted": "Tâche supprimée",
+				"taskMoved": "Tâche déplacée",
+				"taskDueDateChanged": "Date d'échéance modifiée",
+				"taskAssigneeChanged": "Assigné modifié",
+				"taskUnassigned": "Tâche désassignée"
 			},
 			"connect": "Connecter le webhook",
 			"saveChanges": "Enregistrer les modifications",

--- a/i18n/id-ID.json
+++ b/i18n/id-ID.json
@@ -901,7 +901,12 @@
 				"taskPriorityChanged": "Perubahan prioritas",
 				"taskTitleChanged": "Perubahan judul",
 				"taskDescriptionChanged": "Perubahan deskripsi",
-				"taskCommentCreated": "Komentar baru"
+				"taskCommentCreated": "Komentar baru",
+				"taskDeleted": "Tugas dihapus",
+				"taskMoved": "Tugas dipindahkan",
+				"taskDueDateChanged": "Tenggat diubah",
+				"taskAssigneeChanged": "Penanggung jawab diubah",
+				"taskUnassigned": "Penugasan dihapus"
 			},
 			"connect": "Hubungkan webhook",
 			"saveChanges": "Simpan perubahan",

--- a/i18n/ko-KR.json
+++ b/i18n/ko-KR.json
@@ -899,7 +899,12 @@
 				"taskPriorityChanged": "우선순위 변경",
 				"taskTitleChanged": "제목 변경",
 				"taskDescriptionChanged": "설명 변경",
-				"taskCommentCreated": "새 댓글"
+				"taskCommentCreated": "새 댓글",
+				"taskDeleted": "작업 삭제",
+				"taskMoved": "작업 이동",
+				"taskDueDateChanged": "마감일 변경",
+				"taskAssigneeChanged": "담당자 변경",
+				"taskUnassigned": "할당 해제"
 			},
 			"connect": "웹훅 연결",
 			"saveChanges": "변경사항 저장",

--- a/i18n/mk-MK.json
+++ b/i18n/mk-MK.json
@@ -899,7 +899,12 @@
 				"taskPriorityChanged": "Промени на приоритет",
 				"taskTitleChanged": "Промени на наслов",
 				"taskDescriptionChanged": "Промени на опис",
-				"taskCommentCreated": "Нови коментари"
+				"taskCommentCreated": "Нови коментари",
+				"taskDeleted": "Избришана задача",
+				"taskMoved": "Преместена задача",
+				"taskDueDateChanged": "Променет краен рок",
+				"taskAssigneeChanged": "Променето доделување",
+				"taskUnassigned": "Одземено доделување"
 			},
 			"connect": "Поврзи webhook",
 			"saveChanges": "Зачувај промени",

--- a/i18n/nl-NL.json
+++ b/i18n/nl-NL.json
@@ -731,7 +731,12 @@
 				"taskPriorityChanged": "Prioriteitswijzigingen",
 				"taskTitleChanged": "Titelwijzigingen",
 				"taskDescriptionChanged": "Beschrijvingswijzigingen",
-				"taskCommentCreated": "Nieuwe reacties"
+				"taskCommentCreated": "Nieuwe reacties",
+				"taskDeleted": "Taak verwijderd",
+				"taskMoved": "Taak verplaatst",
+				"taskDueDateChanged": "Einddatum gewijzigd",
+				"taskAssigneeChanged": "Toewijzing gewijzigd",
+				"taskUnassigned": "Toewijzing verwijderd"
 			},
 			"connect": "Webhook verbinden",
 			"saveChanges": "Wijzigingen opslaan",

--- a/i18n/ru-RU.json
+++ b/i18n/ru-RU.json
@@ -897,7 +897,12 @@
 				"taskPriorityChanged": "Изменения приоритета",
 				"taskTitleChanged": "Изменения названия",
 				"taskDescriptionChanged": "Изменения описания",
-				"taskCommentCreated": "Новые комментарии"
+				"taskCommentCreated": "Новые комментарии",
+				"taskDeleted": "Задача удалена",
+				"taskMoved": "Задача перемещена",
+				"taskDueDateChanged": "Изменен срок выполнения",
+				"taskAssigneeChanged": "Изменен исполнитель",
+				"taskUnassigned": "Назначение снято"
 			},
 			"connect": "Подключить вебхук",
 			"saveChanges": "Сохранить изменения",

--- a/i18n/tr-TR.json
+++ b/i18n/tr-TR.json
@@ -900,7 +900,12 @@
 				"taskPriorityChanged": "Öncelik değişiklikleri",
 				"taskTitleChanged": "Başlık değişiklikleri",
 				"taskDescriptionChanged": "Açıklama değişiklikleri",
-				"taskCommentCreated": "Yeni yorumlar"
+				"taskCommentCreated": "Yeni yorumlar",
+				"taskDeleted": "Talep silindi",
+				"taskMoved": "Talep taşındı",
+				"taskDueDateChanged": "Bitiş tarihi değişti",
+				"taskAssigneeChanged": "Atanan kişi değişti",
+				"taskUnassigned": "Atama kaldırıldı"
 			},
 			"connect": "Webhook bağla",
 			"saveChanges": "Değişiklikleri kaydet",

--- a/i18n/uk-UA.json
+++ b/i18n/uk-UA.json
@@ -897,7 +897,12 @@
 				"taskPriorityChanged": "Зміни пріоритету",
 				"taskTitleChanged": "Зміни назви",
 				"taskDescriptionChanged": "Зміни опису",
-				"taskCommentCreated": "Нові коментарі"
+				"taskCommentCreated": "Нові коментарі",
+				"taskDeleted": "Завдання видалено",
+				"taskMoved": "Завдання переміщено",
+				"taskDueDateChanged": "Змінено дату завершення",
+				"taskAssigneeChanged": "Змінено виконавця",
+				"taskUnassigned": "Призначення знято"
 			},
 			"connect": "Підключити вебхук",
 			"saveChanges": "Зберегти зміни",

--- a/tests/api/column/to-slug.test.ts
+++ b/tests/api/column/to-slug.test.ts
@@ -31,4 +31,9 @@ describe("toSlug", () => {
     expect(toSlug("!!!")).toBe("");
     expect(toSlug("- - -")).toBe("");
   });
+
+  it("returns an empty slug for names made only of combining marks", () => {
+    expect(toSlug("́́")).toBe("");
+    expect(toSlug(" ̇ ")).toBe("");
+  });
 });

--- a/tests/api/column/to-slug.test.ts
+++ b/tests/api/column/to-slug.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { toSlug } from "../../../apps/api/src/column/controllers/create-column";
+
+describe("toSlug", () => {
+  it("slugifies Latin names", () => {
+    expect(toSlug("To Do")).toBe("to-do");
+    expect(toSlug("  In Progress!  ")).toBe("in-progress");
+  });
+
+  it("keeps non-Latin scripts instead of producing an empty slug", () => {
+    expect(toSlug("тест")).toBe("тест");
+    expect(toSlug("В работе")).toBe("в-работе");
+    expect(toSlug("测试")).toBe("测试");
+    expect(toSlug("قيد التنفيذ")).toBe("قيد-التنفيذ");
+  });
+
+  it("mixes scripts and numbers", () => {
+    expect(toSlug("Спринт 2")).toBe("спринт-2");
+  });
+
+  it("folds full-width characters via NFKC normalization", () => {
+    expect(toSlug("ＡＢＣ")).toBe("abc");
+  });
+
+  it("keeps combining marks attached to their base letters", () => {
+    expect(toSlug("İzmir")).toBe("i̇zmir");
+    expect(toSlug("हिन्दी")).toBe("हिन्दी");
+  });
+
+  it("returns an empty slug for names with no letters or numbers", () => {
+    expect(toSlug("!!!")).toBe("");
+    expect(toSlug("- - -")).toBe("");
+  });
+});

--- a/tests/api/plugins/generic-webhook/config-reminders.test.ts
+++ b/tests/api/plugins/generic-webhook/config-reminders.test.ts
@@ -12,6 +12,11 @@ describe("generic webhook reminder config", () => {
 
     expect(config.events).toEqual(defaultGenericWebhookEvents);
     expect(config.events?.dueDateReminder).toBe(false);
+    expect(config.events?.taskDeleted).toBe(false);
+    expect(config.events?.taskMoved).toBe(false);
+    expect(config.events?.taskDueDateChanged).toBe(false);
+    expect(config.events?.taskAssigneeChanged).toBe(false);
+    expect(config.events?.taskUnassigned).toBe(false);
     expect(config.dueDateReminderLeadTimeMinutes).toBe(1440);
   });
 

--- a/tests/api/plugins/generic-webhook/events.test.ts
+++ b/tests/api/plugins/generic-webhook/events.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { postToGenericWebhook } from "../../../../apps/api/src/plugins/generic-webhook/client";
+import {
+  handleTaskDeleted,
+  handleTaskUnassigned,
+} from "../../../../apps/api/src/plugins/generic-webhook/events";
+
+const { selectMock, findFirstMock } = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  findFirstMock: vi.fn(),
+}));
+
+vi.mock("../../../../apps/api/src/plugins/generic-webhook/client", () => ({
+  postToGenericWebhook: vi.fn(),
+}));
+
+vi.mock("../../../../apps/api/src/database", () => ({
+  default: {
+    select: selectMock,
+    query: {
+      integrationTable: {
+        findFirst: findFirstMock,
+      },
+    },
+  },
+}));
+
+function selectChain(rows: unknown[]) {
+  return {
+    from: () => ({
+      where: () => ({
+        limit: () => Promise.resolve(rows),
+      }),
+    }),
+  };
+}
+
+const context = {
+  integrationId: "integration-1",
+  projectId: "project-1",
+  config: {
+    webhookUrl: "https://example.com/hooks/kaneo",
+  },
+};
+
+const enabledContext = {
+  ...context,
+  config: {
+    webhookUrl: "https://example.com/hooks/kaneo",
+    events: { taskDeleted: true },
+  },
+};
+
+const deletedEvent = {
+  taskId: "task-1",
+  projectId: "project-1",
+  userId: "user-1",
+  title: "Ship the release",
+};
+
+describe("generic webhook event handlers", () => {
+  beforeEach(() => {
+    vi.mocked(postToGenericWebhook).mockClear();
+    selectMock.mockReset();
+    findFirstMock.mockReset();
+    findFirstMock.mockResolvedValue(undefined);
+  });
+
+  it("does not post task.unassigned when taskUnassigned is disabled", async () => {
+    await handleTaskUnassigned(
+      {
+        taskId: "task-1",
+        projectId: "project-1",
+        userId: "user-1",
+        title: "Ship the release",
+      },
+      context,
+    );
+
+    expect(postToGenericWebhook).not.toHaveBeenCalled();
+  });
+
+  it("does not post task.deleted when taskDeleted is disabled", async () => {
+    await handleTaskDeleted(deletedEvent, context);
+
+    expect(postToGenericWebhook).not.toHaveBeenCalled();
+  });
+
+  it("posts a project-scoped task.deleted envelope when enabled", async () => {
+    selectMock
+      .mockImplementationOnce(() =>
+        selectChain([
+          { id: "project-1", name: "Roadmap", workspaceId: "workspace-1" },
+        ]),
+      )
+      .mockImplementationOnce(() =>
+        selectChain([{ id: "user-1", name: "Andrej" }]),
+      );
+
+    await handleTaskDeleted(deletedEvent, enabledContext);
+
+    expect(postToGenericWebhook).toHaveBeenCalledTimes(1);
+    const [url, payload] = vi.mocked(postToGenericWebhook).mock.calls[0] ?? [];
+    expect(url).toBe("https://example.com/hooks/kaneo");
+    expect(payload).toMatchObject({
+      event: "task.deleted",
+      integration: { type: "generic-webhook" },
+      project: { id: "project-1", name: "Roadmap", workspaceId: "workspace-1" },
+      task: { id: "task-1", title: "Ship the release" },
+      actor: { id: "user-1", name: "Andrej" },
+      data: {},
+    });
+  });
+
+  it("skips task.deleted when the project row no longer exists", async () => {
+    selectMock.mockImplementationOnce(() => selectChain([]));
+
+    await handleTaskDeleted(deletedEvent, enabledContext);
+
+    expect(postToGenericWebhook).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes three open issues in one pass: columns can now be created with non-Latin names (#1395), the Kanban board's sort selection survives page reloads (#1357), and the Generic Webhook plugin forwards the five task events that previously never left the app (#1396). Each issue is a separate commit for easier review.

## Changes
- **Non-Latin column names (`fix(api)`)**: `toSlug()` now uses NFKC normalization with a `\p{L}\p{M}\p{N}` keep-class, so Cyrillic/Arabic/CJK/Indic names produce valid slugs while existing Latin slugs stay byte-identical. Combining marks stay attached (Turkish dotted İ, Devanagari matras).
- **Board sort persistence (`feat(web)`)**: new `use-board-sort` hook mirrors the existing per-project filter persistence (`kaneo:board-sort:<projectId>`), with persisted values validated against `Record`-derived maps so a future `SortField` change fails at compile time instead of silently resetting saved sorts.
- **Webhook task events (`feat`)**: `task.deleted`, `task.moved`, `task.due_date_changed`, `task.assignee_changed`, and `task.unassigned` now flow publisher → registry → generic-webhook, each behind a new opt-in toggle (settings UI, fetchers, OpenAPI schema, all 12 locales). `task.deleted` builds its envelope from event data via a shared delivery/health helper since the row is already gone. Bulk operations now emit the same webhook data as single edits (old assignee/due date, title) and publish `task.deleted` only after the delete succeeds.

Known scope limits, left for follow-up discussion: `task.moved` notifies only the destination project's webhooks (the WS layer notifies both sides), and bulk operations fan out one background webhook POST per task.

## Test Plan
- New unit tests: `toSlug` (7 cases incl. Turkish/Devanagari), `use-board-sort` (restore/fallback/write-through), generic-webhook handlers (disabled paths + enabled `task.deleted` envelope + missing-project guard)
- Full suites green: API 200/200, web 34/34, `biome ci` clean, monorepo build passes (pre-commit hook ran both on every commit)
- Multi-agent review over the full diff (10 finder angles, per-finding verification); all confirmed findings fixed or documented above

Closes #1395
Closes #1357
Closes #1396

https://claude.ai/code/session_01UkZ21HKnpGqwN7p2tkr6CV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generic webhooks now support task deletion, movement, due-date changes, assignee changes, and unassignment events.
  * Added new opt-in toggles for these events in generic webhook integration settings, including localized labels.
* **Improvements**
  * Board sorting is now saved/restored per project.
  * Slug generation now properly normalizes Unicode, including full-width text, and avoids empty slugs for non-alphanumeric input.
* **Tests**
  * Added/expanded tests for webhook delivery, new settings behavior, board-sort persistence, and Unicode slugification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->