### PR TITLE
fix(mcp): accept Kaneo API key as Bearer in MCP auth

### DIFF
--- a/apps/api/src/mcp/index.ts
+++ b/apps/api/src/mcp/index.ts
@@ -3,6 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { Hono } from "hono";
 import { auth } from "../auth";
+import { verifyApiKey } from "../utils/verify-api-key";
 import {
   createAuthCode,
   exchangeCode,
@@ -41,8 +42,18 @@ async function validateBearerToken(
   headers.set("authorization", `Bearer ${token}`);
   const session = await auth.api.getSession({ headers });
 
-  if (!session?.user?.id) return null;
-  return { userId: session.user.id, token };
+  if (session?.user?.id) {
+    return { userId: session.user.id, token };
+  }
+
+  // Fallback: Hermes and other agents send Kaneo API keys as Bearer.
+  // Match REST auth (authenticateApiRequest) via verifyApiKey.
+  const apiKeyResult = await verifyApiKey(token);
+  if (apiKeyResult?.valid && apiKeyResult.key?.userId) {
+    return { userId: apiKeyResult.key.userId, token };
+  }
+
+  return null;
 }
 
 const mcp = new Hono();


### PR DESCRIPTION
## Summary
- MCP `validateBearerToken` now accepts Kaneo API keys sent as `Authorization: Bearer <apiKey>` (Hermes / agent server-to-server access).
- Fallback uses existing `verifyApiKey`, matching REST `authenticateApiRequest`, instead of a second `getSession` with `x-api-key`.
- Session Bearer (OAuth MCP) is unchanged: session lookup still runs first.

## Why
Hermes MCP clients send API keys as Bearer. MCP previously only validated session tokens, while REST already accepted API keys as Bearer. This aligns MCP with REST without changing the client contract.

## Test plan
- [ ] `Authorization: Bearer <kaneo-api-key>` against `/api/mcp` authenticates and tools can call REST with the same key
- [ ] OAuth/session Bearer still works for MCP
- [ ] Invalid Bearer still returns 401
- [ ] Confirm PR diff has no Dockerfile changes (nginx pin already handled on main via `nginx=~1.28.3`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication by falling back to API-key verification when Bearer token session lookup doesn’t identify a user.
  * Requests are more likely to authenticate successfully when the provided token matches a supported authentication method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->