### PR TITLE
fix(mcp): accept Kaneo API key as Bearer in MCP auth

### DIFF
--- a/apps/api/src/mcp/index.ts
+++ b/apps/api/src/mcp/index.ts
@@ -3,6 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { Hono } from "hono";
 import { auth } from "../auth";
+import { verifyApiKey } from "../utils/verify-api-key";
 import {
   createAuthCode,
   exchangeCode,
@@ -41,8 +42,18 @@ async function validateBearerToken(
   headers.set("authorization", `Bearer ${token}`);
   const session = await auth.api.getSession({ headers });
 
-  if (!session?.user?.id) return null;
-  return { userId: session.user.id, token };
+  if (session?.user?.id) {
+    return { userId: session.user.id, token };
+  }
+
+  // Fallback: Hermes and other agents send Kaneo API keys as Bearer.
+  // Match REST auth (authenticateApiRequest) via verifyApiKey.
+  const apiKeyResult = await verifyApiKey(token);
+  if (apiKeyResult?.valid && apiKeyResult.key?.userId) {
+    return { userId: apiKeyResult.key.userId, token };
+  }
+
+  return null;
 }
 
 const mcp = new Hono();


### PR DESCRIPTION
Hermes sends API keys as Authorization Bearer. Align MCP validateBearerToken with REST authenticateApiRequest via verifyApiKey.

## Description
<!-- Provide a brief summary of the changes in this PR -->

## Related Issue(s)
<!-- Link to the related issue(s) this PR addresses -->
Fixes #

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any other context about the PR here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for API key authentication when accessing MCP services.
  * Existing session-based authentication continues to work, with API keys used as a fallback when no session is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->