### PR TITLE
fix: make SMTP authentication optional for unauthenticated relays

### DIFF
--- a/apps/api/src/utils/get-settings.ts
+++ b/apps/api/src/utils/get-settings.ts
@@ -14,9 +14,7 @@ function getSettings() {
     hasSmtp:
       Boolean(process.env.SMTP_HOST) &&
       Boolean(process.env.SMTP_PORT) &&
-      Boolean(process.env.SMTP_SECURE) &&
-      Boolean(process.env.SMTP_USER) &&
-      Boolean(process.env.SMTP_PASSWORD),
+      Boolean(process.env.SMTP_SECURE),
     hasGithubSignIn: isGithubSsoConfigured(),
     hasGoogleSignIn:
       Boolean(process.env.GOOGLE_CLIENT_ID) &&

--- a/packages/email/src/send-email.tsx
+++ b/packages/email/src/send-email.tsx
@@ -17,14 +17,16 @@ import WorkspaceInvitationEmail, {
 
 config();
 
+const smtpAuth =
+  process.env.SMTP_USER && process.env.SMTP_PASSWORD
+    ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASSWORD }
+    : undefined;
+
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,
   secure: process.env.SMTP_SECURE !== "false",
   port: Number(process.env.SMTP_PORT),
-  auth: {
-    user: process.env.SMTP_USER,
-    pass: process.env.SMTP_PASSWORD,
-  },
+  auth: smtpAuth,
   requireTLS: process.env.SMTP_REQUIRE_TLS === "true",
   ignoreTLS: process.env.SMTP_IGNORE_TLS === "true",
 });


### PR DESCRIPTION
Fixes #1419

## Summary
SMTP authentication is forced even for unauthenticated relays.

## Changes
- `packages/email/src/send-email.tsx`: Only include `auth` when SMTP_USER and SMTP_PASSWORD are set
- `apps/api/src/utils/get-settings.ts`: Remove SMTP_USER/SMTP_PASSWORD from hasSmtp requirement

## Agent Disclosure
This PR was authored with AI agent assistance (Hermes Agent).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMTP configuration to support email delivery without authentication credentials when the mail server does not require them.
  * SMTP authentication is now enabled only when both a username and password are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->