### PR TITLE
fix(api): stop embedding task rows in the project list response

### DIFF
--- a/apps/api/src/project/controllers/get-projects.ts
+++ b/apps/api/src/project/controllers/get-projects.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, inArray, isNull, min, sql } from "drizzle-orm";
+import { and, count, eq, isNull, min, sql } from "drizzle-orm";
 import db from "../../database";
 import { projectTable, taskTable } from "../../database/schema";
 
@@ -14,17 +14,18 @@ const EMPTY_STATISTICS: ProjectStatistics = {
   dueDate: null,
 };
 
-async function getProjectStatistics(projectIds: string[]) {
+async function getProjectStatistics(
+  workspaceId: string,
+  includeArchived: boolean,
+) {
   const statisticsByProject = new Map<string, ProjectStatistics>();
-
-  if (projectIds.length === 0) {
-    return statisticsByProject;
-  }
 
   // Aggregate in the database instead of loading every task row into memory.
   // This endpoint needs three numbers per project; the previous
   // `with: { tasks: true }` made both the query and the response grow linearly
-  // with the number of tasks in the workspace.
+  // with the number of tasks in the workspace. Scoping by workspaceId through
+  // a join (rather than an `IN (...projectIds)` list) keeps the statement size
+  // constant regardless of how many projects the workspace has.
   const rows = await db
     .select({
       projectId: taskTable.projectId,
@@ -35,7 +36,15 @@ async function getProjectStatistics(projectIds: string[]) {
       dueDate: min(taskTable.dueDate),
     })
     .from(taskTable)
-    .where(inArray(taskTable.projectId, projectIds))
+    .innerJoin(projectTable, eq(taskTable.projectId, projectTable.id))
+    .where(
+      includeArchived
+        ? eq(projectTable.workspaceId, workspaceId)
+        : and(
+            eq(projectTable.workspaceId, workspaceId),
+            isNull(projectTable.archivedAt),
+          ),
+    )
     .groupBy(taskTable.projectId);
 
   for (const row of rows) {
@@ -64,7 +73,8 @@ async function getProjects(workspaceId: string, includeArchived = false) {
   });
 
   const statisticsByProject = await getProjectStatistics(
-    projects.map((project) => project.id),
+    workspaceId,
+    includeArchived,
   );
 
   return projects.map((project) => ({

--- a/apps/api/src/project/controllers/get-projects.ts
+++ b/apps/api/src/project/controllers/get-projects.ts
@@ -1,6 +1,57 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, count, eq, inArray, isNull, min, sql } from "drizzle-orm";
 import db from "../../database";
-import { projectTable } from "../../database/schema";
+import { projectTable, taskTable } from "../../database/schema";
+
+type ProjectStatistics = {
+  completionPercentage: number;
+  totalTasks: number;
+  dueDate: Date | null;
+};
+
+const EMPTY_STATISTICS: ProjectStatistics = {
+  completionPercentage: 0,
+  totalTasks: 0,
+  dueDate: null,
+};
+
+async function getProjectStatistics(projectIds: string[]) {
+  const statisticsByProject = new Map<string, ProjectStatistics>();
+
+  if (projectIds.length === 0) {
+    return statisticsByProject;
+  }
+
+  // Aggregate in the database instead of loading every task row into memory.
+  // This endpoint needs three numbers per project; the previous
+  // `with: { tasks: true }` made both the query and the response grow linearly
+  // with the number of tasks in the workspace.
+  const rows = await db
+    .select({
+      projectId: taskTable.projectId,
+      totalTasks: count(),
+      completedTasks: count(
+        sql`case when ${taskTable.status} in ('done', 'archived') then 1 end`,
+      ),
+      dueDate: min(taskTable.dueDate),
+    })
+    .from(taskTable)
+    .where(inArray(taskTable.projectId, projectIds))
+    .groupBy(taskTable.projectId);
+
+  for (const row of rows) {
+    const totalTasks = Number(row.totalTasks);
+    const completedTasks = Number(row.completedTasks);
+
+    statisticsByProject.set(row.projectId, {
+      totalTasks,
+      completionPercentage:
+        totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0,
+      dueDate: row.dueDate ?? null,
+    });
+  }
+
+  return statisticsByProject;
+}
 
 async function getProjects(workspaceId: string, includeArchived = false) {
   const projects = await db.query.projectTable.findMany({
@@ -10,39 +61,19 @@ async function getProjects(workspaceId: string, includeArchived = false) {
           eq(projectTable.workspaceId, workspaceId),
           isNull(projectTable.archivedAt),
         ),
-    with: {
-      tasks: true,
-    },
   });
 
-  const projectsWithStatistics = projects.map((project) => {
-    const totalTasks = project.tasks.length;
-    const completedTasks = project.tasks.filter(
-      (task) => task.status === "done" || task.status === "archived",
-    ).length;
-    const completionPercentage =
-      totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0;
+  const statisticsByProject = await getProjectStatistics(
+    projects.map((project) => project.id),
+  );
 
-    const dueDate = project.tasks.reduce((earliest: Date | null, task) => {
-      if (!earliest || (task.dueDate && task.dueDate < earliest))
-        return task.dueDate;
-      return earliest;
-    }, null);
-
-    return {
-      ...project,
-      statistics: {
-        completionPercentage,
-        totalTasks,
-        dueDate,
-      },
-      archivedTasks: [],
-      plannedTasks: [],
-      columns: [],
-    };
-  });
-
-  return projectsWithStatistics;
+  return projects.map((project) => ({
+    ...project,
+    statistics: statisticsByProject.get(project.id) ?? EMPTY_STATISTICS,
+    archivedTasks: [],
+    plannedTasks: [],
+    columns: [],
+  }));
 }
 
 export default getProjects;

--- a/tests/api-integration/project-list.test.ts
+++ b/tests/api-integration/project-list.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import db, { schema } from "../../apps/api/src/database";
+import { createApp } from "../../apps/api/src/index";
+import { mockAuthenticatedSession } from "./helpers/auth";
+import { resetTestDatabase } from "./helpers/database";
+import {
+  createProjectFixture,
+  createWorkspaceMember,
+} from "./helpers/fixtures";
+
+type ProjectListEntry = typeof schema.projectTable.$inferSelect & {
+  statistics: {
+    completionPercentage: number;
+    totalTasks: number;
+    dueDate: string | null;
+  };
+  tasks?: unknown;
+};
+
+async function seedTasks(
+  projectId: string,
+  tasks: { title: string; status: string; dueDate?: Date; number: number }[],
+) {
+  for (const task of tasks) {
+    await db.insert(schema.taskTable).values({
+      projectId,
+      title: task.title,
+      status: task.status,
+      dueDate: task.dueDate ?? null,
+      number: task.number,
+    });
+  }
+}
+
+describe("API integration: project list payload", () => {
+  beforeEach(async () => {
+    await resetTestDatabase();
+  });
+
+  it("does not embed task rows in the project list response", async () => {
+    const member = await createWorkspaceMember();
+    const { project } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    await seedTasks(project.id, [
+      { title: "First", status: "to-do", number: 1 },
+      { title: "Second", status: "done", number: 2 },
+      { title: "Third", status: "archived", number: 3 },
+    ]);
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request(
+      `/api/project?workspaceId=${member.workspace.id}`,
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as ProjectListEntry[];
+    expect(payload).toHaveLength(1);
+
+    // The list endpoint is a summary view. Task rows must not ride along:
+    // the payload grows without bound as a project fills up.
+    expect(payload[0].tasks).toBeUndefined();
+  });
+
+  it("still reports accurate task statistics without embedding tasks", async () => {
+    const member = await createWorkspaceMember();
+    const { project } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    const earliest = new Date("2026-01-10T00:00:00.000Z");
+    const later = new Date("2026-03-01T00:00:00.000Z");
+
+    await seedTasks(project.id, [
+      { title: "Open", status: "to-do", dueDate: later, number: 1 },
+      { title: "Closed", status: "done", dueDate: earliest, number: 2 },
+      { title: "Filed", status: "archived", number: 3 },
+      { title: "Doing", status: "in-progress", number: 4 },
+    ]);
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request(
+      `/api/project?workspaceId=${member.workspace.id}`,
+    );
+    const payload = (await response.json()) as ProjectListEntry[];
+
+    // done + archived count as completed: 2 of 4 => 50%
+    expect(payload[0].statistics).toMatchObject({
+      totalTasks: 4,
+      completionPercentage: 50,
+    });
+    expect(new Date(payload[0].statistics.dueDate as string)).toEqual(earliest);
+  });
+
+  it("reports zeroed statistics for a project with no tasks", async () => {
+    const member = await createWorkspaceMember();
+    await createProjectFixture({ workspaceId: member.workspace.id });
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request(
+      `/api/project?workspaceId=${member.workspace.id}`,
+    );
+    const payload = (await response.json()) as ProjectListEntry[];
+
+    expect(payload[0].statistics).toMatchObject({
+      totalTasks: 0,
+      completionPercentage: 0,
+      dueDate: null,
+    });
+    expect(payload[0].tasks).toBeUndefined();
+  });
+
+  it("keeps statistics isolated per project", async () => {
+    const member = await createWorkspaceMember();
+    const { project: alpha } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+      name: "Alpha",
+      slug: "alpha",
+    });
+    const { project: beta } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+      name: "Beta",
+      slug: "beta",
+    });
+
+    await seedTasks(alpha.id, [
+      { title: "A1", status: "done", number: 1 },
+      { title: "A2", status: "to-do", number: 2 },
+    ]);
+    await seedTasks(beta.id, [{ title: "B1", status: "done", number: 1 }]);
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request(
+      `/api/project?workspaceId=${member.workspace.id}`,
+    );
+    const payload = (await response.json()) as ProjectListEntry[];
+
+    const byName = new Map(payload.map((p) => [p.name, p]));
+    expect(byName.get("Alpha")?.statistics).toMatchObject({
+      totalTasks: 2,
+      completionPercentage: 50,
+    });
+    expect(byName.get("Beta")?.statistics).toMatchObject({
+      totalTasks: 1,
+      completionPercentage: 100,
+    });
+  });
+});


### PR DESCRIPTION
`GET /api/project` uses `with: { tasks: true }` to compute three summary numbers per project (total tasks, completion percentage, earliest due date), then spreads the loaded rows into the response via `...project`. Every task in the workspace is fetched into memory and serialised to the client on every call, even though the endpoint only needs the aggregates.

The surrounding code suggests this was unintended: the same return object explicitly sets `archivedTasks: []`, `plannedTasks: []` and `columns: []`, so nested collections were already being deliberately omitted here. `tasks` slipped through the spread.

## Change

Replaces the join with a grouped aggregate: `count()`, a filtered count for `done`/`archived`, and `min(dueDate)`. Projects with no tasks fall back to zeroed statistics.

Semantics are unchanged, including ignoring null due dates when finding the earliest — which is what SQL `min()` does natively.

## Measurements

10 projects / 2,000 tasks, median of 5 runs:

| | payload | latency |
|---|---|---|
| before | 946.4 KB | 31.3 ms |
| after | 3.8 KB | 5.0 ms |

The response is now flat with respect to task count rather than linear, so it stays constant as a workspace fills up.

## Tests

Adds `tests/api-integration/project-list.test.ts` covering payload shape, statistics accuracy, empty projects, and per-project isolation. These fail against the previous implementation.

Locally: integration 68/68, unit 201/201, `biome check` and `tsc --noEmit` clean.

## Note on the response shape

Consumers reading `.tasks` off this endpoint would stop receiving it. Nothing in `apps/web` does — the board and list views read `column.tasks` from a different endpoint.

This follows the same principle as #1037, where the task list endpoint stopped forcing clients to download everything and filter locally. This endpoint appears to have been missed by that pass.

Happy to rework this as an opt-in (`?includeTasks=true`) instead if you'd prefer to keep the current shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project listings now include task statistics: total tasks, completion percentage, and earliest due date.
  * Projects without tasks display zeroed statistics.
  * Task data remains excluded from the project list response while statistics are included.

* **Bug Fixes**
  * Improved isolation of task statistics between multiple projects within the same workspace.

* **Tests**
  * Added integration coverage for the project list payload, including correct statistics calculations and response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->