### PR TITLE
fix: serve public-project assets to anonymous callers

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -55,10 +55,8 @@ import task from "./task";
 import taskRelation from "./task-relation";
 import telegramIntegration from "./telegram-integration";
 import timeEntry from "./time-entry";
-import {
-  authenticateApiRequest,
-  resolveAssetBearerOrCookie,
-} from "./utils/authenticate-api-request";
+import { authenticateApiRequest } from "./utils/authenticate-api-request";
+import { authorizeAssetAccess } from "./utils/authorize-asset-access";
 import { getInvitationDetails } from "./utils/check-registration-allowed";
 import { migrateApiKeyReferenceId } from "./utils/migrate-apikey-reference-id";
 import { migrateNotificationPreferencesSchema } from "./utils/migrate-notification-preferences-schema";
@@ -312,13 +310,7 @@ export function createApp() {
         throw new HTTPException(404, { message: "Asset not found" });
       }
 
-      const { userId, apiKeyId } = await resolveAssetBearerOrCookie(c);
-
-      if (userId) {
-        await validateWorkspaceAccess(userId, asset.workspaceId, apiKeyId);
-      } else if (!asset.isPublic) {
-        throw new HTTPException(401, { message: "Unauthorized" });
-      }
+      await authorizeAssetAccess(c, asset);
 
       try {
         const object = await getPrivateObject(asset.objectKey);

--- a/apps/api/src/utils/authorize-asset-access.ts
+++ b/apps/api/src/utils/authorize-asset-access.ts
@@ -1,0 +1,29 @@
+import type { Context } from "hono";
+import { resolveAssetBearerOrCookie } from "./authenticate-api-request";
+import { validateWorkspaceAccess } from "./validate-workspace-access";
+
+type AssetAccessTarget = {
+  workspaceId: string;
+  isPublic: boolean | null;
+};
+
+/**
+ * Authorizes a request for a stored asset.
+ *
+ * Assets that belong to a public project are readable by anyone, so the
+ * credential check must be skipped entirely for them —
+ * `resolveAssetBearerOrCookie` throws a 401 for anonymous callers rather than
+ * returning an empty user, so calling it first makes the public case
+ * unreachable.
+ */
+export async function authorizeAssetAccess(
+  c: Context,
+  asset: AssetAccessTarget,
+): Promise<void> {
+  if (asset.isPublic) {
+    return;
+  }
+
+  const { userId, apiKeyId } = await resolveAssetBearerOrCookie(c);
+  await validateWorkspaceAccess(userId, asset.workspaceId, apiKeyId);
+}

--- a/tests/api/utils/authorize-asset-access.test.ts
+++ b/tests/api/utils/authorize-asset-access.test.ts
@@ -1,0 +1,111 @@
+import type { Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    resolveCalls: 0,
+    validateCalls: [] as { userId: string; workspaceId: string }[],
+    caller: "anonymous" as "anonymous" | "member" | "outsider",
+  },
+}));
+
+vi.mock("../../../apps/api/src/utils/authenticate-api-request", () => ({
+  // Mirrors the real helper: every unauthenticated path throws, so it never
+  // returns a falsy userId.
+  resolveAssetBearerOrCookie: async () => {
+    state.resolveCalls += 1;
+    if (state.caller === "anonymous") {
+      throw new HTTPException(401, { message: "Unauthorized" });
+    }
+    return { userId: `user-${state.caller}` };
+  },
+}));
+
+vi.mock("../../../apps/api/src/utils/validate-workspace-access", () => ({
+  validateWorkspaceAccess: async (userId: string, workspaceId: string) => {
+    state.validateCalls.push({ userId, workspaceId });
+    if (userId !== "user-member") {
+      throw new HTTPException(403, {
+        message: "You don't have access to this workspace",
+      });
+    }
+  },
+}));
+
+const { authorizeAssetAccess } = await import(
+  "../../../apps/api/src/utils/authorize-asset-access"
+);
+
+const context = {} as Context;
+
+async function statusOf(promise: Promise<void>) {
+  try {
+    await promise;
+    return 200;
+  } catch (error) {
+    return error instanceof HTTPException ? error.status : 500;
+  }
+}
+
+describe("authorizeAssetAccess", () => {
+  beforeEach(() => {
+    state.resolveCalls = 0;
+    state.validateCalls = [];
+    state.caller = "anonymous";
+  });
+
+  it("allows an anonymous caller to read an asset of a public project", async () => {
+    const status = await statusOf(
+      authorizeAssetAccess(context, {
+        workspaceId: "workspace-1",
+        isPublic: true,
+      }),
+    );
+
+    expect(status).toBe(200);
+    // The credential check must be skipped entirely — it throws for anonymous
+    // callers, which is what made the public branch unreachable.
+    expect(state.resolveCalls).toBe(0);
+  });
+
+  it("rejects an anonymous caller for a private asset", async () => {
+    const status = await statusOf(
+      authorizeAssetAccess(context, {
+        workspaceId: "workspace-1",
+        isPublic: false,
+      }),
+    );
+
+    expect(status).toBe(401);
+  });
+
+  it("rejects an authenticated non-member for a private asset", async () => {
+    state.caller = "outsider";
+
+    const status = await statusOf(
+      authorizeAssetAccess(context, {
+        workspaceId: "workspace-1",
+        isPublic: null,
+      }),
+    );
+
+    expect(status).toBe(403);
+  });
+
+  it("allows a workspace member to read a private asset", async () => {
+    state.caller = "member";
+
+    const status = await statusOf(
+      authorizeAssetAccess(context, {
+        workspaceId: "workspace-1",
+        isPublic: false,
+      }),
+    );
+
+    expect(status).toBe(200);
+    expect(state.validateCalls).toEqual([
+      { userId: "user-member", workspaceId: "workspace-1" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

`GET /api/asset/:id` resolves credentials *before* it consults `asset.isPublic` ([`index.ts:315-321`](https://github.com/usekaneo/kaneo/blob/main/apps/api/src/index.ts#L315-L321)):

```ts
const { userId, apiKeyId } = await resolveAssetBearerOrCookie(c);

if (userId) {
  await validateWorkspaceAccess(userId, asset.workspaceId, apiKeyId);
} else if (!asset.isPublic) {
  throw new HTTPException(401, { message: "Unauthorized" });
}
```

`resolveAssetBearerOrCookie` is declared `Promise<{ userId: string; apiKeyId?: string }>` and **throws on every unauthenticated path** — malformed bearer (`authenticate-api-request.ts:126`), bad api key (`:138`), bad bearer (`:153`), no session (`:158`). It never returns a falsy `userId`.

So by the time line 317 runs, `userId` is always truthy, and the `else if` on line 319 is unreachable. The anonymous case is rejected at line 315, before `isPublic` is ever read.

### Impact

The route declares `security: []` (`index.ts:281`) and varies its cache header on the flag (`"Cache-Control": asset.isPublic ? "public, max-age=300" : …`, `index.ts:334`), so public assets are clearly meant to be readable by anyone. In practice they aren't:

- Anonymous `GET /api/asset/<id>` for a public project's asset → **401** (expected 200)
- Signed-in user who isn't a member of that workspace → **403** via `validateWorkspaceAccess`

Every image embedded in a task description therefore renders broken on the public project share page (`components/public-project/task-detail-modal.tsx:166` renders the markdown), for exactly the audience the feature exists for.

### The fix

Skip the credential check entirely for assets of a public project; keep the identical authenticate-then-authorize pair for everything else. Private-asset behaviour is unchanged.

I pulled the policy into `apps/api/src/utils/authorize-asset-access.ts` so it can be unit tested — the route body lives inside the 900-line `createApp()` factory, which only the PostgreSQL-backed integration suite can exercise. Happy to inline it back into `index.ts` if you'd rather keep the diff to the route, though then the fix ships without a unit test.

## Related Issue(s)

No pre-filed issue — the full write-up is above. Happy to open one if you'd like it tracked separately.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Adds `tests/api/utils/authorize-asset-access.test.ts` with four cases:

1. **anonymous + public asset → allowed, and the credential check is never called** ← fails on `main` with 401
2. anonymous + private asset → 401
3. authenticated non-member + private asset → 403
4. workspace member + private asset → allowed, `validateWorkspaceAccess` called with the asset's workspace

Verified locally:

```
# with main's ordering restored, case 1 fails:
#   AssertionError: expected 401 to be 200
$ cd apps/api && pnpm test
 Test Files  36 passed (36)
      Tests  216 passed (216)     # main baseline: 35 files / 212 tests

$ pnpm exec biome ci .            # exit 0
```

`pnpm test:integration` was not run locally (no PostgreSQL in this environment); CI covers it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public assets can be accessed without authentication.
  * Private asset access now supports bearer-token and cookie-based authentication with workspace membership validation.

* **Bug Fixes**
  * Improved authorization responses for unauthorized and restricted asset requests, including clearer handling of 401 and 403 errors.

* **Tests**
  * Added coverage for public access, unauthorized private access, restricted workspace access, and authorized members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->