### PR TITLE
fix: hide warning due-date badges on done tasks

### DIFF
--- a/apps/site/components/project-private-kanban-view.tsx
+++ b/apps/site/components/project-private-kanban-view.tsx
@@ -60,6 +60,7 @@ export function PrivateKanbanView({
                     key={task.id}
                     task={task}
                     projectSlug={project.slug}
+                    isCompleted={column.isFinal}
                     onTaskClick={onTaskClick}
                   />
                 ))}

--- a/apps/site/components/project-private-list-view.tsx
+++ b/apps/site/components/project-private-list-view.tsx
@@ -146,27 +146,27 @@ export function PrivateListView({
                         {/* Due date */}
                         {task.dueDate && (
                           <div
-                            className={`shrink-0 flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate, task.status === "done")]}`}
+                            className={`shrink-0 flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate, column.isFinal)]}`}
                           >
                             {getDueDateStatus(
                               task.dueDate,
-                              task.status === "done",
+                              column.isFinal,
                             ) === "overdue" && (
                               <CalendarX className="w-3 h-3" />
                             )}
                             {getDueDateStatus(
                               task.dueDate,
-                              task.status === "done",
+                              column.isFinal,
                             ) === "due-soon" && (
                               <CalendarClock className="w-3 h-3" />
                             )}
                             {(getDueDateStatus(
                               task.dueDate,
-                              task.status === "done",
+                              column.isFinal,
                             ) === "far-future" ||
                               getDueDateStatus(
                                 task.dueDate,
-                                task.status === "done",
+                                column.isFinal,
                               ) === "no-due-date") && (
                               <Calendar className="w-3 h-3" />
                             )}

--- a/apps/site/components/project-private-list-view.tsx
+++ b/apps/site/components/project-private-list-view.tsx
@@ -146,17 +146,28 @@ export function PrivateListView({
                         {/* Due date */}
                         {task.dueDate && (
                           <div
-                            className={`shrink-0 flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                            className={`shrink-0 flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate, task.status === "done")]}`}
                           >
-                            {getDueDateStatus(task.dueDate) === "overdue" && (
+                            {getDueDateStatus(
+                              task.dueDate,
+                              task.status === "done",
+                            ) === "overdue" && (
                               <CalendarX className="w-3 h-3" />
                             )}
-                            {getDueDateStatus(task.dueDate) === "due-soon" && (
+                            {getDueDateStatus(
+                              task.dueDate,
+                              task.status === "done",
+                            ) === "due-soon" && (
                               <CalendarClock className="w-3 h-3" />
                             )}
-                            {(getDueDateStatus(task.dueDate) === "far-future" ||
-                              getDueDateStatus(task.dueDate) ===
-                                "no-due-date") && (
+                            {(getDueDateStatus(
+                              task.dueDate,
+                              task.status === "done",
+                            ) === "far-future" ||
+                              getDueDateStatus(
+                                task.dueDate,
+                                task.status === "done",
+                              ) === "no-due-date") && (
                               <Calendar className="w-3 h-3" />
                             )}
                             <span>

--- a/apps/site/components/project-task-card.tsx
+++ b/apps/site/components/project-task-card.tsx
@@ -121,18 +121,16 @@ export function PublicTaskCard({
 
         {task.dueDate && (
           <div
-            className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+            className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate, task.status === "done")]}`}
           >
-            {getDueDateStatus(task.dueDate) === "overdue" && (
-              <CalendarX className="w-3 h-3" />
-            )}
-            {getDueDateStatus(task.dueDate) === "due-soon" && (
-              <CalendarClock className="w-3 h-3" />
-            )}
-            {(getDueDateStatus(task.dueDate) === "far-future" ||
-              getDueDateStatus(task.dueDate) === "no-due-date") && (
-              <Calendar className="w-3 h-3" />
-            )}
+            {getDueDateStatus(task.dueDate, task.status === "done") ===
+              "overdue" && <CalendarX className="w-3 h-3" />}
+            {getDueDateStatus(task.dueDate, task.status === "done") ===
+              "due-soon" && <CalendarClock className="w-3 h-3" />}
+            {(getDueDateStatus(task.dueDate, task.status === "done") ===
+              "far-future" ||
+              getDueDateStatus(task.dueDate, task.status === "done") ===
+                "no-due-date") && <Calendar className="w-3 h-3" />}
             <span>{format(new Date(task.dueDate), "MMM d")}</span>
           </div>
         )}

--- a/apps/site/components/project-task-card.tsx
+++ b/apps/site/components/project-task-card.tsx
@@ -15,12 +15,14 @@ type PublicTaskCardProps = {
     externalLinks?: Array<ExternalLink>;
   };
   projectSlug: string;
+  isCompleted?: boolean;
   onTaskClick: (task: Task) => void;
 };
 
 export function PublicTaskCard({
   task,
   projectSlug,
+  isCompleted = false,
   onTaskClick,
 }: PublicTaskCardProps) {
   const labels = task.labels || [];
@@ -121,15 +123,15 @@ export function PublicTaskCard({
 
         {task.dueDate && (
           <div
-            className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate, task.status === "done")]}`}
+            className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate, isCompleted)]}`}
           >
-            {getDueDateStatus(task.dueDate, task.status === "done") ===
+            {getDueDateStatus(task.dueDate, isCompleted) ===
               "overdue" && <CalendarX className="w-3 h-3" />}
-            {getDueDateStatus(task.dueDate, task.status === "done") ===
+            {getDueDateStatus(task.dueDate, isCompleted) ===
               "due-soon" && <CalendarClock className="w-3 h-3" />}
-            {(getDueDateStatus(task.dueDate, task.status === "done") ===
+            {(getDueDateStatus(task.dueDate, isCompleted) ===
               "far-future" ||
-              getDueDateStatus(task.dueDate, task.status === "done") ===
+              getDueDateStatus(task.dueDate, isCompleted) ===
                 "no-due-date") && <Calendar className="w-3 h-3" />}
             <span>{format(new Date(task.dueDate), "MMM d")}</span>
           </div>

--- a/apps/site/lib/due-date-status.ts
+++ b/apps/site/lib/due-date-status.ts
@@ -4,8 +4,12 @@ export type DueDateStatus =
   | "far-future"
   | "no-due-date";
 
-export function getDueDateStatus(dueDate: string | null): DueDateStatus {
+export function getDueDateStatus(
+  dueDate: string | null,
+  isCompleted = false,
+): DueDateStatus {
   if (!dueDate) return "no-due-date";
+  if (isCompleted) return "far-future";
 
   const now = new Date();
   const due = new Date(dueDate);

--- a/apps/web/src/components/backlog-list-view/backlog-task-row.tsx
+++ b/apps/web/src/components/backlog-list-view/backlog-task-row.tsx
@@ -51,6 +51,10 @@ export default function BacklogTaskRow({ task }: BacklogTaskRowProps) {
 
   const { project } = useProjectStore();
   const { data: workspace } = useActiveWorkspace();
+  const isTaskCompleted =
+    project?.columns?.find(
+      (column) => column.slug === task.status || column.id === task.status,
+    )?.isFinal ?? task.status === "done";
   const {
     showAssignees,
     showPriority,
@@ -179,16 +183,16 @@ export default function BacklogTaskRow({ task }: BacklogTaskRowProps) {
 
             {showDueDates && task.dueDate && (
               <div
-                className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded flex-shrink-0 ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded flex-shrink-0 ${dueDateStatusColors[getDueDateStatus(task.dueDate, isTaskCompleted)]}`}
               >
-                {getDueDateStatus(task.dueDate) === "overdue" && (
+                {getDueDateStatus(task.dueDate, isTaskCompleted) === "overdue" && (
                   <CalendarX className="w-3 h-3" />
                 )}
-                {getDueDateStatus(task.dueDate) === "due-soon" && (
+                {getDueDateStatus(task.dueDate, isTaskCompleted) === "due-soon" && (
                   <CalendarClock className="w-3 h-3" />
                 )}
-                {(getDueDateStatus(task.dueDate) === "far-future" ||
-                  getDueDateStatus(task.dueDate) === "no-due-date") && (
+                {(getDueDateStatus(task.dueDate, isTaskCompleted) === "far-future" ||
+                  getDueDateStatus(task.dueDate, isTaskCompleted) === "no-due-date") && (
                   <Calendar className="w-3 h-3" />
                 )}
                 <span>{format(new Date(task.dueDate), "MMM d")}</span>

--- a/apps/web/src/components/kanban-board/task-card.tsx
+++ b/apps/web/src/components/kanban-board/task-card.tsx
@@ -63,6 +63,10 @@ function TaskCard({ task, disableDragDrop = false }: TaskCardProps) {
   const { data: workspace } = useActiveWorkspace();
   const { mutateAsync: deleteTask } = useDeleteTask();
   const navigate = useNavigate();
+  const isTaskCompleted =
+    project?.columns?.find(
+      (column) => column.slug === task.status || column.id === task.status,
+    )?.isFinal ?? task.status === "done";
   const {
     showAssignees,
     showPriority,
@@ -261,15 +265,15 @@ function TaskCard({ task, disableDragDrop = false }: TaskCardProps) {
 
               {showDueDates && task.dueDate && (
                 <div
-                  className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate, task.status === "done")]}`}
+                  className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate, isTaskCompleted)]}`}
                 >
-                  {getDueDateStatus(task.dueDate, task.status === "done") ===
+                  {getDueDateStatus(task.dueDate, isTaskCompleted) ===
                     "overdue" && <CalendarX className="w-3 h-3" />}
-                  {getDueDateStatus(task.dueDate, task.status === "done") ===
+                  {getDueDateStatus(task.dueDate, isTaskCompleted) ===
                     "due-soon" && <CalendarClock className="w-3 h-3" />}
-                  {(getDueDateStatus(task.dueDate, task.status === "done") ===
+                  {(getDueDateStatus(task.dueDate, isTaskCompleted) ===
                     "far-future" ||
-                    getDueDateStatus(task.dueDate, task.status === "done") ===
+                    getDueDateStatus(task.dueDate, isTaskCompleted) ===
                       "no-due-date") && <Calendar className="w-3 h-3" />}
                   <span>{format(new Date(task.dueDate), "MMM d")}</span>
                 </div>

--- a/apps/web/src/components/kanban-board/task-card.tsx
+++ b/apps/web/src/components/kanban-board/task-card.tsx
@@ -261,18 +261,16 @@ function TaskCard({ task, disableDragDrop = false }: TaskCardProps) {
 
               {showDueDates && task.dueDate && (
                 <div
-                  className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                  className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate, task.status === "done")]}`}
                 >
-                  {getDueDateStatus(task.dueDate) === "overdue" && (
-                    <CalendarX className="w-3 h-3" />
-                  )}
-                  {getDueDateStatus(task.dueDate) === "due-soon" && (
-                    <CalendarClock className="w-3 h-3" />
-                  )}
-                  {(getDueDateStatus(task.dueDate) === "far-future" ||
-                    getDueDateStatus(task.dueDate) === "no-due-date") && (
-                    <Calendar className="w-3 h-3" />
-                  )}
+                  {getDueDateStatus(task.dueDate, task.status === "done") ===
+                    "overdue" && <CalendarX className="w-3 h-3" />}
+                  {getDueDateStatus(task.dueDate, task.status === "done") ===
+                    "due-soon" && <CalendarClock className="w-3 h-3" />}
+                  {(getDueDateStatus(task.dueDate, task.status === "done") ===
+                    "far-future" ||
+                    getDueDateStatus(task.dueDate, task.status === "done") ===
+                      "no-due-date") && <Calendar className="w-3 h-3" />}
                   <span>{format(new Date(task.dueDate), "MMM d")}</span>
                 </div>
               )}

--- a/apps/web/src/components/list-view/task-row.tsx
+++ b/apps/web/src/components/list-view/task-row.tsx
@@ -333,18 +333,16 @@ function TaskRow({ task, projectSlug }: TaskRowProps) {
 
             {showDueDates && task.dueDate && (
               <div
-                className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded flex-shrink-0 ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded flex-shrink-0 ${dueDateStatusColors[getDueDateStatus(task.dueDate, task.status === "done")]}`}
               >
-                {getDueDateStatus(task.dueDate) === "overdue" && (
-                  <CalendarX className="w-3 h-3" />
-                )}
-                {getDueDateStatus(task.dueDate) === "due-soon" && (
-                  <CalendarClock className="w-3 h-3" />
-                )}
-                {(getDueDateStatus(task.dueDate) === "far-future" ||
-                  getDueDateStatus(task.dueDate) === "no-due-date") && (
-                  <Calendar className="w-3 h-3" />
-                )}
+                {getDueDateStatus(task.dueDate, task.status === "done") ===
+                  "overdue" && <CalendarX className="w-3 h-3" />}
+                {getDueDateStatus(task.dueDate, task.status === "done") ===
+                  "due-soon" && <CalendarClock className="w-3 h-3" />}
+                {(getDueDateStatus(task.dueDate, task.status === "done") ===
+                  "far-future" ||
+                  getDueDateStatus(task.dueDate, task.status === "done") ===
+                    "no-due-date") && <Calendar className="w-3 h-3" />}
                 <span>{format(new Date(task.dueDate), "MMM d")}</span>
               </div>
             )}

--- a/apps/web/src/components/list-view/task-row.tsx
+++ b/apps/web/src/components/list-view/task-row.tsx
@@ -64,6 +64,10 @@ function TaskRow({ task, projectSlug }: TaskRowProps) {
 
   const { project } = useProjectStore();
   const { data: workspace } = useActiveWorkspace();
+  const isTaskCompleted =
+    project?.columns?.find(
+      (column) => column.slug === task.status || column.id === task.status,
+    )?.isFinal ?? task.status === "done";
   const {
     showAssignees,
     showPriority,
@@ -333,15 +337,15 @@ function TaskRow({ task, projectSlug }: TaskRowProps) {
 
             {showDueDates && task.dueDate && (
               <div
-                className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded flex-shrink-0 ${dueDateStatusColors[getDueDateStatus(task.dueDate, task.status === "done")]}`}
+                className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded flex-shrink-0 ${dueDateStatusColors[getDueDateStatus(task.dueDate, isTaskCompleted)]}`}
               >
-                {getDueDateStatus(task.dueDate, task.status === "done") ===
+                {getDueDateStatus(task.dueDate, isTaskCompleted) ===
                   "overdue" && <CalendarX className="w-3 h-3" />}
-                {getDueDateStatus(task.dueDate, task.status === "done") ===
+                {getDueDateStatus(task.dueDate, isTaskCompleted) ===
                   "due-soon" && <CalendarClock className="w-3 h-3" />}
-                {(getDueDateStatus(task.dueDate, task.status === "done") ===
+                {(getDueDateStatus(task.dueDate, isTaskCompleted) ===
                   "far-future" ||
-                  getDueDateStatus(task.dueDate, task.status === "done") ===
+                  getDueDateStatus(task.dueDate, isTaskCompleted) ===
                     "no-due-date") && <Calendar className="w-3 h-3" />}
                 <span>{format(new Date(task.dueDate), "MMM d")}</span>
               </div>

--- a/apps/web/src/components/public-project/kanban-view.tsx
+++ b/apps/web/src/components/public-project/kanban-view.tsx
@@ -45,6 +45,7 @@ export function PublicKanbanView({
                         key={task.id}
                         task={task}
                         projectSlug={project.slug}
+                        isCompleted={column.isFinal}
                         onTaskClick={onTaskClick}
                       />
                     ))}

--- a/apps/web/src/components/public-project/list-view.tsx
+++ b/apps/web/src/components/public-project/list-view.tsx
@@ -35,6 +35,7 @@ export function PublicListView({ project, onTaskClick }: PublicListViewProps) {
                     key={task.id}
                     task={task}
                     projectSlug={project.slug}
+                    isCompleted={column.isFinal}
                     onTaskClick={onTaskClick}
                   />
                 ))}

--- a/apps/web/src/components/public-project/task-card.tsx
+++ b/apps/web/src/components/public-project/task-card.tsx
@@ -16,12 +16,14 @@ type PublicTaskCardProps = {
     externalLinks?: Array<ExternalLink>;
   };
   projectSlug: string;
+  isCompleted?: boolean;
   onTaskClick: (task: Task) => void;
 };
 
 export function PublicTaskCard({
   task,
   projectSlug,
+  isCompleted = false,
   onTaskClick,
 }: PublicTaskCardProps) {
   const labels = task.labels || [];
@@ -122,16 +124,16 @@ export function PublicTaskCard({
 
         {task.dueDate && (
           <div
-            className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+            className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate, isCompleted)]}`}
           >
-            {getDueDateStatus(task.dueDate) === "overdue" && (
+            {getDueDateStatus(task.dueDate, isCompleted) === "overdue" && (
               <CalendarX className="w-3 h-3" />
             )}
-            {getDueDateStatus(task.dueDate) === "due-soon" && (
+            {getDueDateStatus(task.dueDate, isCompleted) === "due-soon" && (
               <CalendarClock className="w-3 h-3" />
             )}
-            {(getDueDateStatus(task.dueDate) === "far-future" ||
-              getDueDateStatus(task.dueDate) === "no-due-date") && (
+            {(getDueDateStatus(task.dueDate, isCompleted) === "far-future" ||
+              getDueDateStatus(task.dueDate, isCompleted) === "no-due-date") && (
               <Calendar className="w-3 h-3" />
             )}
             <span>{formatDateShort(task.dueDate)}</span>

--- a/apps/web/src/components/public-project/task-detail-modal.tsx
+++ b/apps/web/src/components/public-project/task-detail-modal.tsx
@@ -29,6 +29,7 @@ type PublicTaskDetailModalProps = {
       })
     | null;
   projectSlug: string;
+  isCompleted?: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 };
@@ -36,6 +37,7 @@ type PublicTaskDetailModalProps = {
 export function PublicTaskDetailModal({
   task,
   projectSlug,
+  isCompleted = false,
   open,
   onOpenChange,
 }: PublicTaskDetailModalProps) {
@@ -124,16 +126,16 @@ export function PublicTaskDetailModal({
 
                 {task.dueDate && (
                   <div
-                    className={`flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-md ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                    className={`flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-md ${dueDateStatusColors[getDueDateStatus(task.dueDate, isCompleted)]}`}
                   >
-                    {getDueDateStatus(task.dueDate) === "overdue" && (
+                    {getDueDateStatus(task.dueDate, isCompleted) === "overdue" && (
                       <CalendarX className="w-3 h-3" />
                     )}
-                    {getDueDateStatus(task.dueDate) === "due-soon" && (
+                    {getDueDateStatus(task.dueDate, isCompleted) === "due-soon" && (
                       <CalendarClock className="w-3 h-3" />
                     )}
-                    {(getDueDateStatus(task.dueDate) === "far-future" ||
-                      getDueDateStatus(task.dueDate) === "no-due-date") && (
+                    {(getDueDateStatus(task.dueDate, isCompleted) === "far-future" ||
+                      getDueDateStatus(task.dueDate, isCompleted) === "no-due-date") && (
                       <Calendar className="w-3 h-3" />
                     )}
                     <span>

--- a/apps/web/src/components/public-project/task-row.tsx
+++ b/apps/web/src/components/public-project/task-row.tsx
@@ -16,12 +16,14 @@ type PublicTaskRowProps = {
     externalLinks?: Array<ExternalLink>;
   };
   projectSlug: string;
+  isCompleted?: boolean;
   onTaskClick: (task: Task) => void;
 };
 
 export function PublicTaskRow({
   task,
   projectSlug,
+  isCompleted = false,
   onTaskClick,
 }: PublicTaskRowProps) {
   const { t } = useTranslation();
@@ -69,16 +71,16 @@ export function PublicTaskRow({
 
         {task.dueDate && (
           <div
-            className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+            className={`flex items-center gap-1 text-[10px] px-2 py-1 rounded ${dueDateStatusColors[getDueDateStatus(task.dueDate, isCompleted)]}`}
           >
-            {getDueDateStatus(task.dueDate) === "overdue" && (
+            {getDueDateStatus(task.dueDate, isCompleted) === "overdue" && (
               <CalendarX className="w-3 h-3" />
             )}
-            {getDueDateStatus(task.dueDate) === "due-soon" && (
+            {getDueDateStatus(task.dueDate, isCompleted) === "due-soon" && (
               <CalendarClock className="w-3 h-3" />
             )}
-            {(getDueDateStatus(task.dueDate) === "far-future" ||
-              getDueDateStatus(task.dueDate) === "no-due-date") && (
+            {(getDueDateStatus(task.dueDate, isCompleted) === "far-future" ||
+              getDueDateStatus(task.dueDate, isCompleted) === "no-due-date") && (
               <Calendar className="w-3 h-3" />
             )}
             <span>{formatDateShort(task.dueDate)}</span>

--- a/apps/web/src/components/task/task-properties-sidebar.tsx
+++ b/apps/web/src/components/task/task-properties-sidebar.tsx
@@ -98,7 +98,7 @@ export default function TaskPropertiesSidebar({
     task?.status ?? "",
     statusColumn?.name,
   );
-  const statusIsFinal = statusColumn?.isFinal ?? false;
+  const statusIsFinal = statusColumn?.isFinal ?? task?.status === "done";
   const statusIcon = statusColumn?.icon;
 
   const projectSlug = project?.slug;

--- a/apps/web/src/components/task/task-properties-sidebar.tsx
+++ b/apps/web/src/components/task/task-properties-sidebar.tsx
@@ -284,20 +284,20 @@ export default function TaskPropertiesSidebar({
                   >
                     {task.dueDate ? (
                       <>
-                        {getDueDateStatus(task.dueDate) === "overdue" && (
+                        {getDueDateStatus(task.dueDate, statusIsFinal) === "overdue" && (
                           <CalendarX
-                            className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                            className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate, statusIsFinal)]}`}
                           />
                         )}
-                        {getDueDateStatus(task.dueDate) === "due-soon" && (
+                        {getDueDateStatus(task.dueDate, statusIsFinal) === "due-soon" && (
                           <CalendarClock
-                            className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                            className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate, statusIsFinal)]}`}
                           />
                         )}
-                        {(getDueDateStatus(task.dueDate) === "far-future" ||
-                          getDueDateStatus(task.dueDate) === "no-due-date") && (
+                        {(getDueDateStatus(task.dueDate, statusIsFinal) === "far-future" ||
+                          getDueDateStatus(task.dueDate, statusIsFinal) === "no-due-date") && (
                           <Calendar
-                            className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                            className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate, statusIsFinal)]}`}
                           />
                         )}
                         <span className="text-xs font-semibold">
@@ -471,21 +471,21 @@ export default function TaskPropertiesSidebar({
                     >
                       {task.dueDate ? (
                         <>
-                          {getDueDateStatus(task.dueDate) === "overdue" && (
+                          {getDueDateStatus(task.dueDate, statusIsFinal) === "overdue" && (
                             <CalendarX
-                              className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                              className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate, statusIsFinal)]}`}
                             />
                           )}
-                          {getDueDateStatus(task.dueDate) === "due-soon" && (
+                          {getDueDateStatus(task.dueDate, statusIsFinal) === "due-soon" && (
                             <CalendarClock
-                              className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                              className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate, statusIsFinal)]}`}
                             />
                           )}
-                          {(getDueDateStatus(task.dueDate) === "far-future" ||
-                            getDueDateStatus(task.dueDate) ===
+                          {(getDueDateStatus(task.dueDate, statusIsFinal) === "far-future" ||
+                            getDueDateStatus(task.dueDate, statusIsFinal) ===
                               "no-due-date") && (
                             <Calendar
-                              className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                              className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate, statusIsFinal)]}`}
                             />
                           )}
                           <span className="text-xs font-semibold">
@@ -661,21 +661,21 @@ export default function TaskPropertiesSidebar({
                     >
                       {task.dueDate ? (
                         <>
-                          {getDueDateStatus(task.dueDate) === "overdue" && (
+                          {getDueDateStatus(task.dueDate, statusIsFinal) === "overdue" && (
                             <CalendarX
-                              className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                              className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate, statusIsFinal)]}`}
                             />
                           )}
-                          {getDueDateStatus(task.dueDate) === "due-soon" && (
+                          {getDueDateStatus(task.dueDate, statusIsFinal) === "due-soon" && (
                             <CalendarClock
-                              className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                              className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate, statusIsFinal)]}`}
                             />
                           )}
-                          {(getDueDateStatus(task.dueDate) === "far-future" ||
-                            getDueDateStatus(task.dueDate) ===
+                          {(getDueDateStatus(task.dueDate, statusIsFinal) === "far-future" ||
+                            getDueDateStatus(task.dueDate, statusIsFinal) ===
                               "no-due-date") && (
                             <Calendar
-                              className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate)]}`}
+                              className={`w-3.5 h-3.5 ${dueDateStatusColors[getDueDateStatus(task.dueDate, statusIsFinal)]}`}
                             />
                           )}
                           <span className="text-xs font-semibold">

--- a/apps/web/src/lib/due-date-status.test.ts
+++ b/apps/web/src/lib/due-date-status.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDueDateStatus } from "./due-date-status";
+
+describe("getDueDateStatus", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-02T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not mark completed tasks as overdue", () => {
+    expect(getDueDateStatus("2026-07-31T12:00:00Z", true)).toBe("far-future");
+  });
+
+  it("does not mark completed tasks as due soon", () => {
+    expect(getDueDateStatus("2026-08-03T12:00:00Z", true)).toBe("far-future");
+  });
+});

--- a/apps/web/src/lib/due-date-status.test.ts
+++ b/apps/web/src/lib/due-date-status.test.ts
@@ -12,10 +12,14 @@ describe("getDueDateStatus", () => {
   });
 
   it("does not mark completed tasks as overdue", () => {
-    expect(getDueDateStatus("2026-07-31T12:00:00Z", true)).toBe("far-future");
+    const status = getDueDateStatus("2026-07-31T12:00:00Z", true);
+
+    expect(status).toBe("far-future");
   });
 
   it("does not mark completed tasks as due soon", () => {
-    expect(getDueDateStatus("2026-08-03T12:00:00Z", true)).toBe("far-future");
+    const status = getDueDateStatus("2026-08-03T12:00:00Z", true);
+
+    expect(status).toBe("far-future");
   });
 });

--- a/apps/web/src/lib/due-date-status.ts
+++ b/apps/web/src/lib/due-date-status.ts
@@ -4,8 +4,12 @@ export type DueDateStatus =
   | "far-future"
   | "no-due-date";
 
-export function getDueDateStatus(dueDate: string | null): DueDateStatus {
+export function getDueDateStatus(
+  dueDate: string | null,
+  isCompleted = false,
+): DueDateStatus {
   if (!dueDate) return "no-due-date";
+  if (isCompleted) return "far-future";
 
   const now = new Date();
   const due = new Date(dueDate);

--- a/apps/web/src/routes/public-project.$projectId.tsx
+++ b/apps/web/src/routes/public-project.$projectId.tsx
@@ -144,6 +144,13 @@ function RouteComponent() {
         <PublicTaskDetailModal
           task={selectedTask}
           projectSlug={project.slug}
+          isCompleted={
+            project.columns?.find(
+              (column) =>
+                column.slug === selectedTask?.status ||
+                column.id === selectedTask?.status,
+            )?.isFinal ?? false
+          }
           open={isTaskModalOpen}
           onOpenChange={handleTaskModalClose}
         />

--- a/apps/web/src/routes/public-project.$projectId.tsx
+++ b/apps/web/src/routes/public-project.$projectId.tsx
@@ -149,7 +149,7 @@ function RouteComponent() {
               (column) =>
                 column.slug === selectedTask?.status ||
                 column.id === selectedTask?.status,
-            )?.isFinal ?? false
+            )?.isFinal ?? selectedTask?.status === "done"
           }
           open={isTaskModalOpen}
           onOpenChange={handleTaskModalClose}


### PR DESCRIPTION
## Summary
- Treat completed tasks as the neutral due-date state so Done-column cards no longer show overdue/due-soon warning styling.
- Apply the same due-date status call path in the authenticated web board/list views and public site project views.
- Add a focused Vitest regression for overdue and due-soon completed tasks.

## Why
Closes #1465. Done tasks can keep historical due dates, but those dates should not continue to look actionable/overdue after completion.

## Test plan
- [x] RED: `pnpm --filter @kaneo/web test -- due-date-status.test.ts` failed before the fix with `expected 'overdue' to be 'far-future'` and `expected 'due-soon' to be 'far-future'`.
- [x] GREEN: `pnpm --filter @kaneo/web test -- due-date-status.test.ts` — 14 files / 36 tests passed.
- [x] `pnpm exec biome check --write apps/web/src/lib/due-date-status.ts apps/web/src/lib/due-date-status.test.ts apps/web/src/components/kanban-board/task-card.tsx apps/web/src/components/list-view/task-row.tsx apps/site/lib/due-date-status.ts apps/site/components/project-task-card.tsx apps/site/components/project-private-list-view.tsx` — checked 7 files, no fixes applied.
- [x] `pnpm --filter @kaneo/site build` — compiled, typed, and exported successfully.
- [x] `pnpm --filter @kaneo/web build` — Vite production build succeeded (existing large-chunk warning only).
- [x] `git diff --check` — passed.

Note: `pnpm --filter @kaneo/web typecheck` is currently blocked by existing unrelated type errors outside this change (for example `apps/api/src/auth.ts`, `apps/api/src/index.ts`, and existing web test/type definitions). The targeted web build and regression test above pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completed tasks with due dates no longer appear overdue or due soon.
  * Task cards, list views, detail views, and sidebars now show appropriate due-date colors and calendar icons for completed tasks.
  * Completion status consistently reflects final workflow columns across task views.

* **Tests**
  * Added coverage verifying completed tasks are treated as having no imminent due date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->