### PR TITLE
fix: enforce bulk task permissions

### DIFF
--- a/apps/api/src/task/controllers/bulk-update-tasks.ts
+++ b/apps/api/src/task/controllers/bulk-update-tasks.ts
@@ -226,6 +226,12 @@ async function bulkUpdateTasks({
         throw new HTTPException(404, { message: "Label not found" });
       }
 
+      if (label.workspaceId && label.workspaceId !== workspaceId) {
+        throw new HTTPException(400, {
+          message: "Label and tasks must belong to the same workspace",
+        });
+      }
+
       for (const task of tasks) {
         const existingAssignment = await db.query.labelTable.findFirst({
           where: and(

--- a/apps/api/src/task/controllers/require-task-permission.ts
+++ b/apps/api/src/task/controllers/require-task-permission.ts
@@ -1,0 +1,54 @@
+import { eq } from "drizzle-orm";
+import type { Context, Next } from "hono";
+import { requireEntitlement } from "../../billing/require-entitlement-middleware";
+import db from "../../database";
+import { taskTable } from "../../database/schema";
+import { requireWorkspacePermission } from "../../utils/require-workspace-permission";
+
+export async function requireBulkTaskPermission(c: Context, next: Next) {
+  const { operation } = c.req.valid("json");
+
+  if (operation === "delete") {
+    return requireWorkspacePermission({ task: ["delete"] })(c, next);
+  }
+
+  if (operation === "updateAssignee") {
+    return requireWorkspacePermission({ task: ["assign"] })(c, next);
+  }
+
+  if (operation === "addLabel" || operation === "removeLabel") {
+    return requireWorkspacePermission({ label: ["update"] })(c, next);
+  }
+
+  return requireWorkspacePermission({ task: ["update"] })(c, next);
+}
+
+export async function requireBulkTaskEntitlement(c: Context, next: Next) {
+  const { operation } = c.req.valid("json");
+
+  if (
+    operation === "delete" ||
+    operation === "addLabel" ||
+    operation === "removeLabel"
+  ) {
+    return next();
+  }
+
+  return requireEntitlement(c, next);
+}
+
+export async function requireTaskAssigneePermission(c: Context, next: Next) {
+  const { id } = c.req.valid("param");
+  const { userId } = c.req.valid("json");
+  const [existingTask] = await db
+    .select({ userId: taskTable.userId })
+    .from(taskTable)
+    .where(eq(taskTable.id, id))
+    .limit(1);
+
+  if (existingTask && existingTask.userId !== (userId || null)) {
+    return requireWorkspacePermission({ task: ["assign"] })(c, next);
+  }
+
+  return next();
+}

--- a/apps/api/src/task/index.ts
+++ b/apps/api/src/task/index.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import { type Context, Hono, type Next } from "hono";
+import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import * as v from "valibot";
@@ -29,6 +29,11 @@ import getTask from "./controllers/get-task";
 import getTasks from "./controllers/get-tasks";
 import importTasks from "./controllers/import-tasks";
 import moveTask from "./controllers/move-task";
+import {
+  requireBulkTaskEntitlement,
+  requireBulkTaskPermission,
+  requireTaskAssigneePermission,
+} from "./controllers/require-task-permission";
 import updateTask from "./controllers/update-task";
 import updateTaskAssignee from "./controllers/update-task-assignee";
 import updateTaskDescription from "./controllers/update-task-description";
@@ -37,54 +42,6 @@ import updateTaskPriority from "./controllers/update-task-priority";
 import updateTaskStatus from "./controllers/update-task-status";
 import updateTaskTitle from "./controllers/update-task-title";
 import { VALID_PRIORITIES } from "./validate-task-fields";
-
-async function requireBulkTaskPermission(c: Context, next: Next) {
-  const { operation } = c.req.valid("json");
-
-  if (operation === "delete") {
-    return requireWorkspacePermission({ task: ["delete"] })(c, next);
-  }
-
-  if (operation === "updateAssignee") {
-    return requireWorkspacePermission({ task: ["assign"] })(c, next);
-  }
-
-  if (operation === "addLabel" || operation === "removeLabel") {
-    return requireWorkspacePermission({ label: ["update"] })(c, next);
-  }
-
-  return requireWorkspacePermission({ task: ["update"] })(c, next);
-}
-
-async function requireBulkTaskEntitlement(c: Context, next: Next) {
-  const { operation } = c.req.valid("json");
-
-  if (
-    operation === "delete" ||
-    operation === "addLabel" ||
-    operation === "removeLabel"
-  ) {
-    return next();
-  }
-
-  return requireEntitlement(c, next);
-}
-
-async function requireTaskAssigneePermission(c: Context, next: Next) {
-  const { id } = c.req.valid("param");
-  const { userId } = c.req.valid("json");
-  const [existingTask] = await db
-    .select({ userId: taskTable.userId })
-    .from(taskTable)
-    .where(eq(taskTable.id, id))
-    .limit(1);
-
-  if (existingTask && existingTask.userId !== (userId || null)) {
-    return requireWorkspacePermission({ task: ["assign"] })(c, next);
-  }
-
-  return next();
-}
 
 const task = new Hono<{
   Variables: {

--- a/apps/api/src/task/index.ts
+++ b/apps/api/src/task/index.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import { Hono } from "hono";
+import { type Context, Hono, type Next } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import * as v from "valibot";
@@ -37,6 +37,54 @@ import updateTaskPriority from "./controllers/update-task-priority";
 import updateTaskStatus from "./controllers/update-task-status";
 import updateTaskTitle from "./controllers/update-task-title";
 import { VALID_PRIORITIES } from "./validate-task-fields";
+
+async function requireBulkTaskPermission(c: Context, next: Next) {
+  const { operation } = c.req.valid("json");
+
+  if (operation === "delete") {
+    return requireWorkspacePermission({ task: ["delete"] })(c, next);
+  }
+
+  if (operation === "updateAssignee") {
+    return requireWorkspacePermission({ task: ["assign"] })(c, next);
+  }
+
+  if (operation === "addLabel" || operation === "removeLabel") {
+    return requireWorkspacePermission({ label: ["update"] })(c, next);
+  }
+
+  return requireWorkspacePermission({ task: ["update"] })(c, next);
+}
+
+async function requireBulkTaskEntitlement(c: Context, next: Next) {
+  const { operation } = c.req.valid("json");
+
+  if (
+    operation === "delete" ||
+    operation === "addLabel" ||
+    operation === "removeLabel"
+  ) {
+    return next();
+  }
+
+  return requireEntitlement(c, next);
+}
+
+async function requireTaskAssigneePermission(c: Context, next: Next) {
+  const { id } = c.req.valid("param");
+  const { userId } = c.req.valid("json");
+  const [existingTask] = await db
+    .select({ userId: taskTable.userId })
+    .from(taskTable)
+    .where(eq(taskTable.id, id))
+    .limit(1);
+
+  if (existingTask && existingTask.userId !== (userId || null)) {
+    return requireWorkspacePermission({ task: ["assign"] })(c, next);
+  }
+
+  return next();
+}
 
 const task = new Hono<{
   Variables: {
@@ -132,6 +180,9 @@ const task = new Hono<{
         value: v.optional(v.nullable(v.string())),
       }),
     ),
+    workspaceAccess.fromTasks(),
+    requireBulkTaskPermission,
+    requireBulkTaskEntitlement,
     async (c) => {
       const { taskIds, operation, value } = c.req.valid("json");
       const userId = c.get("userId");
@@ -323,6 +374,7 @@ const task = new Hono<{
     ),
     workspaceAccess.fromTask(),
     requireWorkspacePermission({ task: ["update"] }),
+    requireTaskAssigneePermission,
     requireEntitlement,
     async (c) => {
       const { id } = c.req.valid("param");

--- a/apps/api/src/utils/workspace-access-middleware.ts
+++ b/apps/api/src/utils/workspace-access-middleware.ts
@@ -90,7 +90,15 @@ export function workspaceAccessMiddleware(
             const workspaceIds = [
               ...new Set(tasks.map((task) => task.workspaceId)),
             ];
-            workspaceId = workspaceIds.length === 1 ? workspaceIds[0] : null;
+            if (workspaceIds.length === 0) {
+              throw new HTTPException(404, { message: "No tasks found" });
+            }
+            if (workspaceIds.length > 1) {
+              throw new HTTPException(400, {
+                message: "All tasks must belong to the same workspace",
+              });
+            }
+            workspaceId = workspaceIds[0];
           }
         }
       }

--- a/apps/api/src/utils/workspace-access-middleware.ts
+++ b/apps/api/src/utils/workspace-access-middleware.ts
@@ -79,16 +79,18 @@ export function workspaceAccessMiddleware(
             (id): id is string => typeof id === "string",
           );
           if (taskIds.length > 0) {
-            const [task] = await db
+            const tasks = await db
               .select({ workspaceId: schema.projectTable.workspaceId })
               .from(schema.taskTable)
               .innerJoin(
                 schema.projectTable,
                 eq(schema.taskTable.projectId, schema.projectTable.id),
               )
-              .where(inArray(schema.taskTable.id, taskIds))
-              .limit(1);
-            workspaceId = task?.workspaceId || null;
+              .where(inArray(schema.taskTable.id, taskIds));
+            const workspaceIds = [
+              ...new Set(tasks.map((task) => task.workspaceId)),
+            ];
+            workspaceId = workspaceIds.length === 1 ? workspaceIds[0] : null;
           }
         }
       }

--- a/apps/api/src/utils/workspace-access-middleware.ts
+++ b/apps/api/src/utils/workspace-access-middleware.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { Context, Next } from "hono";
 import { HTTPException } from "hono/http-exception";
 import db, { schema } from "../database";
@@ -19,6 +19,11 @@ type WorkspaceIdSource =
         | "comment"
         | "column"
         | "workflowRule";
+      idKey: string;
+    }
+  | {
+      type: "lookupMany";
+      resource: "task";
       idKey: string;
     };
 
@@ -65,6 +70,26 @@ export function workspaceAccessMiddleware(
           c.req.param(source.idKey) || c.req.query(source.idKey) || idFromBody;
         if (id) {
           workspaceId = await lookupWorkspaceId(source.resource, id);
+        }
+      } else if (source.type === "lookupMany") {
+        const body = await readJsonObjectBody(c);
+        const ids = body[source.idKey];
+        if (Array.isArray(ids)) {
+          const taskIds = ids.filter(
+            (id): id is string => typeof id === "string",
+          );
+          if (taskIds.length > 0) {
+            const [task] = await db
+              .select({ workspaceId: schema.projectTable.workspaceId })
+              .from(schema.taskTable)
+              .innerJoin(
+                schema.projectTable,
+                eq(schema.taskTable.projectId, schema.projectTable.id),
+              )
+              .where(inArray(schema.taskTable.id, taskIds))
+              .limit(1);
+            workspaceId = task?.workspaceId || null;
+          }
         }
       }
 
@@ -267,6 +292,11 @@ export const workspaceAccess = {
         { type: "lookup", resource: "task", idKey },
         { type: "query", key: "workspaceId" },
       ],
+    }),
+
+  fromTasks: (idKey = "taskIds") =>
+    workspaceAccessMiddleware({
+      sources: [{ type: "lookupMany", resource: "task", idKey }],
     }),
 
   fromLabel: (idKey = "id") =>

--- a/tests/api-integration/workspace-rbac.test.ts
+++ b/tests/api-integration/workspace-rbac.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { beforeEach, describe, expect, it } from "vitest";
 import db, { schema } from "../../apps/api/src/database";
 import { createApp } from "../../apps/api/src/index";
@@ -275,6 +275,62 @@ describe("API integration: workspace RBAC enforcement", () => {
         where: eq(schema.taskTable.id, task.id),
       });
       expect(persisted?.priority).toBe("high");
+    });
+
+    it("preserves the not-found response for unknown tasks", async () => {
+      const member = await createWorkspaceMember({ role: "member" });
+
+      mockAuthenticatedSession(member.user);
+      const { app } = createApp();
+
+      const response = await app.request("/api/task/bulk", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          taskIds: [randomUUID()],
+          operation: "updatePriority",
+          value: "high",
+        }),
+      });
+      expect(response.status).toBe(404);
+    });
+
+    it("rejects bulk mutations that span workspaces", async () => {
+      const member = await createWorkspaceMember({ role: "member" });
+      const foreign = await createWorkspaceMember({ role: "admin" });
+      const { project, columns } = await createProjectFixture({
+        workspaceId: member.workspace.id,
+      });
+      const { project: foreignProject, columns: foreignColumns } =
+        await createProjectFixture({ workspaceId: foreign.workspace.id });
+      const task = await seedTask(project.id, columns.todo.id);
+      const foreignTask = await seedTask(
+        foreignProject.id,
+        foreignColumns.todo.id,
+      );
+
+      mockAuthenticatedSession(member.user);
+      const { app } = createApp();
+
+      const response = await app.request("/api/task/bulk", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          taskIds: [task.id, foreignTask.id],
+          operation: "updatePriority",
+          value: "high",
+        }),
+      });
+      expect(response.status).toBe(400);
+
+      const persistedTasks = await db
+        .select({ priority: schema.taskTable.priority })
+        .from(schema.taskTable)
+        .where(inArray(schema.taskTable.id, [task.id, foreignTask.id]));
+      expect(persistedTasks).toHaveLength(2);
+      expect(persistedTasks.every((task) => task.priority === "medium")).toBe(
+        true,
+      );
     });
 
     it("blocks a member from deleting a task in bulk", async () => {

--- a/tests/api-integration/workspace-rbac.test.ts
+++ b/tests/api-integration/workspace-rbac.test.ts
@@ -17,7 +17,11 @@ type CreateTaskBody = {
   status: string;
 };
 
-async function seedTask(projectId: string, columnId: string | null) {
+async function seedTask(
+  projectId: string,
+  columnId: string | null,
+  userId?: string,
+) {
   const [task] = await db
     .insert(schema.taskTable)
     .values({
@@ -29,6 +33,7 @@ async function seedTask(projectId: string, columnId: string | null) {
       columnId,
       number: 1,
       position: 1,
+      ...(userId ? { userId } : {}),
     })
     .returning();
   return task;
@@ -217,6 +222,178 @@ describe("API integration: workspace RBAC enforcement", () => {
     });
   });
 
+  describe("bulk task mutations", () => {
+    it("blocks a viewer from changing task priority in bulk", async () => {
+      const viewer = await createWorkspaceMember({ role: "viewer" });
+      const { project, columns } = await createProjectFixture({
+        workspaceId: viewer.workspace.id,
+      });
+      const task = await seedTask(project.id, columns.todo.id);
+
+      mockAuthenticatedSession(viewer.user);
+      const { app } = createApp();
+
+      const response = await app.request("/api/task/bulk", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          taskIds: [task.id],
+          operation: "updatePriority",
+          value: "high",
+        }),
+      });
+      expect(response.status).toBe(403);
+
+      const persisted = await db.query.taskTable.findFirst({
+        where: eq(schema.taskTable.id, task.id),
+      });
+      expect(persisted?.priority).toBe("medium");
+    });
+
+    it("allows a member to change task priority in bulk", async () => {
+      const member = await createWorkspaceMember({ role: "member" });
+      const { project, columns } = await createProjectFixture({
+        workspaceId: member.workspace.id,
+      });
+      const task = await seedTask(project.id, columns.todo.id);
+
+      mockAuthenticatedSession(member.user);
+      const { app } = createApp();
+
+      const response = await app.request("/api/task/bulk", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          taskIds: [task.id],
+          operation: "updatePriority",
+          value: "high",
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      const persisted = await db.query.taskTable.findFirst({
+        where: eq(schema.taskTable.id, task.id),
+      });
+      expect(persisted?.priority).toBe("high");
+    });
+
+    it("blocks a member from deleting a task in bulk", async () => {
+      const member = await createWorkspaceMember({ role: "member" });
+      const { project, columns } = await createProjectFixture({
+        workspaceId: member.workspace.id,
+      });
+      const task = await seedTask(project.id, columns.todo.id);
+
+      mockAuthenticatedSession(member.user);
+      const { app } = createApp();
+
+      const response = await app.request("/api/task/bulk", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ taskIds: [task.id], operation: "delete" }),
+      });
+      expect(response.status).toBe(403);
+
+      const persisted = await db.query.taskTable.findFirst({
+        where: eq(schema.taskTable.id, task.id),
+      });
+      expect(persisted).toBeDefined();
+    });
+
+    it("blocks a member from assigning a task in bulk", async () => {
+      const member = await createWorkspaceMember({ role: "member" });
+      const { project, columns } = await createProjectFixture({
+        workspaceId: member.workspace.id,
+      });
+      const task = await seedTask(project.id, columns.todo.id);
+
+      mockAuthenticatedSession(member.user);
+      const { app } = createApp();
+
+      const response = await app.request("/api/task/bulk", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          taskIds: [task.id],
+          operation: "updateAssignee",
+          value: member.user.id,
+        }),
+      });
+      expect(response.status).toBe(403);
+
+      const persisted = await db.query.taskTable.findFirst({
+        where: eq(schema.taskTable.id, task.id),
+      });
+      expect(persisted?.userId).toBeNull();
+    });
+
+    it("allows an admin to assign a task in bulk", async () => {
+      const admin = await createWorkspaceMember({ role: "admin" });
+      const { project, columns } = await createProjectFixture({
+        workspaceId: admin.workspace.id,
+      });
+      const task = await seedTask(project.id, columns.todo.id);
+
+      mockAuthenticatedSession(admin.user);
+      const { app } = createApp();
+
+      const response = await app.request("/api/task/bulk", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          taskIds: [task.id],
+          operation: "updateAssignee",
+          value: admin.user.id,
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      const persisted = await db.query.taskTable.findFirst({
+        where: eq(schema.taskTable.id, task.id),
+      });
+      expect(persisted?.userId).toBe(admin.user.id);
+    });
+
+    it("does not copy a label from another workspace in bulk", async () => {
+      const member = await createWorkspaceMember({ role: "member" });
+      const foreign = await createWorkspaceMember({ role: "admin" });
+      const { project, columns } = await createProjectFixture({
+        workspaceId: member.workspace.id,
+      });
+      const task = await seedTask(project.id, columns.todo.id);
+      const [foreignLabel] = await db
+        .insert(schema.labelTable)
+        .values({
+          name: "private",
+          color: "#000000",
+          workspaceId: foreign.workspace.id,
+        })
+        .returning();
+
+      mockAuthenticatedSession(member.user);
+      const { app } = createApp();
+
+      const response = await app.request("/api/task/bulk", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          taskIds: [task.id],
+          operation: "addLabel",
+          value: foreignLabel.id,
+        }),
+      });
+      expect(response.status).toBe(400);
+
+      const copiedLabel = await db.query.labelTable.findFirst({
+        where: and(
+          eq(schema.labelTable.taskId, task.id),
+          eq(schema.labelTable.name, foreignLabel.name),
+        ),
+      });
+      expect(copiedLabel).toBeUndefined();
+    });
+  });
+
   describe("custom workspace roles", () => {
     it("blocks a custom role that only grants task:read from creating a task", async () => {
       const member = await createWorkspaceMember({ role: "readonly" });
@@ -351,6 +528,131 @@ describe("API integration: workspace RBAC enforcement", () => {
         }),
       });
       expect(response.status).toBe(200);
+    });
+
+    it("allows a member to update an assigned task without changing its assignee", async () => {
+      const member = await createWorkspaceMember({ role: "member" });
+      const { project, columns } = await createProjectFixture({
+        workspaceId: member.workspace.id,
+      });
+      const task = await seedTask(project.id, columns.todo.id, member.user.id);
+
+      mockAuthenticatedSession(member.user);
+      const { app } = createApp();
+
+      const response = await app.request(`/api/task/${task.id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: "Updated by member",
+          description: "edit",
+          priority: "high",
+          status: "to-do",
+          projectId: project.id,
+          position: 1,
+          userId: member.user.id,
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      const persisted = await db.query.taskTable.findFirst({
+        where: eq(schema.taskTable.id, task.id),
+      });
+      expect(persisted?.title).toBe("Updated by member");
+      expect(persisted?.userId).toBe(member.user.id);
+    });
+
+    it("blocks a member from assigning an unassigned task through full update", async () => {
+      const member = await createWorkspaceMember({ role: "member" });
+      const { project, columns } = await createProjectFixture({
+        workspaceId: member.workspace.id,
+      });
+      const task = await seedTask(project.id, columns.todo.id);
+
+      mockAuthenticatedSession(member.user);
+      const { app } = createApp();
+
+      const response = await app.request(`/api/task/${task.id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: "Member attempt",
+          description: "nope",
+          priority: "low",
+          status: "to-do",
+          projectId: project.id,
+          position: 1,
+          userId: member.user.id,
+        }),
+      });
+      expect(response.status).toBe(403);
+
+      const persisted = await db.query.taskTable.findFirst({
+        where: eq(schema.taskTable.id, task.id),
+      });
+      expect(persisted?.userId).toBeNull();
+    });
+
+    it("blocks a member from unassigning a task through full update", async () => {
+      const member = await createWorkspaceMember({ role: "member" });
+      const { project, columns } = await createProjectFixture({
+        workspaceId: member.workspace.id,
+      });
+      const task = await seedTask(project.id, columns.todo.id, member.user.id);
+
+      mockAuthenticatedSession(member.user);
+      const { app } = createApp();
+
+      const response = await app.request(`/api/task/${task.id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: "Member attempt",
+          description: "nope",
+          priority: "low",
+          status: "to-do",
+          projectId: project.id,
+          position: 1,
+          userId: "",
+        }),
+      });
+      expect(response.status).toBe(403);
+
+      const persisted = await db.query.taskTable.findFirst({
+        where: eq(schema.taskTable.id, task.id),
+      });
+      expect(persisted?.userId).toBe(member.user.id);
+    });
+
+    it("allows an admin to assign a task through full update", async () => {
+      const admin = await createWorkspaceMember({ role: "admin" });
+      const { project, columns } = await createProjectFixture({
+        workspaceId: admin.workspace.id,
+      });
+      const task = await seedTask(project.id, columns.todo.id);
+
+      mockAuthenticatedSession(admin.user);
+      const { app } = createApp();
+
+      const response = await app.request(`/api/task/${task.id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: "Assigned by admin",
+          description: "",
+          priority: "medium",
+          status: "to-do",
+          projectId: project.id,
+          position: 1,
+          userId: admin.user.id,
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      const persisted = await db.query.taskTable.findFirst({
+        where: eq(schema.taskTable.id, task.id),
+      });
+      expect(persisted?.userId).toBe(admin.user.id);
     });
 
     it("blocks a viewer from updating a task", async () => {


### PR DESCRIPTION
## Summary
- Enforce workspace access and operation-specific permissions for bulk task mutations.
- Require task assignment permission only when a full task update changes the assignee.
- Reject bulk labels from another workspace.

## Tests
- Biome check
- API unit suite
- API integration suite: 82 passing tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented assigning labels from another workspace during bulk task updates.
  * Improved workspace access validation for bulk task operations.
  * Enforced permission and entitlement checks for bulk task updates and deletions.
  * Restricted task assignment and unassignment based on user permissions.
  * Preserved existing task assignments when updates are made without assignment permissions.

* **Tests**
  * Added coverage for bulk task updates, deletion, assignment, permission enforcement, and cross-workspace label protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->