### PR TITLE
fix(web): keep planned subtasks in backlog

### DIFF
--- a/apps/web/src/components/task/task-details-content.tsx
+++ b/apps/web/src/components/task/task-details-content.tsx
@@ -88,11 +88,14 @@ export default function TaskDetailsContent({
         </div>
       )}
       <div className="mt-4">
-        <TaskSubtasks
-          taskId={taskId}
-          projectId={projectId}
-          workspaceId={workspaceId}
-        />
+        {task && (
+          <TaskSubtasks
+            taskId={taskId}
+            projectId={projectId}
+            workspaceId={workspaceId}
+            parentStatus={task.status}
+          />
+        )}
       </div>
       <div className="mt-2">
         <TaskRelations

--- a/apps/web/src/components/task/task-subtasks.test.tsx
+++ b/apps/web/src/components/task/task-subtasks.test.tsx
@@ -5,12 +5,13 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import TaskSubtasks from "./task-subtasks";
 
 const mocks = vi.hoisted(() => ({
   createTask: vi.fn(),
   createRelation: vi.fn(),
+  getColumns: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
@@ -33,12 +34,7 @@ vi.mock("@/hooks/mutations/task/use-update-task-status", () => ({
   useUpdateTaskStatus: () => ({ mutateAsync: vi.fn() }),
 }));
 vi.mock("@/hooks/queries/column/use-get-columns", () => ({
-  useGetColumns: () => ({
-    data: [
-      { id: "todo", slug: "to-do", name: "To Do", isFinal: false },
-      { id: "done", slug: "done", name: "Done", isFinal: true },
-    ],
-  }),
+  useGetColumns: () => mocks.getColumns(),
 }));
 vi.mock("@/hooks/queries/task-relation/use-get-task-relations", () => ({
   default: () => ({ data: [] }),
@@ -56,6 +52,16 @@ vi.mock("@/hooks/use-workspace-permission", () => ({
   useWorkspacePermission: () => ({ canManageTasks: () => true }),
 }));
 vi.mock("@/lib/toast", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+beforeEach(() => {
+  mocks.getColumns.mockReturnValue({
+    data: [
+      { id: "todo", slug: "to-do", name: "To Do", isFinal: false },
+      { id: "done", slug: "done", name: "Done", isFinal: true },
+    ],
+    isLoading: false,
+  });
+});
 
 afterEach(() => {
   cleanup();
@@ -76,7 +82,11 @@ describe("TaskSubtasks", () => {
       />,
     );
 
-    fireEvent.click(screen.getAllByRole("button")[1]);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "tasks:subtasks.addAction tasks:subtasks.title",
+      }),
+    );
     fireEvent.change(
       screen.getByPlaceholderText("tasks:subtasks.inputPlaceholder"),
       { target: { value: "Design login form" } },
@@ -104,7 +114,11 @@ describe("TaskSubtasks", () => {
       />,
     );
 
-    fireEvent.click(screen.getAllByRole("button")[1]);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "tasks:subtasks.addAction tasks:subtasks.title",
+      }),
+    );
     fireEvent.change(
       screen.getByPlaceholderText("tasks:subtasks.inputPlaceholder"),
       { target: { value: "Implement login form" } },
@@ -117,5 +131,24 @@ describe("TaskSubtasks", () => {
     expect(mocks.createTask).toHaveBeenCalledWith(
       expect.objectContaining({ status: "to-do" }),
     );
+  });
+
+  it("blocks active-parent creation until project columns are available", () => {
+    mocks.getColumns.mockReturnValue({ data: [], isLoading: true });
+
+    render(
+      <TaskSubtasks
+        taskId="parent-3"
+        projectId="project-1"
+        workspaceId="workspace-1"
+        parentStatus="in-progress"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "tasks:subtasks.addAction tasks:subtasks.title",
+      }),
+    ).toBeDisabled();
   });
 });

--- a/apps/web/src/components/task/task-subtasks.test.tsx
+++ b/apps/web/src/components/task/task-subtasks.test.tsx
@@ -1,0 +1,121 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import TaskSubtasks from "./task-subtasks";
+
+const mocks = vi.hoisted(() => ({
+  createTask: vi.fn(),
+  createRelation: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: unknown }) => children,
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@/hooks/mutations/task/use-create-task", () => ({
+  default: () => ({ mutateAsync: mocks.createTask, isPending: false }),
+}));
+vi.mock("@/hooks/mutations/task-relation/use-create-task-relation", () => ({
+  default: () => ({ mutateAsync: mocks.createRelation }),
+}));
+vi.mock("@/hooks/mutations/task/use-delete-task", () => ({
+  useDeleteTask: () => ({ mutateAsync: vi.fn() }),
+}));
+vi.mock("@/hooks/mutations/task/use-update-task-status", () => ({
+  useUpdateTaskStatus: () => ({ mutateAsync: vi.fn() }),
+}));
+vi.mock("@/hooks/queries/column/use-get-columns", () => ({
+  useGetColumns: () => ({
+    data: [
+      { id: "todo", slug: "to-do", name: "To Do", isFinal: false },
+      { id: "done", slug: "done", name: "Done", isFinal: true },
+    ],
+  }),
+}));
+vi.mock("@/hooks/queries/task-relation/use-get-task-relations", () => ({
+  default: () => ({ data: [] }),
+}));
+vi.mock("@/hooks/queries/workspace/use-active-workspace", () => ({
+  default: () => ({ data: { id: "workspace-1" } }),
+}));
+vi.mock(
+  "@/hooks/queries/workspace-users/use-get-active-workspace-users",
+  () => ({
+    useGetActiveWorkspaceUsers: () => ({ data: { members: [] } }),
+  }),
+);
+vi.mock("@/hooks/use-workspace-permission", () => ({
+  useWorkspacePermission: () => ({ canManageTasks: () => true }),
+}));
+vi.mock("@/lib/toast", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("TaskSubtasks", () => {
+  it("creates a subtask as planned when its parent is planned", async () => {
+    mocks.createTask.mockResolvedValue({ id: "subtask-1" });
+    mocks.createRelation.mockResolvedValue({});
+
+    render(
+      <TaskSubtasks
+        taskId="parent-1"
+        projectId="project-1"
+        workspaceId="workspace-1"
+        parentStatus="planned"
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("button")[1]);
+    fireEvent.change(
+      screen.getByPlaceholderText("tasks:subtasks.inputPlaceholder"),
+      { target: { value: "Design login form" } },
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "tasks:subtasks.addAction" }),
+    );
+
+    await waitFor(() => expect(mocks.createTask).toHaveBeenCalledTimes(1));
+    expect(mocks.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "planned" }),
+    );
+  });
+
+  it("uses the project's first active column for an active parent", async () => {
+    mocks.createTask.mockResolvedValue({ id: "subtask-2" });
+    mocks.createRelation.mockResolvedValue({});
+
+    render(
+      <TaskSubtasks
+        taskId="parent-2"
+        projectId="project-1"
+        workspaceId="workspace-1"
+        parentStatus="in-progress"
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("button")[1]);
+    fireEvent.change(
+      screen.getByPlaceholderText("tasks:subtasks.inputPlaceholder"),
+      { target: { value: "Implement login form" } },
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "tasks:subtasks.addAction" }),
+    );
+
+    await waitFor(() => expect(mocks.createTask).toHaveBeenCalledTimes(1));
+    expect(mocks.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "to-do" }),
+    );
+  });
+});

--- a/apps/web/src/components/task/task-subtasks.tsx
+++ b/apps/web/src/components/task/task-subtasks.tsx
@@ -66,7 +66,8 @@ export default function TaskSubtasks({
   const createRelation = useCreateTaskRelation();
   const { mutateAsync: deleteTask } = useDeleteTask();
   const { mutateAsync: updateTaskStatus } = useUpdateTaskStatus();
-  const { data: columns = [] } = useGetColumns(projectId);
+  const { data: columns = [], isLoading: isLoadingColumns } =
+    useGetColumns(projectId);
   const { canManageTasks } = useWorkspacePermission();
   const canEdit = canManageTasks();
 
@@ -74,7 +75,9 @@ export default function TaskSubtasks({
   // validates status against columns). A subtask counts as completed when its
   // status is a final column.
   const doneSlug = columns.find((c) => c.isFinal)?.slug ?? "done";
-  const todoSlug = columns.find((c) => !c.isFinal)?.slug ?? "to-do";
+  const todoSlug = columns.find((c) => !c.isFinal)?.slug;
+  const canCreateSubtask =
+    parentStatus === "planned" || (!isLoadingColumns && Boolean(todoSlug));
   const isCompleted = (status: string) =>
     columns.length > 0
       ? (columns.find((c) => c.slug === status)?.isFinal ?? false)
@@ -256,13 +259,15 @@ export default function TaskSubtasks({
 
   const handleAddSubtask = async () => {
     if (!newTitle.trim()) return;
+    const initialStatus = parentStatus === "planned" ? "planned" : todoSlug;
+    if (!initialStatus) return;
 
     try {
       const newTask = await createTask.mutateAsync({
         title: newTitle.trim(),
         description: "",
         projectId,
-        status: parentStatus === "planned" ? "planned" : todoSlug,
+        status: initialStatus,
         priority: "no-priority",
       });
 
@@ -337,7 +342,9 @@ export default function TaskSubtasks({
               variant="ghost"
               size="xs"
               className="text-muted-foreground"
+              aria-label={`${t("tasks:subtasks.addAction")} ${t("tasks:subtasks.title")}`}
               onClick={() => setIsAdding(true)}
+              disabled={!canCreateSubtask}
             >
               <Plus className="size-3.5" />
             </Button>
@@ -412,7 +419,9 @@ export default function TaskSubtasks({
               <Button
                 size="xs"
                 onClick={handleAddSubtask}
-                disabled={!newTitle.trim() || createTask.isPending}
+                disabled={
+                  !newTitle.trim() || createTask.isPending || !canCreateSubtask
+                }
               >
                 {t("tasks:subtasks.addAction")}
               </Button>

--- a/apps/web/src/components/task/task-subtasks.tsx
+++ b/apps/web/src/components/task/task-subtasks.tsx
@@ -38,12 +38,14 @@ type TaskSubtasksProps = {
   taskId: string;
   projectId: string;
   workspaceId: string;
+  parentStatus: string;
 };
 
 export default function TaskSubtasks({
   taskId,
   projectId,
   workspaceId,
+  parentStatus,
 }: TaskSubtasksProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -260,7 +262,7 @@ export default function TaskSubtasks({
         title: newTitle.trim(),
         description: "",
         projectId,
-        status: "to-do",
+        status: parentStatus === "planned" ? "planned" : todoSlug,
         priority: "no-priority",
       });
 


### PR DESCRIPTION
## Description

Keeps newly created subtasks in the backlog when their parent task is still planned. The subtask form now receives the loaded parent status and creates the child with `planned` instead of always using `to-do`.

Active parents retain the existing workflow: their new subtasks use the project's first non-final column. The subtask section waits for the parent task to load, and active-parent creation waits for a real project column instead of falling back to a potentially invalid slug.

## Related Issue(s)

Fixes #1460

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other: changed-file Biome check and the repository pre-commit build

Validation commands:

- `pnpm --filter @kaneo/web test` — 14 files, 37 tests passed
- `pnpm test` — 9 Turbo tasks passed across API, web, and packages
- `pnpm exec biome check apps/web/src/components/task/task-subtasks.tsx apps/web/src/components/task/task-details-content.tsx apps/web/src/components/task/task-subtasks.test.tsx` — passed
- `pnpm run build` — 6 Turbo tasks passed via the pre-commit hook
- `git diff --check` — passed

## Screenshots (if applicable)

Not applicable; this changes the status assigned during subtask creation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Cascading later parent status changes and nested rendering remain outside this fix; this only corrects the create-new-subtask flow described in #1460.
