### PR TITLE
fix: move overrides to workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,38 +29,6 @@
   "engines": {
     "node": ">=20.19.0"
   },
-  "pnpm": {
-    "overrides": {
-      "@isaacs/brace-expansion": "5.0.1",
-      "@hono/node-server": ">=1.19.13",
-      "ajv": "8.18.0",
-      "diff": "8.0.3",
-      "esbuild": "0.28.1",
-      "express-rate-limit": "8.2.2",
-      "hono": ">=4.12.25",
-      "lodash": "4.18.0",
-      "next": ">=15.5.18 <16.0.0 || >=16.2.6",
-      "markdown-it": "14.1.1",
-      "minimatch": "10.2.3",
-      "rollup": "4.59.0",
-      "seroval": "1.4.1",
-      "effect": ">=3.20.0",
-      "fast-xml-parser": ">=5.5.7",
-      "socket.io-parser": ">=4.2.6",
-      "picomatch": ">=4.0.4",
-      "path-to-regexp": ">=8.4.0",
-      "brace-expansion": ">=5.0.6",
-      "yaml": ">=2.8.3",
-      "qs": ">=6.15.2",
-      "ws": ">=8.20.1",
-      "ip-address": ">=10.1.1",
-      "postcss": ">=8.5.10",
-      "better-auth": "1.6.23",
-      "undici": ">=7.28.0 <8",
-      "js-yaml": ">=4.2.0 <5",
-      "@babel/core": ">=7.29.6 <8"
-    }
-  },
   "packageManager": "pnpm@10.32.1",
   "version": "2.12.1",
   "dependencies": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,35 @@
 packages:
   - packages/**
   - apps/**
+overrides:
+  '@isaacs/brace-expansion': 5.0.1
+  '@hono/node-server': '>=1.19.13'
+  ajv: 8.18.0
+  diff: 8.0.3
+  esbuild: 0.28.1
+  express-rate-limit: 8.2.2
+  hono: '>=4.12.25'
+  lodash: 4.18.0
+  next: '>=15.5.18 <16.0.0 || >=16.2.6'
+  markdown-it: 14.1.1
+  minimatch: 10.2.3
+  rollup: 4.59.0
+  seroval: 1.4.1
+  effect: '>=3.20.0'
+  fast-xml-parser: '>=5.5.7'
+  socket.io-parser: '>=4.2.6'
+  picomatch: '>=4.0.4'
+  path-to-regexp: '>=8.4.0'
+  brace-expansion: '>=5.0.6'
+  yaml: '>=2.8.3'
+  qs: '>=6.15.2'
+  ws: '>=8.20.1'
+  ip-address: '>=10.1.1'
+  postcss: '>=8.5.10'
+  better-auth: 1.6.23
+  undici: '>=7.28.0 <8'
+  js-yaml: '>=4.2.0 <5'
+  '@babel/core': '>=7.29.6 <8'
 onlyBuiltDependencies:
   - '@biomejs/biome'
   - bcrypt


### PR DESCRIPTION
## Description

Move the existing pnpm overrides from `package.json` to the workspace root configuration in `pnpm-workspace.yaml`.

Kaneo declares pnpm 10.32.1 as its package manager. With pnpm 10, the `pnpm` field in `package.json` is ignored and installation prints:

> The "pnpm" field in package.json is not supported by pnpm. Create a "pnpm-workspace.yaml" file instead.

This keeps every existing override value unchanged. The lockfile therefore remains unchanged as well.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

Validation performed with Node.js 24.18.1 and the repository-pinned pnpm 10.32.1:

- `pnpm install --frozen-lockfile`
- `pnpm test` (294 tests passed)
- `pnpm exec biome ci .`
- `pnpm run build`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The change intentionally preserves the existing override versions and does not modify `pnpm-lock.yaml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized dependency version overrides at the workspace level.
  * Updated version constraints for security- and compatibility-sensitive packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->