### PR TITLE
feat: deep-link pricing CTAs through signup to checkout

### DIFF
--- a/apps/site/app/pricing/page.tsx
+++ b/apps/site/app/pricing/page.tsx
@@ -1,8 +1,8 @@
-import { Check } from "lucide-react";
 import type { Metadata } from "next";
 import { FadeIn } from "@/components/landing/fade-in";
 import { Footer } from "@/components/landing/footer";
 import { Navbar } from "@/components/landing/navbar";
+import { PricingPlans } from "@/components/landing/pricing-plans";
 import { SectionSeparator } from "@/components/landing/section-separator";
 
 export const metadata: Metadata = {
@@ -13,73 +13,6 @@ export const metadata: Metadata = {
     canonical: "/pricing",
   },
 };
-
-type Plan = {
-  name: string;
-  tagline: string;
-  price: string;
-  priceSuffix: string;
-  annualNote: string;
-  features: string[];
-  cta: { href: string; label: string };
-  highlighted?: boolean;
-};
-
-const plans: Plan[] = [
-  {
-    name: "Self-hosted",
-    tagline: "Your servers, your rules",
-    price: "€0",
-    priceSuffix: "forever",
-    annualNote: "MIT licensed, no strings attached",
-    features: [
-      "Unlimited users and projects",
-      "Every feature, including SSO",
-      "Your data on your servers",
-      "Community support on Discord",
-    ],
-    cta: {
-      href: "/docs/core/installation",
-      label: "Read installation guide",
-    },
-  },
-  {
-    name: "Cloud Personal",
-    tagline: "Managed hosting for one",
-    price: "€4",
-    priceSuffix: "/ month",
-    annualNote: "€40 / year (2 months free)",
-    features: [
-      "Single user",
-      "Unlimited projects and tasks",
-      "Automatic backups and updates",
-      "Email support",
-    ],
-    cta: {
-      href: "https://cloud.kaneo.app",
-      label: "Start 14-day free trial",
-    },
-  },
-  {
-    name: "Cloud Team",
-    tagline: "Managed hosting for teams",
-    price: "€5",
-    priceSuffix: "/ user / month",
-    annualNote: "€50 / user / year (2 months free)",
-    features: [
-      "Unlimited team members",
-      "Unlimited projects and tasks",
-      "Workspace roles and permissions",
-      "Automatic backups and updates",
-      "Priority email support",
-    ],
-    cta: {
-      href: "https://cloud.kaneo.app",
-      label: "Start 14-day free trial",
-    },
-    highlighted: true,
-  },
-];
 
 const notes = [
   {
@@ -124,71 +57,8 @@ export default function PricingPage() {
             </div>
 
             <FadeIn delay={200}>
-              <div className="mt-12 rounded-2xl border border-border/70 bg-card/70 p-2">
-                <div className="grid grid-cols-1 gap-2 lg:grid-cols-3">
-                  {plans.map((plan) => (
-                    <article
-                      key={plan.name}
-                      className={`flex flex-col rounded-xl border p-6 lg:p-8 ${
-                        plan.highlighted
-                          ? "border-primary/40 bg-card shadow-[0_0_40px_-12px] shadow-primary/20"
-                          : "border-border/70 bg-card"
-                      }`}
-                    >
-                      <div className="flex items-center justify-between">
-                        <h2 className="font-medium text-sm">{plan.name}</h2>
-                        {plan.highlighted && (
-                          <span className="rounded-full border border-primary/30 bg-primary/10 px-2.5 py-0.5 font-medium text-primary text-xs">
-                            Most popular
-                          </span>
-                        )}
-                      </div>
-                      <p className="mt-1 text-foreground/60 text-sm">
-                        {plan.tagline}
-                      </p>
-
-                      <div className="mt-6 flex items-baseline gap-1.5">
-                        <span className="text-4xl font-medium tracking-tight">
-                          {plan.price}
-                        </span>
-                        <span className="text-foreground/60 text-sm">
-                          {plan.priceSuffix}
-                        </span>
-                      </div>
-                      <p className="mt-1.5 text-foreground/60 text-sm">
-                        {plan.annualNote}
-                      </p>
-
-                      <ul className="mt-8 flex-1 space-y-3 text-sm">
-                        {plan.features.map((feature) => (
-                          <li
-                            key={feature}
-                            className="flex items-start gap-2.5"
-                          >
-                            <Check
-                              aria-hidden="true"
-                              className="mt-0.5 h-4 w-4 shrink-0 text-primary"
-                            />
-                            <span className="text-foreground/90">
-                              {feature}
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-
-                      <a
-                        className={`mt-8 inline-flex h-10 items-center justify-center rounded-lg border px-4 font-medium text-sm transition-colors ${
-                          plan.highlighted
-                            ? "border-transparent bg-primary text-primary-foreground hover:bg-primary/90"
-                            : "border-border bg-transparent hover:bg-accent"
-                        }`}
-                        href={plan.cta.href}
-                      >
-                        {plan.cta.label}
-                      </a>
-                    </article>
-                  ))}
-                </div>
+              <div className="mt-12">
+                <PricingPlans />
               </div>
             </FadeIn>
           </div>

--- a/apps/site/components/landing/pricing-plans.tsx
+++ b/apps/site/components/landing/pricing-plans.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { Check } from "lucide-react";
+import { useState } from "react";
+
+const APP_URL = "https://cloud.kaneo.app";
+
+type Interval = "monthly" | "annual";
+
+type Plan = {
+  name: string;
+  tagline: string;
+  checkout?: "personal" | "team";
+  monthly: { price: string; suffix: string; note: string };
+  annual: { price: string; suffix: string; note: string };
+  features: string[];
+  cta: { href: string; label: string };
+  highlighted?: boolean;
+};
+
+const plans: Plan[] = [
+  {
+    name: "Self-hosted",
+    tagline: "Run it on your own servers",
+    monthly: { price: "€0", suffix: "forever", note: "MIT licensed" },
+    annual: { price: "€0", suffix: "forever", note: "MIT licensed" },
+    features: [
+      "Unlimited users and projects",
+      "Every feature, including SSO",
+      "Your data on your servers",
+      "Community support on Discord",
+    ],
+    cta: { href: "/docs/core/installation", label: "Read installation guide" },
+  },
+  {
+    name: "Cloud Personal",
+    tagline: "Managed hosting for one",
+    checkout: "personal",
+    monthly: { price: "€4", suffix: "/ month", note: "Billed monthly" },
+    annual: {
+      price: "€40",
+      suffix: "/ year",
+      note: "€3.33 / month, billed yearly",
+    },
+    features: [
+      "Single user",
+      "Unlimited projects and tasks",
+      "Automatic backups and updates",
+      "Email support",
+    ],
+    cta: { href: APP_URL, label: "Start 14-day free trial" },
+  },
+  {
+    name: "Cloud Team",
+    tagline: "Managed hosting for teams",
+    checkout: "team",
+    monthly: { price: "€5", suffix: "/ user / month", note: "Billed monthly" },
+    annual: {
+      price: "€50",
+      suffix: "/ user / year",
+      note: "€4.17 / user / month, billed yearly",
+    },
+    features: [
+      "Unlimited team members",
+      "Unlimited projects and tasks",
+      "Workspace roles and permissions",
+      "Automatic backups and updates",
+      "Priority email support",
+    ],
+    cta: { href: APP_URL, label: "Start 14-day free trial" },
+    highlighted: true,
+  },
+];
+
+export function PricingPlans() {
+  const [interval, setInterval] = useState<Interval>("annual");
+
+  return (
+    <div>
+      <div className="flex items-center justify-center gap-3">
+        <div className="inline-flex rounded-lg border border-border/70 bg-card/70 p-0.5 text-sm">
+          {(["monthly", "annual"] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setInterval(value)}
+              className={`rounded-md px-3 py-1 font-medium capitalize transition-colors ${
+                interval === value
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-foreground/60 hover:text-foreground"
+              }`}
+            >
+              {value}
+            </button>
+          ))}
+        </div>
+        {interval === "annual" ? (
+          <span className="rounded-full border border-primary/30 bg-primary/10 px-2.5 py-0.5 font-medium text-primary text-xs">
+            2 months free
+          </span>
+        ) : null}
+      </div>
+
+      <div className="mt-8 rounded-2xl border border-border/70 bg-card/70 p-2">
+        <div className="grid grid-cols-1 gap-2 lg:grid-cols-3">
+          {plans.map((plan) => {
+            const price = interval === "monthly" ? plan.monthly : plan.annual;
+            const href = plan.checkout
+              ? `${APP_URL}/auth/sign-up?checkout=${plan.checkout}-${interval}`
+              : plan.cta.href;
+            return (
+              <article
+                key={plan.name}
+                className={`flex flex-col rounded-xl border p-6 lg:p-8 ${
+                  plan.highlighted
+                    ? "border-primary/40 bg-card shadow-[0_0_40px_-12px] shadow-primary/20"
+                    : "border-border/70 bg-card"
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <h2 className="font-medium text-sm">{plan.name}</h2>
+                  {plan.highlighted ? (
+                    <span className="rounded-full border border-primary/30 bg-primary/10 px-2.5 py-0.5 font-medium text-primary text-xs">
+                      Most popular
+                    </span>
+                  ) : null}
+                </div>
+                <p className="mt-1 text-foreground/60 text-sm">
+                  {plan.tagline}
+                </p>
+
+                <div className="mt-6 flex items-baseline gap-1.5">
+                  <span className="text-4xl font-medium tracking-tight">
+                    {price.price}
+                  </span>
+                  <span className="text-foreground/60 text-sm">
+                    {price.suffix}
+                  </span>
+                </div>
+                <p className="mt-1.5 text-foreground/60 text-sm">
+                  {price.note}
+                </p>
+
+                <ul className="mt-8 flex-1 space-y-3 text-sm">
+                  {plan.features.map((feature) => (
+                    <li key={feature} className="flex items-start gap-2.5">
+                      <Check
+                        aria-hidden="true"
+                        className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+                      />
+                      <span className="text-foreground/90">{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <a
+                  className={`mt-8 inline-flex h-10 items-center justify-center rounded-lg border px-4 font-medium text-sm transition-colors ${
+                    plan.highlighted
+                      ? "border-transparent bg-primary text-primary-foreground hover:bg-primary/90"
+                      : "border-border bg-transparent hover:bg-accent"
+                  }`}
+                  href={href}
+                >
+                  {plan.cta.label}
+                </a>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-pending-checkout.ts
+++ b/apps/web/src/hooks/use-pending-checkout.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from "react";
+import { useCreateCheckout } from "@/hooks/mutations/billing/use-billing-actions";
+import { useGetBilling } from "@/hooks/queries/billing/use-get-billing";
+import useGetConfig from "@/hooks/queries/config/use-get-config";
+import useActiveWorkspace from "@/hooks/queries/workspace/use-active-workspace";
+import { useWorkspacePermission } from "@/hooks/use-workspace-permission";
+import { clearCheckoutIntent, readCheckoutIntent } from "@/lib/checkout-intent";
+
+/**
+ * Completes a pricing-page deep link: once a new user lands in a workspace,
+ * if they arrived via `?checkout=<plan>-<interval>` and the workspace can be
+ * billed, redirect them straight into Creem checkout instead of making them
+ * find the billing page. No-ops (and clears the intent) when it doesn't apply.
+ */
+export function usePendingCheckout() {
+  const { data: workspace } = useActiveWorkspace();
+  const { data: config } = useGetConfig();
+  const { data: billing } = useGetBilling(workspace?.id);
+  const { isAdmin, isCheckingPermissions } = useWorkspacePermission();
+  const checkout = useCreateCheckout(workspace?.id);
+  const handled = useRef(false);
+
+  useEffect(() => {
+    if (handled.current) return;
+    if (!readCheckoutIntent()) return;
+
+    // Wait until everything needed to decide has loaded.
+    if (!config || !workspace?.id || !billing || isCheckingPermissions) return;
+
+    handled.current = true;
+
+    const intent = readCheckoutIntent();
+    clearCheckoutIntent();
+
+    const alreadyBilled =
+      billing.foundingFree || Boolean(billing.plan && billing.status);
+    if (!intent || !config.billingEnabled || alreadyBilled || !isAdmin) {
+      return;
+    }
+
+    checkout.mutate({ plan: intent.plan, interval: intent.interval });
+  }, [
+    config,
+    workspace?.id,
+    billing,
+    isAdmin,
+    isCheckingPermissions,
+    checkout,
+  ]);
+}

--- a/apps/web/src/lib/checkout-intent.ts
+++ b/apps/web/src/lib/checkout-intent.ts
@@ -1,0 +1,49 @@
+const KEY = "kaneo:pending-checkout";
+
+const VALID = new Set([
+  "personal-monthly",
+  "personal-annual",
+  "team-monthly",
+  "team-annual",
+]);
+
+export type CheckoutIntent = {
+  plan: "personal" | "team";
+  interval: "monthly" | "annual";
+};
+
+/**
+ * Reads a `?checkout=<plan>-<interval>` param from the current URL and stores
+ * it. Called once at app boot, before the router runs — the sign-up →
+ * onboarding → workspace redirect chain drops query params, so the value has
+ * to be captured synchronously on first load.
+ */
+export function captureCheckoutIntent() {
+  if (typeof window === "undefined") return;
+  try {
+    const value = new URLSearchParams(window.location.search).get("checkout");
+    if (value && VALID.has(value)) {
+      localStorage.setItem(KEY, value);
+    }
+  } catch {}
+}
+
+export function readCheckoutIntent(): CheckoutIntent | null {
+  try {
+    const value = localStorage.getItem(KEY);
+    if (!value || !VALID.has(value)) return null;
+    const [plan, interval] = value.split("-");
+    return {
+      plan: plan as CheckoutIntent["plan"],
+      interval: interval as CheckoutIntent["interval"],
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function clearCheckoutIntent() {
+  try {
+    localStorage.removeItem(KEY);
+  } catch {}
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -9,8 +9,13 @@ import { KeyboardShortcutsHelp } from "./components/keyboard-shortcuts-help";
 import AuthProvider from "./components/providers/auth-provider";
 import { ThemeProvider } from "./components/providers/theme-provider";
 import { KeyboardShortcutsProvider } from "./hooks/use-keyboard-shortcuts";
+import { captureCheckoutIntent } from "./lib/checkout-intent";
 import { AppI18nProvider } from "./lib/i18n/provider";
 import { routeTree } from "./routeTree.gen";
+
+// Capture a pricing-page `?checkout=<plan>-<interval>` deep link before the
+// router runs and strips it across the sign-up → onboarding redirect chain.
+captureCheckoutIntent();
 
 console.log(`
                      ////////  

--- a/apps/web/src/routes/_layout/_authenticated/dashboard.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import PageTitle from "@/components/page-title";
 import useActiveWorkspace from "@/hooks/queries/workspace/use-active-workspace";
+import { usePendingCheckout } from "@/hooks/use-pending-checkout";
 
 export const Route = createFileRoute("/_layout/_authenticated/dashboard")({
   component: DashboardLayoutComponent,
@@ -10,6 +11,7 @@ export const Route = createFileRoute("/_layout/_authenticated/dashboard")({
 function DashboardLayoutComponent() {
   const { t } = useTranslation();
   const { data: workspace } = useActiveWorkspace();
+  usePendingCheckout();
 
   return (
     <>


### PR DESCRIPTION
High-intent buyers who pick a plan on the pricing page now go pricing → sign up → straight to Creem checkout, instead of re-selecting the plan inside the app.

- Pricing page: adds a monthly/annual toggle; Cloud CTAs deep-link to `/auth/sign-up?checkout=<plan>-<interval>`.
- App: captures the intent at boot (survives the signup→onboarding redirect chain that strips query params), then completes checkout once the user has a billable workspace.
- Safely no-ops for founding-free, already-subscribed, non-admin, and self-hosted cases; one-shot (intent cleared on first attempt).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monthly and annual pricing plan cards with interval switching.
  * Added an annual billing badge highlighting two months free.
  * Added checkout links for supported plans and billing intervals.
  * Preserved checkout selections through sign-up and onboarding, then automatically resumes checkout when eligible.

* **Bug Fixes**
  * Improved reliability of pricing-page checkout deep links across navigation and authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->