### PR TITLE
fix(email): stop forcing SMTP auth when no credentials are set

### DIFF
--- a/apps/api/src/utils/get-settings.ts
+++ b/apps/api/src/utils/get-settings.ts
@@ -1,3 +1,4 @@
+import { isSmtpConfigured } from "@kaneo/email";
 import { config } from "dotenv-mono";
 import { isGithubSsoConfigured } from "./github-sso-env";
 
@@ -10,12 +11,7 @@ function getSettings() {
       process.env.DISABLE_PASSWORD_REGISTRATION === "true",
     disableEmailOtpSignIn: process.env.DISABLE_EMAIL_OTP_SIGN_IN === "true",
     isDemoMode: process.env.DEMO_MODE === "true",
-    hasSmtp:
-      Boolean(process.env.SMTP_HOST) &&
-      Boolean(process.env.SMTP_PORT) &&
-      Boolean(process.env.SMTP_SECURE) &&
-      Boolean(process.env.SMTP_USER) &&
-      Boolean(process.env.SMTP_PASSWORD),
+    hasSmtp: isSmtpConfigured(),
     hasGithubSignIn: isGithubSsoConfigured(),
     hasGoogleSignIn:
       Boolean(process.env.GOOGLE_CLIENT_ID) &&

--- a/packages/email/src/index.tsx
+++ b/packages/email/src/index.tsx
@@ -5,3 +5,4 @@ export {
   sendPasswordResetEmail,
   sendWorkspaceInvitationEmail,
 } from "./send-email";
+export { isSmtpConfigured } from "./smtp-config";

--- a/packages/email/src/send-email.tsx
+++ b/packages/email/src/send-email.tsx
@@ -1,6 +1,7 @@
 import { render } from "@react-email/components";
 import { config } from "dotenv-mono";
 import * as nodemailer from "nodemailer";
+import { getSmtpTransportOptions, isSmtpConfigured } from "./smtp-config";
 import type { MagicLinkEmailProps } from "./templates/magic-link";
 import MagicLinkEmail from "./templates/magic-link";
 import NotificationEmail, {
@@ -17,17 +18,7 @@ import WorkspaceInvitationEmail, {
 
 config();
 
-const transporter = nodemailer.createTransport({
-  host: process.env.SMTP_HOST,
-  secure: process.env.SMTP_SECURE !== "false",
-  port: Number(process.env.SMTP_PORT),
-  auth: {
-    user: process.env.SMTP_USER,
-    pass: process.env.SMTP_PASSWORD,
-  },
-  requireTLS: process.env.SMTP_REQUIRE_TLS === "true",
-  ignoreTLS: process.env.SMTP_IGNORE_TLS === "true",
-});
+const transporter = nodemailer.createTransport(getSmtpTransportOptions());
 
 export const sendMagicLinkEmail = async (
   to: string,
@@ -93,7 +84,7 @@ export const sendWorkspaceInvitationEmail = async (
   subject: string,
   data: WorkspaceInvitationEmailProps,
 ): Promise<EmailResult> => {
-  if (!process.env.SMTP_HOST || !process.env.SMTP_FROM) {
+  if (!isSmtpConfigured()) {
     return { success: false, reason: "SMTP_NOT_CONFIGURED" };
   }
 
@@ -119,7 +110,7 @@ export const sendNotificationEmail = async (
   subject: string,
   data: NotificationEmailProps,
 ): Promise<EmailResult> => {
-  if (!process.env.SMTP_HOST || !process.env.SMTP_FROM) {
+  if (!isSmtpConfigured()) {
     return { success: false, reason: "SMTP_NOT_CONFIGURED" };
   }
 

--- a/packages/email/src/smtp-config.test.ts
+++ b/packages/email/src/smtp-config.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { getSmtpTransportOptions, isSmtpConfigured } from "./smtp-config";
+
+describe("getSmtpTransportOptions", () => {
+  it("omits auth when no credentials are configured", () => {
+    const options = getSmtpTransportOptions({
+      SMTP_HOST: "relay.internal",
+      SMTP_PORT: "25",
+      SMTP_SECURE: "false",
+    });
+
+    expect(options.auth).toBeUndefined();
+    expect("auth" in options).toBe(false);
+    expect(options.host).toBe("relay.internal");
+    expect(options.port).toBe(25);
+    expect(options.secure).toBe(false);
+  });
+
+  it("omits auth when only one credential is configured", () => {
+    expect(
+      getSmtpTransportOptions({ SMTP_HOST: "relay.internal", SMTP_USER: "me" })
+        .auth,
+    ).toBeUndefined();
+    expect(
+      getSmtpTransportOptions({
+        SMTP_HOST: "relay.internal",
+        SMTP_PASSWORD: "s",
+      }).auth,
+    ).toBeUndefined();
+  });
+
+  it("includes auth when both credentials are configured", () => {
+    const options = getSmtpTransportOptions({
+      SMTP_HOST: "smtp.example.com",
+      SMTP_PORT: "465",
+      SMTP_USER: "me",
+      SMTP_PASSWORD: "secret",
+    });
+
+    expect(options.auth).toEqual({ user: "me", pass: "secret" });
+  });
+
+  it("leaves the port unset instead of NaN when SMTP_PORT is missing", () => {
+    const options = getSmtpTransportOptions({ SMTP_HOST: "relay.internal" });
+
+    expect(options.port).toBeUndefined();
+  });
+
+  it("defaults to a secure connection and honours the TLS flags", () => {
+    expect(getSmtpTransportOptions({ SMTP_HOST: "h" }).secure).toBe(true);
+    expect(
+      getSmtpTransportOptions({ SMTP_HOST: "h", SMTP_REQUIRE_TLS: "true" })
+        .requireTLS,
+    ).toBe(true);
+    expect(
+      getSmtpTransportOptions({ SMTP_HOST: "h", SMTP_IGNORE_TLS: "true" })
+        .ignoreTLS,
+    ).toBe(true);
+  });
+});
+
+describe("isSmtpConfigured", () => {
+  it("is true for a relay that needs no credentials", () => {
+    expect(
+      isSmtpConfigured({
+        SMTP_HOST: "relay.internal",
+        SMTP_FROM: "kaneo@example.com",
+      }),
+    ).toBe(true);
+  });
+
+  it("is false without a host or a sender", () => {
+    expect(isSmtpConfigured({ SMTP_FROM: "kaneo@example.com" })).toBe(false);
+    expect(isSmtpConfigured({ SMTP_HOST: "relay.internal" })).toBe(false);
+    expect(isSmtpConfigured({})).toBe(false);
+  });
+});

--- a/packages/email/src/smtp-config.ts
+++ b/packages/email/src/smtp-config.ts
@@ -1,0 +1,41 @@
+import type SMTPTransport from "nodemailer/lib/smtp-transport";
+
+type SmtpEnv = Record<string, string | undefined>;
+
+/**
+ * Build the nodemailer transport options from the environment.
+ *
+ * `auth` is only included when both a user and a password are set. Passing an
+ * `auth` object with undefined values makes nodemailer authenticate anyway,
+ * which fails against relays that accept unauthenticated mail. The same goes
+ * for `port`: leaving it out lets nodemailer pick the default for the chosen
+ * security mode instead of receiving NaN.
+ */
+export function getSmtpTransportOptions(
+  env: SmtpEnv = process.env,
+): SMTPTransport.Options {
+  const options: SMTPTransport.Options = {
+    host: env.SMTP_HOST,
+    secure: env.SMTP_SECURE !== "false",
+    requireTLS: env.SMTP_REQUIRE_TLS === "true",
+    ignoreTLS: env.SMTP_IGNORE_TLS === "true",
+  };
+
+  if (env.SMTP_PORT) {
+    options.port = Number(env.SMTP_PORT);
+  }
+
+  if (env.SMTP_USER && env.SMTP_PASSWORD) {
+    options.auth = { user: env.SMTP_USER, pass: env.SMTP_PASSWORD };
+  }
+
+  return options;
+}
+
+/**
+ * Whether outgoing mail can be sent at all. This is what the send helpers
+ * actually require: a host to connect to and an envelope sender.
+ */
+export function isSmtpConfigured(env: SmtpEnv = process.env): boolean {
+  return Boolean(env.SMTP_HOST) && Boolean(env.SMTP_FROM);
+}

--- a/tests/api-integration/mocks/email.ts
+++ b/tests/api-integration/mocks/email.ts
@@ -23,3 +23,7 @@ export async function sendWorkspaceInvitationEmail(
 ): Promise<EmailResult> {
   return { success: true };
 }
+
+export function isSmtpConfigured(): boolean {
+  return false;
+}


### PR DESCRIPTION
Closes #1419.

`packages/email/src/send-email.tsx` builds the nodemailer transport with an `auth` object that is always present:

```ts
auth: { user: process.env.SMTP_USER, pass: process.env.SMTP_PASSWORD }
```

Nodemailer reads the presence of `auth` as "authenticate this session", so with `SMTP_USER` and `SMTP_PASSWORD` unset it still tries to authenticate, and a relay that accepts unauthenticated mail refuses. Workspace invitations never arrive.

Transport options now come from `getSmtpTransportOptions()`, which adds `auth` only when both a user and a password are set. It also leaves `port` out when `SMTP_PORT` is unset instead of passing `Number(undefined)`, which was NaN, so nodemailer can fall back to the default port for the chosen security mode.

The same assumption sits in a second place. `hasSmtp` in `apps/api/src/utils/get-settings.ts` required `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_PORT` and `SMTP_SECURE`, so the unauthenticated relay case also made the API report SMTP as unconfigured and the sign-in page hide the email option. It never checked `SMTP_FROM`, which the send helpers do require, so the two definitions of "SMTP is set up" had drifted apart. Both now come from one `isSmtpConfigured()` (host plus sender), which is what `sendWorkspaceInvitationEmail` and `sendNotificationEmail` already guard on.

`packages/email/src/smtp-config.test.ts` covers no credentials, one credential, both credentials, the missing port, the TLS flags, and both `isSmtpConfigured` outcomes.

One caveat on my end: npm cannot reach the registry from this machine, so I could not install the workspace and run vitest. I ran the same assertions against the real `smtp-config.ts` using node's TypeScript stripping instead, 15 of them, all passing. The vitest file mirrors those cases, so CI should be the real check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMTP configuration detection for email sending.
  * Prevented email attempts when required SMTP settings are incomplete.
  * Improved handling of optional SMTP ports, credentials, and TLS settings.
  * Ensured email-related settings accurately reflect whether SMTP is available.

* **Tests**
  * Added coverage for SMTP configuration and transport options across supported settings.
  * Added validation for incomplete credentials and missing required settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->