### PR TITLE
fix: resolve workspace access from the id the handler acts on

### DIFF
--- a/apps/api/src/utils/workspace-access-middleware.ts
+++ b/apps/api/src/utils/workspace-access-middleware.ts
@@ -61,8 +61,11 @@ export function workspaceAccessMiddleware(
         const body = await readJsonObjectBody(c);
         const idFromBody =
           typeof body[source.idKey] === "string" ? body[source.idKey] : null;
-        const id =
-          c.req.param(source.idKey) || c.req.query(source.idKey) || idFromBody;
+        // Only accept the id from the same place the handler will read it
+        // (path param or JSON body). Accepting it from the query string let a
+        // caller authorize against one resource (`?taskId=<mine>`) while the
+        // handler acted on another (`{"taskId": "<someone else's>"}`).
+        const id = c.req.param(source.idKey) || idFromBody;
         if (id) {
           workspaceId = await lookupWorkspaceId(source.resource, id);
         }

--- a/tests/api/utils/workspace-access-middleware.test.ts
+++ b/tests/api/utils/workspace-access-middleware.test.ts
@@ -10,30 +10,25 @@ const WORKSPACE_BY_TASK: Record<string, string> = {
   "task-in-other-workspace": "workspace-theirs",
 };
 
-// The `lookup` sources resolve a workspace with a single `... where(eq(id))`
-// query, so reading the bound parameter back off that condition tells us which
-// id the middleware actually authorized against.
-function readBoundId(condition: unknown): string | undefined {
-  const chunks = (condition as { queryChunks?: unknown[] })?.queryChunks ?? [];
-  for (const chunk of chunks) {
-    const value = (chunk as { value?: unknown })?.value;
-    if (typeof value === "string") {
-      return value;
-    }
-  }
-  return undefined;
-}
-
 vi.mock("../../../apps/api/src/database", async () => {
   const schema = await import("../../../apps/api/src/database/schema");
+  const { PgDialect } = await import("drizzle-orm/pg-core");
 
+  // `sqlToQuery` is the dialect method drizzle's own `.toSQL()` is built on, so
+  // the bound parameters come back through a supported surface rather than by
+  // reaching into the condition object's internals.
+  const dialect = new PgDialect();
   let boundId: string | undefined;
+
   const chain = {
     select: () => chain,
     from: () => chain,
     innerJoin: () => chain,
-    where: (condition: unknown) => {
-      boundId = readBoundId(condition);
+    where: (condition: Parameters<typeof dialect.sqlToQuery>[0]) => {
+      // The `task` lookup filters on a single id; joins contribute no
+      // parameters because they compare two columns.
+      const [id] = dialect.sqlToQuery(condition).params;
+      boundId = typeof id === "string" ? id : undefined;
       return chain;
     },
     limit: async () => {
@@ -104,6 +99,7 @@ describe("workspaceAccess lookup sources", () => {
     const res = await post("", { taskId: "task-in-other-workspace" });
 
     expect(res.status).toBe(403);
+    expect(state.lookedUpIds).toEqual(["task-in-other-workspace"]);
   });
 
   it("does not let a query id override the body id the handler acts on", async () => {

--- a/tests/api/utils/workspace-access-middleware.test.ts
+++ b/tests/api/utils/workspace-access-middleware.test.ts
@@ -1,0 +1,117 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { state } = vi.hoisted(() => ({
+  state: { lookedUpIds: [] as string[] },
+}));
+
+const WORKSPACE_BY_TASK: Record<string, string> = {
+  "task-in-my-workspace": "workspace-mine",
+  "task-in-other-workspace": "workspace-theirs",
+};
+
+// The `lookup` sources resolve a workspace with a single `... where(eq(id))`
+// query, so reading the bound parameter back off that condition tells us which
+// id the middleware actually authorized against.
+function readBoundId(condition: unknown): string | undefined {
+  const chunks = (condition as { queryChunks?: unknown[] })?.queryChunks ?? [];
+  for (const chunk of chunks) {
+    const value = (chunk as { value?: unknown })?.value;
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+vi.mock("../../../apps/api/src/database", async () => {
+  const schema = await import("../../../apps/api/src/database/schema");
+
+  let boundId: string | undefined;
+  const chain = {
+    select: () => chain,
+    from: () => chain,
+    innerJoin: () => chain,
+    where: (condition: unknown) => {
+      boundId = readBoundId(condition);
+      return chain;
+    },
+    limit: async () => {
+      if (!boundId) {
+        return [];
+      }
+      state.lookedUpIds.push(boundId);
+      const workspaceId = WORKSPACE_BY_TASK[boundId];
+      return workspaceId ? [{ workspaceId }] : [];
+    },
+  };
+
+  return { default: chain, schema };
+});
+
+vi.mock("../../../apps/api/src/utils/validate-workspace-access", async () => {
+  const { HTTPException } = await import("hono/http-exception");
+  return {
+    validateWorkspaceAccess: async (_userId: string, workspaceId: string) => {
+      if (workspaceId !== "workspace-mine") {
+        throw new HTTPException(403, {
+          message: "You don't have access to this workspace",
+        });
+      }
+    },
+  };
+});
+
+const { workspaceAccess } = await import(
+  "../../../apps/api/src/utils/workspace-access-middleware"
+);
+
+// Mirrors POST /api/activity/comment: there is no `taskId` path param, the id
+// travels in the JSON body, and the handler acts on that body value.
+function buildApp() {
+  return new Hono()
+    .use("*", async (c, next) => {
+      c.set("userId", "user-1");
+      return next();
+    })
+    .post("/comment", workspaceAccess.fromTaskId(), async (c) => {
+      const body = (await c.req.json()) as { taskId: string };
+      return c.json({ actedOn: body.taskId });
+    });
+}
+
+function post(query: string, body: Record<string, unknown>) {
+  return buildApp().request(`/comment${query}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("workspaceAccess lookup sources", () => {
+  beforeEach(() => {
+    state.lookedUpIds.length = 0;
+  });
+
+  it("authorizes against the body id the handler will act on", async () => {
+    const res = await post("", { taskId: "task-in-my-workspace" });
+
+    expect(res.status).toBe(200);
+    expect(state.lookedUpIds).toEqual(["task-in-my-workspace"]);
+  });
+
+  it("rejects a body id in a workspace the caller cannot access", async () => {
+    const res = await post("", { taskId: "task-in-other-workspace" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("does not let a query id override the body id the handler acts on", async () => {
+    const res = await post("?taskId=task-in-my-workspace", {
+      taskId: "task-in-other-workspace",
+    });
+
+    expect(state.lookedUpIds).toEqual(["task-in-other-workspace"]);
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Description

`workspaceAccessMiddleware`'s `lookup` sources resolve the resource id as `param || query || body` ([`workspace-access-middleware.ts:64-65`](https://github.com/usekaneo/kaneo/blob/main/apps/api/src/utils/workspace-access-middleware.ts#L64-L65)).

Three routes declare the id in the **JSON body** and have no matching path param, so a query-string value wins over the body value the handler then acts on:

| Route | Middleware | Handler reads |
|---|---|---|
| `POST /api/activity/comment` | `workspaceAccess.fromTaskId()` (`activity/index.ts:103`) | `c.req.valid("json").taskId` |
| `POST /api/activity/create` | `workspaceAccess.fromTaskId()` (`activity/index.ts:67`) | `c.req.valid("json").taskId` |
| `POST /api/time-entry` | `workspaceAccess.fromTaskId()` (`time-entry/index.ts:87`) | `c.req.valid("json").taskId` |

The result is that the id used to **authorize** and the id the handler **acts on** can differ, which allows a write into a workspace the caller is not a member of.

### Reproduction

Attacker is a `member` of workspace **A** and owns `TASK_A`. `TASK_B` lives in workspace **B**, where they have no membership.

```http
POST /api/activity/comment?taskId=TASK_A
Cookie: <attacker session>
Content-Type: application/json

{"taskId":"TASK_B","comment":"pwned"}
```

- `c.req.param("taskId")` is `undefined` — the route path is `/comment`.
- `c.req.query("taskId")` = `TASK_A` wins the `||` chain → workspace **A**.
- `validateWorkspaceAccess` and `requireWorkspacePermission({task:["update"]})` both pass, in **A**.
- The handler (`activity/index.ts:106-108`) reads the **body** id and calls `createComment("TASK_B", …)`, which inserts into workspace B's activity feed, publishes `comment.created` to workspace-B WebSocket subscribers (`create-comment.ts:47-53`) and notifies B's assignee (`:72-90`).

None of `createComment` / `createActivity` / `createTimeEntry` re-checks the workspace, so nothing downstream catches the mismatch.

Routes whose id is a **path param** are unaffected, because `c.req.param()` still wins — which is why the existing `workspace-rbac.test.ts:192` case ("does not authorize a project through a conflicting workspaceId query") passes today and doesn't cover this.

### The fix

Drop the query string as a `lookup`-id source, so the id used to authorize is always the id the handler reads.

This does not change any working route: no `workspaceAccess.*` call site sources a lookup id from the query string — they all use a path param or the body. The `{ type: "query" }` **fallback** sources declared in `fromTask` / `fromTaskId` / `fromLabel` / etc. resolve a *workspace* id rather than a *resource* id and are untouched.

Happy to switch to rejecting a body/query mismatch with a 400 instead, if you'd prefer the stricter shape.

## Related Issue(s)

No pre-filed issue — the full write-up is above. Happy to open one if you'd like it tracked separately.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Adds `tests/api/utils/workspace-access-middleware.test.ts` covering the three source orderings:

1. body id in an accessible workspace → `200`, and the lookup used the body id
2. body id in an inaccessible workspace → `403`
3. **query id + conflicting body id → `403`, and the lookup used the body id** ← fails on `main`, passes with this change

Verified locally:

```
# on unfixed main, test 3 fails with:
#   expected [ "task-in-my-workspace" ] to deeply equal [ "task-in-other-workspace" ]
$ cd apps/api && pnpm test
 Test Files  36 passed (36)
      Tests  215 passed (215)     # main baseline: 35 files / 212 tests

$ pnpm exec biome ci .            # exit 0
```

`pnpm test:integration` was not run locally (no PostgreSQL available in this environment); CI covers it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace authorization to ensure access checks use the resource being processed.
  * Prevented query parameters from overriding resource IDs supplied in the request body.
  * Blocked authorization against a different resource than the one handled by the request.
  * Added safeguards to reject access when the associated workspace permissions are insufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->