### PR TITLE
feat(site): comparison / alternative pages for SEO

### DIFF
--- a/apps/site/app/jira-alternative/page.tsx
+++ b/apps/site/app/jira-alternative/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import { ComparisonPage } from "@/components/landing/comparison-page";
+import { comparisons } from "@/lib/comparisons";
+
+export const metadata: Metadata = {
+  title: "Open-source Jira alternative",
+  description:
+    "Kaneo is an open-source, self-hostable project management tool — a simple Jira alternative you can run yourself or use as a managed cloud. Free to self-host, fair cloud pricing.",
+  alternates: { canonical: "/jira-alternative" },
+};
+
+export default function Page() {
+  return <ComparisonPage data={comparisons.jira} />;
+}

--- a/apps/site/app/linear-alternative/page.tsx
+++ b/apps/site/app/linear-alternative/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import { ComparisonPage } from "@/components/landing/comparison-page";
+import { comparisons } from "@/lib/comparisons";
+
+export const metadata: Metadata = {
+  title: "Open-source Linear alternative",
+  description:
+    "Kaneo is an open-source, self-hostable project management tool — a simple Linear alternative you can run yourself or use as a managed cloud. Free to self-host, fair cloud pricing.",
+  alternates: { canonical: "/linear-alternative" },
+};
+
+export default function Page() {
+  return <ComparisonPage data={comparisons.linear} />;
+}

--- a/apps/site/app/sitemap-pages.xml/route.ts
+++ b/apps/site/app/sitemap-pages.xml/route.ts
@@ -30,6 +30,24 @@ export function GET() {
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
+  <url>
+    <loc>${SITE}/jira-alternative</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>${SITE}/trello-alternative</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>${SITE}/linear-alternative</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>`;
 
   return new Response(xml, {

--- a/apps/site/app/trello-alternative/page.tsx
+++ b/apps/site/app/trello-alternative/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import { ComparisonPage } from "@/components/landing/comparison-page";
+import { comparisons } from "@/lib/comparisons";
+
+export const metadata: Metadata = {
+  title: "Open-source Trello alternative",
+  description:
+    "Kaneo is an open-source, self-hostable project management tool — a simple Trello alternative you can run yourself or use as a managed cloud. Free to self-host, fair cloud pricing.",
+  alternates: { canonical: "/trello-alternative" },
+};
+
+export default function Page() {
+  return <ComparisonPage data={comparisons.trello} />;
+}

--- a/apps/site/components/landing/comparison-page.tsx
+++ b/apps/site/components/landing/comparison-page.tsx
@@ -1,0 +1,158 @@
+import { Check, Minus } from "lucide-react";
+import { FadeIn } from "@/components/landing/fade-in";
+import { Footer } from "@/components/landing/footer";
+import { Navbar } from "@/components/landing/navbar";
+import { SectionSeparator } from "@/components/landing/section-separator";
+
+const SIGN_UP = "https://cloud.kaneo.app/auth/sign-up";
+
+type Cell = boolean | string;
+
+export type Comparison = {
+  competitor: string;
+  heading: string;
+  subheading: string;
+  rows: { feature: string; kaneo: Cell; them: Cell }[];
+  reasons: { title: string; body: string }[];
+  honestNote: string;
+};
+
+function CellValue({ value, emphasize }: { value: Cell; emphasize?: boolean }) {
+  if (typeof value === "boolean") {
+    return value ? (
+      <Check
+        aria-label="Yes"
+        className={
+          emphasize ? "size-4 text-primary" : "size-4 text-foreground/40"
+        }
+      />
+    ) : (
+      <Minus aria-label="No" className="size-4 text-foreground/30" />
+    );
+  }
+  return (
+    <span className={emphasize ? "text-foreground" : "text-foreground/70"}>
+      {value}
+    </span>
+  );
+}
+
+export function ComparisonPage({ data }: { data: Comparison }) {
+  return (
+    <>
+      <Navbar />
+      <main className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
+        <section className="relative overflow-hidden px-6 pt-14 pb-16 md:pt-20 md:pb-20">
+          <div className="mx-auto w-full max-w-6xl">
+            <div className="max-w-2xl">
+              <FadeIn delay={0}>
+                <p className="font-medium text-primary text-sm">
+                  Kaneo vs {data.competitor}
+                </p>
+              </FadeIn>
+              <FadeIn delay={60}>
+                <h1 className="mt-3 text-balance text-4xl font-medium leading-[1.06] md:text-5xl">
+                  {data.heading}
+                </h1>
+              </FadeIn>
+              <FadeIn delay={120}>
+                <p className="mt-5 text-balance text-foreground/70 text-lg leading-relaxed">
+                  {data.subheading}
+                </p>
+              </FadeIn>
+              <FadeIn delay={180}>
+                <div className="mt-8 flex flex-wrap items-center gap-3">
+                  <a
+                    className="inline-flex h-10 items-center justify-center rounded-lg border border-transparent bg-primary px-4 font-medium text-primary-foreground text-sm transition-colors hover:bg-primary/90"
+                    href={SIGN_UP}
+                  >
+                    Start 14-day free trial
+                  </a>
+                  <a
+                    className="inline-flex h-10 items-center justify-center rounded-lg border border-border bg-transparent px-4 font-medium text-sm transition-colors hover:bg-accent"
+                    href="/docs/core/installation"
+                  >
+                    Self-host for free
+                  </a>
+                </div>
+              </FadeIn>
+            </div>
+
+            <FadeIn delay={220}>
+              <div className="mt-12 overflow-hidden rounded-2xl border border-border/70 bg-card/70">
+                <div className="grid grid-cols-[1.4fr_1fr_1fr] text-sm">
+                  <div className="border-border/50 border-b px-4 py-3 font-medium sm:px-6" />
+                  <div className="border-border/50 border-b bg-primary/5 px-4 py-3 text-center font-medium sm:px-6">
+                    Kaneo
+                  </div>
+                  <div className="border-border/50 border-b px-4 py-3 text-center font-medium text-foreground/70 sm:px-6">
+                    {data.competitor}
+                  </div>
+
+                  {data.rows.map((row) => (
+                    <div key={row.feature} className="contents">
+                      <div className="border-border/40 border-b px-4 py-3 text-foreground/80 sm:px-6">
+                        {row.feature}
+                      </div>
+                      <div className="flex items-center justify-center border-border/40 border-b bg-primary/5 px-4 py-3 text-center sm:px-6">
+                        <CellValue value={row.kaneo} emphasize />
+                      </div>
+                      <div className="flex items-center justify-center border-border/40 border-b px-4 py-3 text-center sm:px-6">
+                        <CellValue value={row.them} />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </FadeIn>
+          </div>
+        </section>
+
+        <SectionSeparator>
+          <section className="px-6 py-14 md:py-20">
+            <div className="mx-auto w-full max-w-6xl">
+              <h2 className="max-w-2xl text-2xl font-medium md:text-3xl">
+                Why teams choose Kaneo
+              </h2>
+              <div className="mt-8 grid gap-8 md:grid-cols-3">
+                {data.reasons.map((reason) => (
+                  <div key={reason.title} className="space-y-2">
+                    <h3 className="font-medium text-sm">{reason.title}</h3>
+                    <p className="text-foreground/70 text-sm leading-relaxed">
+                      {reason.body}
+                    </p>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-14 max-w-2xl rounded-xl border border-border/70 bg-card/70 p-5">
+                <h3 className="font-medium text-sm">
+                  When {data.competitor} is the better choice
+                </h3>
+                <p className="mt-2 text-foreground/70 text-sm leading-relaxed">
+                  {data.honestNote}
+                </p>
+              </div>
+
+              <div className="mt-12 flex flex-wrap items-center gap-3">
+                <a
+                  className="inline-flex h-10 items-center justify-center rounded-lg border border-transparent bg-primary px-4 font-medium text-primary-foreground text-sm transition-colors hover:bg-primary/90"
+                  href={SIGN_UP}
+                >
+                  Try Kaneo Cloud free
+                </a>
+                <a
+                  className="inline-flex h-10 items-center justify-center rounded-lg border border-border bg-transparent px-4 font-medium text-sm transition-colors hover:bg-accent"
+                  href="/pricing"
+                >
+                  See pricing
+                </a>
+              </div>
+            </div>
+          </section>
+        </SectionSeparator>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/apps/site/components/landing/footer.tsx
+++ b/apps/site/components/landing/footer.tsx
@@ -41,6 +41,24 @@ export function Footer() {
               >
                 Pricing
               </a>
+              <a
+                className="block text-muted-foreground transition-colors hover:text-foreground"
+                href="/jira-alternative"
+              >
+                vs Jira
+              </a>
+              <a
+                className="block text-muted-foreground transition-colors hover:text-foreground"
+                href="/trello-alternative"
+              >
+                vs Trello
+              </a>
+              <a
+                className="block text-muted-foreground transition-colors hover:text-foreground"
+                href="/linear-alternative"
+              >
+                vs Linear
+              </a>
             </div>
 
             <div className="space-y-3 text-sm">

--- a/apps/site/lib/comparisons.ts
+++ b/apps/site/lib/comparisons.ts
@@ -1,0 +1,103 @@
+import type { Comparison } from "@/components/landing/comparison-page";
+
+export const comparisons: Record<string, Comparison> = {
+  jira: {
+    competitor: "Jira",
+    heading: "The open-source Jira alternative",
+    subheading:
+      "Jira can run a 500-person org, but most teams just want to plan and ship work without the weight. Kaneo is a simple, open-source project manager you can self-host or let us run for you.",
+    rows: [
+      { feature: "Open source (MIT)", kaneo: true, them: false },
+      { feature: "Self-hostable", kaneo: true, them: "Data Center only" },
+      { feature: "Own your data", kaneo: true, them: false },
+      { feature: "Free to self-host", kaneo: true, them: false },
+      { feature: "SSO included", kaneo: "Free", them: "Paid tier" },
+      { feature: "Setup", kaneo: "Minutes", them: "Involved" },
+      { feature: "Learning curve", kaneo: "Minutes", them: "Steep" },
+      {
+        feature: "Cloud pricing",
+        kaneo: "From €4/mo",
+        them: "Per user, higher",
+      },
+    ],
+    reasons: [
+      {
+        title: "No bloat",
+        body: "Boards, backlog, and workflows that work out of the box. No admin console to configure for a week before you can create a task.",
+      },
+      {
+        title: "Own your data",
+        body: "Self-host Kaneo on your own servers under the MIT license, or use our EU-hosted cloud. Either way you can export everything, anytime.",
+      },
+      {
+        title: "Fair, honest pricing",
+        body: "Free forever to self-host, including SSO. Managed cloud starts at €4/month with no per-feature paywalls.",
+      },
+    ],
+    honestNote:
+      "If you're a large organization that needs deep enterprise workflows, advanced permission schemes, and a big marketplace of add-ons — and you have the time to configure it — Jira is built for exactly that. Kaneo is for teams who want to manage work, not administer a tool.",
+  },
+  trello: {
+    competitor: "Trello",
+    heading: "The self-hostable Trello alternative",
+    subheading:
+      "Trello nails simple kanban, but your boards live on someone else's servers and grow into paid Power-Ups. Kaneo keeps the simplicity, adds backlog and workflows, and lets you own the whole thing.",
+    rows: [
+      { feature: "Open source (MIT)", kaneo: true, them: false },
+      { feature: "Self-hostable", kaneo: true, them: false },
+      { feature: "Own your data", kaneo: true, them: false },
+      { feature: "Kanban boards", kaneo: true, them: true },
+      { feature: "Backlog & workflows", kaneo: true, them: "Power-Ups" },
+      { feature: "Free to self-host", kaneo: true, them: false },
+      { feature: "SSO included", kaneo: "Free", them: "Enterprise" },
+      { feature: "Cloud pricing", kaneo: "From €4/mo", them: "Per user" },
+    ],
+    reasons: [
+      {
+        title: "Just as simple",
+        body: "A clean board you can use in minutes — no manual, no onboarding wizard. Kaneo keeps the thing people love about Trello.",
+      },
+      {
+        title: "Room to grow",
+        body: "Backlog planning, custom workflows, and roles are built in, so you don't hit a wall and start bolting on paid Power-Ups.",
+      },
+      {
+        title: "Your boards, your servers",
+        body: "Self-host under MIT for free, or use our managed cloud. Your data is exportable and never locked in.",
+      },
+    ],
+    honestNote:
+      "If you only need a couple of personal boards, never want to self-host, and Trello's free tier covers you, it's a perfectly good choice. Kaneo makes more sense the moment you care about owning your data or your team outgrows a simple board.",
+  },
+  linear: {
+    competitor: "Linear",
+    heading: "The open-source Linear alternative",
+    subheading:
+      "Linear is fast and beautifully focused, but it's closed-source, cloud-only, and you can't run it yourself. Kaneo gives you a clean, focused workflow that's open source and self-hostable.",
+    rows: [
+      { feature: "Open source (MIT)", kaneo: true, them: false },
+      { feature: "Self-hostable", kaneo: true, them: false },
+      { feature: "Own your data", kaneo: true, them: false },
+      { feature: "Fast, focused UI", kaneo: true, them: true },
+      { feature: "Free to self-host", kaneo: true, them: false },
+      { feature: "SSO included", kaneo: "Free", them: "Paid plans" },
+      { feature: "Cloud pricing", kaneo: "From €4/mo", them: "Per user" },
+    ],
+    reasons: [
+      {
+        title: "Clean and focused",
+        body: "Kaneo is built around the same idea Linear popularized — a fast, uncluttered way to plan and execute — without the SaaS lock-in.",
+      },
+      {
+        title: "Open and self-hostable",
+        body: "Run Kaneo on your own infrastructure under the MIT license, keep your data in-house, and never depend on a vendor staying online.",
+      },
+      {
+        title: "Honest pricing",
+        body: "Free forever to self-host with every feature, including SSO. Managed cloud from €4/month — no seats-gated features.",
+      },
+    ],
+    honestNote:
+      "Linear sets the bar for polish, speed, and deep product-team features like cycles and triage. If you're committed to cloud SaaS and want that specific, highly-refined workflow, it's excellent. Kaneo is for teams who want a clean experience they can actually own.",
+  },
+};


### PR DESCRIPTION
Adds three keyword-targeted landing pages that rank for high-intent searches and feed the signup funnel:

- /jira-alternative — "open-source Jira alternative"
- /trello-alternative — "self-hostable Trello alternative"
- /linear-alternative — "open-source Linear alternative"

Shared ComparisonPage component + data module (DRY), honest comparison tables, a "when the competitor is the better choice" section for credibility, CTAs into signup and pricing, sitemap entries, and footer internal links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comparison pages for Kaneo versus Jira, Trello, and Linear.
  * Added feature comparison tables, benefits, calls to action, and supporting content.
  * Added links to the new comparison pages in the site footer.
  * Added the comparison pages to the sitemap for improved discoverability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->