### PR TITLE
fix: include labels in task export

### DIFF
--- a/apps/api/src/task/controllers/export-tasks.ts
+++ b/apps/api/src/task/controllers/export-tasks.ts
@@ -1,7 +1,12 @@
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import db from "../../database";
-import { projectTable, taskTable, userTable } from "../../database/schema";
+import {
+  labelTable,
+  projectTable,
+  taskTable,
+  userTable,
+} from "../../database/schema";
 
 async function exportTasks(projectId: string) {
   const project = await db.query.projectTable.findFirst({
@@ -35,6 +40,37 @@ async function exportTasks(projectId: string) {
     .where(eq(taskTable.projectId, projectId))
     .orderBy(taskTable.position);
 
+  const taskIds = tasks.map((task) => task.id);
+
+  const labelsData =
+    taskIds.length > 0
+      ? await db
+          .select({
+            id: labelTable.id,
+            name: labelTable.name,
+            color: labelTable.color,
+            taskId: labelTable.taskId,
+          })
+          .from(labelTable)
+          .where(inArray(labelTable.taskId, taskIds))
+      : [];
+
+  const taskLabelsMap = new Map<
+    string,
+    Array<{ name: string; color: string }>
+  >();
+  for (const label of labelsData) {
+    if (label.taskId) {
+      if (!taskLabelsMap.has(label.taskId)) {
+        taskLabelsMap.set(label.taskId, []);
+      }
+      taskLabelsMap.get(label.taskId)?.push({
+        name: label.name,
+        color: label.color,
+      });
+    }
+  }
+
   return {
     project: {
       name: project.name,
@@ -50,6 +86,7 @@ async function exportTasks(projectId: string) {
       dueDate: task.dueDate ? new Date(task.dueDate).toISOString() : null,
       startDate: task.startDate ? new Date(task.startDate).toISOString() : null,
       userId: task.userId || null,
+      labels: taskLabelsMap.get(task.id) || [],
     })),
   };
 }


### PR DESCRIPTION
## Problem

The `exportTasks()` function exports task fields (title, description, status, priority, dates, userId) but **completely omits labels**. When users export tasks and re-import them, all label assignments are permanently lost - a silent data integrity issue.

The `get-tasks.ts` controller already fetches labels correctly (via `inArray` query on `labelTable`), but the export controller did not follow the same pattern.

## Impact

Any export/import round-trip permanently destroys all label data. Users with carefully organized labeling systems would lose all their categorization with no way to recover it.

## Fix

Query labels for all exported tasks using the same batch pattern as `get-tasks.ts`:
1. Collect all task IDs from the export query
2. Batch-fetch labels via `inArray(labelTable.taskId, taskIds)`
3. Build a `taskId -> labels` map
4. Include the `labels` array in each exported task object

## Changes

- `apps/api/src/task/controllers/export-tasks.ts`:
  - Added `labelTable` import and `inArray` from drizzle-orm
  - Added label query after task fetch
  - Built taskLabelsMap for efficient lookup
  - Added `labels` field to each exported task

## Testing

- Verified exported JSON now includes `labels: [{name, color}]` for each task
- Labels with no tasks return empty array `[]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task exports now include associated labels, including each label’s name and color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->