### PR TITLE
fix: prevent task number gaps during partial import failures

### DIFF
--- a/apps/api/src/task/controllers/import-tasks.ts
+++ b/apps/api/src/task/controllers/import-tasks.ts
@@ -8,7 +8,7 @@ import {
   coerceStatus,
   getValidTaskStatuses,
 } from "../validate-task-fields";
-import claimTaskNumbers from "./claim-task-numbers";
+import { claimTaskNumber } from "./claim-task-numbers";
 
 export type ImportTask = {
   title: string;
@@ -35,10 +35,6 @@ async function importTasks(
     });
   }
 
-  let taskNumber =
-    tasksToImport.length > 0
-      ? (await claimTaskNumbers(projectId, tasksToImport.length)) - 1
-      : 0;
   const validStatuses = await getValidTaskStatuses(projectId);
 
   const results = [];
@@ -61,21 +57,29 @@ async function importTasks(
         ),
       });
 
-      const [createdTask] = await db
-        .insert(taskTable)
-        .values({
-          projectId,
-          userId: taskData.userId || null,
-          title: taskData.title,
-          status,
-          columnId: column?.id ?? null,
-          startDate: taskData.startDate ? new Date(taskData.startDate) : null,
-          dueDate: taskData.dueDate ? new Date(taskData.dueDate) : null,
-          description: taskData.description || "",
-          priority,
-          number: ++taskNumber,
-        })
-        .returning();
+      const createdTask = await db.transaction(async (tx) => {
+        const taskNumber = await claimTaskNumber(projectId, tx);
+
+        const [task] = await tx
+          .insert(taskTable)
+          .values({
+            projectId,
+            userId: taskData.userId || null,
+            title: taskData.title,
+            status,
+            columnId: column?.id ?? null,
+            startDate: taskData.startDate
+              ? new Date(taskData.startDate)
+              : null,
+            dueDate: taskData.dueDate ? new Date(taskData.dueDate) : null,
+            description: taskData.description || "",
+            priority,
+            number: taskNumber,
+          })
+          .returning();
+
+        return task;
+      });
 
       if (createdTask) {
         await publishEvent("task.created", {

--- a/apps/api/src/task/controllers/import-tasks.ts
+++ b/apps/api/src/task/controllers/import-tasks.ts
@@ -68,9 +68,7 @@ async function importTasks(
             title: taskData.title,
             status,
             columnId: column?.id ?? null,
-            startDate: taskData.startDate
-              ? new Date(taskData.startDate)
-              : null,
+            startDate: taskData.startDate ? new Date(taskData.startDate) : null,
             dueDate: taskData.dueDate ? new Date(taskData.dueDate) : null,
             description: taskData.description || "",
             priority,


### PR DESCRIPTION
## Problem

`importTasks()` pre-claimed ALL task numbers upfront via `claimTaskNumbers(projectId, tasksToImport.length)` before inserting tasks one-by-one. If any individual task insert failed (caught in the try/catch), the claimed task number for that slot was permanently wasted - creating gaps in the task numbering sequence.

**Example:** Importing 10 tasks where 3 fail means task numbers jump from N to N+10, but only 7 tasks exist. Numbers at the failed positions are gone forever.

## Root Cause

`claimTaskNumbers()` was called once before the loop, pre-allocating a contiguous block. Each failed insert consumed a number that could never be reclaimed since the claim had already committed.

## Fix

Wrap each task insert in its own `db.transaction()` with `claimTaskNumber()` called **inside** the transaction. If the insert fails, the transaction rolls back and the number is never claimed.

## Changes

- `apps/api/src/task/controllers/import-tasks.ts`: Moved from batch `claimTaskNumbers()` to per-task `claimTaskNumber()` inside individual transactions.

## Testing

- Verified that successful imports maintain contiguous numbering
- Verified that failed imports do not consume task numbers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task-number assignment during task imports.
  * Ensured each imported task receives a unique number as part of its database transaction, reducing the risk of numbering conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->