### PR TITLE
fix: persist task title activity atomically

### DIFF
--- a/apps/api/src/activity/index.ts
+++ b/apps/api/src/activity/index.ts
@@ -287,18 +287,4 @@ subscribeToEvent<{
   });
 });
 
-subscribeToEvent<{
-  taskId: string;
-  userId: string;
-  oldTitle: string;
-  newTitle: string;
-  title: string;
-  type: string;
-}>("task.title_changed", async (data) => {
-  await createActivity(data.taskId, data.type, data.userId, null, {
-    oldTitle: data.oldTitle,
-    newTitle: data.newTitle,
-  });
-});
-
 export default activity;

--- a/apps/api/src/task/controllers/update-task-title.ts
+++ b/apps/api/src/task/controllers/update-task-title.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import db from "../../database";
-import { taskTable } from "../../database/schema";
+import { activityTable, taskTable } from "../../database/schema";
 import { publishEvent } from "../../events";
 
 async function updateTaskTitle({
@@ -23,17 +23,34 @@ async function updateTaskTitle({
     });
   }
 
-  const [updatedTask] = await db
-    .update(taskTable)
-    .set({ title })
-    .where(eq(taskTable.id, id))
-    .returning();
+  if (existingTask.title === title) return existingTask;
 
-  if (!updatedTask) {
-    throw new HTTPException(500, {
-      message: "Failed to update task title",
+  // Audit history is not best-effort. Commit the title and its immutable
+  // history row atomically; event subscribers remain notifications/integrations
+  // only and cannot make the audit trail disappear.
+  const updatedTask = await db.transaction(async (tx) => {
+    const [task] = await tx
+      .update(taskTable)
+      .set({ title })
+      .where(eq(taskTable.id, id))
+      .returning();
+
+    if (!task) {
+      throw new HTTPException(500, {
+        message: "Failed to update task title",
+      });
+    }
+
+    await tx.insert(activityTable).values({
+      taskId: task.id,
+      type: "title_changed",
+      userId: currentUserId,
+      content: null,
+      eventData: { oldTitle: existingTask.title, newTitle: title },
     });
-  }
+
+    return task;
+  });
 
   await publishEvent("task.title_changed", {
     taskId: updatedTask.id,

--- a/tests/api-integration/task-title-activity.test.ts
+++ b/tests/api-integration/task-title-activity.test.ts
@@ -1,0 +1,124 @@
+import { and, eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import db, { schema } from "../../apps/api/src/database";
+import { createApp } from "../../apps/api/src/index";
+import updateTaskTitle from "../../apps/api/src/task/controllers/update-task-title";
+import { mockAuthenticatedSession } from "./helpers/auth";
+import { resetTestDatabase } from "./helpers/database";
+import {
+  createProjectFixture,
+  createWorkspaceMember,
+} from "./helpers/fixtures";
+
+async function createTaskFixture() {
+  const member = await createWorkspaceMember();
+  const { project, columns } = await createProjectFixture({
+    workspaceId: member.workspace.id,
+  });
+  const [task] = await db
+    .insert(schema.taskTable)
+    .values({
+      projectId: project.id,
+      title: "Original title",
+      description: "Activity test task",
+      status: "to-do",
+      columnId: columns.todo.id,
+      priority: "medium",
+      number: 1,
+      position: 1,
+    })
+    .returning();
+
+  return { member, task };
+}
+
+describe("API integration: task title activity", () => {
+  beforeEach(async () => {
+    await resetTestDatabase();
+  });
+
+  it("persists the title and its activity before returning", async () => {
+    const { member, task } = await createTaskFixture();
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request(`/api/task/title/${task.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "Updated title" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      id: task.id,
+      title: "Updated title",
+    });
+
+    const [persistedTask, activities] = await Promise.all([
+      db.query.taskTable.findFirst({
+        where: eq(schema.taskTable.id, task.id),
+      }),
+      db
+        .select()
+        .from(schema.activityTable)
+        .where(
+          and(
+            eq(schema.activityTable.taskId, task.id),
+            eq(schema.activityTable.type, "title_changed"),
+          ),
+        ),
+    ]);
+
+    expect(persistedTask?.title).toBe("Updated title");
+    expect(activities).toHaveLength(1);
+    expect(activities[0]).toMatchObject({
+      taskId: task.id,
+      userId: member.user.id,
+      type: "title_changed",
+      eventData: {
+        oldTitle: "Original title",
+        newTitle: "Updated title",
+      },
+    });
+  });
+
+  it("does not create activity for an unchanged title", async () => {
+    const { member, task } = await createTaskFixture();
+
+    const result = await updateTaskTitle({
+      id: task.id,
+      title: task.title,
+      currentUserId: member.user.id,
+    });
+
+    expect(result.title).toBe(task.title);
+    const activities = await db
+      .select()
+      .from(schema.activityTable)
+      .where(eq(schema.activityTable.taskId, task.id));
+    expect(activities).toHaveLength(0);
+  });
+
+  it("rolls back the title when the activity insert fails", async () => {
+    const { task } = await createTaskFixture();
+
+    await expect(
+      updateTaskTitle({
+        id: task.id,
+        title: "Must not persist",
+        currentUserId: "missing-user",
+      }),
+    ).rejects.toThrow();
+
+    const persistedTask = await db.query.taskTable.findFirst({
+      where: eq(schema.taskTable.id, task.id),
+    });
+    const activities = await db
+      .select()
+      .from(schema.activityTable)
+      .where(eq(schema.activityTable.taskId, task.id));
+
+    expect(persistedTask?.title).toBe("Original title");
+    expect(activities).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- persist task title changes and their activity record in one database transaction
- skip writes and activity generation when the title is unchanged
- keep `task.title_changed` events for notifications and integrations, while removing the duplicate activity subscriber
- add integration coverage for persistence, no-op updates, and transaction rollback

## Why

Title updates previously committed the task row first, then created audit history asynchronously through an event subscriber. A failed or interrupted subscriber could therefore leave a changed title without its corresponding activity record.

This makes the activity row part of the same transaction as the title update. Publishing the event remains outside the transaction and continues to drive notifications and integrations.

## Tests

- `pnpm exec biome ci apps/api/src/activity/index.ts apps/api/src/task/controllers/update-task-title.ts tests/api-integration/task-title-activity.test.ts`
- focused integration suite: 3/3 passed
- `pnpm test`: 9/9 Turbo tasks passed; API 201/201, web 34/34
- `pnpm build`: 6/6 Turbo tasks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task title changes now reliably create activity history with the previous and updated titles.
  * Unchanged titles no longer create unnecessary activity entries.
  * Failed title updates leave both the task and activity history unchanged.

* **Tests**
  * Added coverage for successful updates, no-op changes, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->