### PR TITLE
perf(web): avoid per-task kanban metadata requests

### DIFF
--- a/apps/web/src/components/kanban-board/task-card.tsx
+++ b/apps/web/src/components/kanban-board/task-card.tsx
@@ -27,7 +27,6 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/preview-card";
 import { useDeleteTask } from "@/hooks/mutations/task/use-delete-task";
-import useExternalLinks from "@/hooks/queries/external-link/use-external-links";
 import useActiveWorkspace from "@/hooks/queries/workspace/use-active-workspace";
 import { useGetActiveWorkspaceUsers } from "@/hooks/queries/workspace-users/use-get-active-workspace-users";
 import { dueDateStatusColors, getDueDateStatus } from "@/lib/due-date-status";
@@ -42,7 +41,7 @@ import type Task from "@/types/task";
 import { Button } from "../ui/button";
 import { ContextMenu, ContextMenuTrigger } from "../ui/context-menu";
 import TaskCardContextMenuContent from "./task-card-context-menu/task-card-context-menu-content";
-import TaskCardLabels from "./task-labels";
+import { TaskLabels } from "./task-labels";
 
 type TaskCardProps = {
   task: Task;
@@ -71,15 +70,15 @@ function TaskCard({ task, disableDragDrop = false }: TaskCardProps) {
     showTaskNumbers,
   } = useUserPreferencesStore();
   const [isDeleteTaskModalOpen, setIsDeleteTaskModalOpen] = useState(false);
-  const { data: externalLinks } = useExternalLinks(task.id);
   const { toggleSelection, isSelected, isFocused } = useBulkSelectionStore();
   const isTaskSelected = isSelected(task.id);
   const isTaskFocused = isFocused(task.id);
 
   const pullRequests = useMemo(() => {
-    if (!externalLinks) return [];
-    return externalLinks.filter((link) => link.resourceType === "pull_request");
-  }, [externalLinks]);
+    return (task.externalLinks ?? []).filter(
+      (link) => link.resourceType === "pull_request",
+    );
+  }, [task.externalLinks]);
 
   const getPRInfo = (pr: (typeof pullRequests)[number]) => {
     const isMerged = pr.metadata?.merged === true;
@@ -248,7 +247,7 @@ function TaskCard({ task, disableDragDrop = false }: TaskCardProps) {
 
             {showLabels && (
               <div className="mb-2.5">
-                <TaskCardLabels taskId={task.id} />
+                <TaskLabels labels={task.labels ?? []} />
               </div>
             )}
 

--- a/apps/web/src/components/kanban-board/task-labels.test.tsx
+++ b/apps/web/src/components/kanban-board/task-labels.test.tsx
@@ -1,0 +1,25 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TaskLabels } from "./task-labels";
+
+const useGetLabelsByTask = vi.fn();
+
+vi.mock("@/hooks/queries/label/use-get-labels-by-task", () => ({
+  default: (...args: unknown[]) => useGetLabelsByTask(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  useGetLabelsByTask.mockReset();
+});
+
+describe("TaskLabels", () => {
+  it("renders labels supplied by the task without fetching them", () => {
+    render(
+      <TaskLabels labels={[{ id: "label-1", name: "Bug", color: "red" }]} />,
+    );
+
+    expect(screen.getByText("Bug")).toBeVisible();
+    expect(useGetLabelsByTask).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/kanban-board/task-labels.tsx
+++ b/apps/web/src/components/kanban-board/task-labels.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import useGetLabelsByTask from "@/hooks/queries/label/use-get-labels-by-task";
+import type Task from "@/types/task";
 
 const labelColors = [
   { value: "gray", label: "Stone", color: "var(--color-stone-500)" },
@@ -32,9 +33,11 @@ function validColor(value: string): string {
   return "var(--color-neutral-400)";
 }
 
-function TaskCardLabels({ taskId }: { taskId: string }) {
-  const { data: labels = [] } = useGetLabelsByTask(taskId);
-
+export function TaskLabels({
+  labels,
+}: {
+  labels: NonNullable<Task["labels"]>;
+}) {
   if (!labels.length) return null;
 
   return (
@@ -56,6 +59,12 @@ function TaskCardLabels({ taskId }: { taskId: string }) {
       ))}
     </div>
   );
+}
+
+function TaskCardLabels({ taskId }: { taskId: string }) {
+  const { data: labels = [] } = useGetLabelsByTask(taskId);
+
+  return <TaskLabels labels={labels} />;
 }
 
 export default TaskCardLabels;


### PR DESCRIPTION
## Summary
- render Kanban labels from task data already returned by the project tasks endpoint
- render pull-request badges from task external links instead of one query per card
- keep the existing query-backed label component for list and backlog views

## Validation
- `pnpm --filter @kaneo/web test` (14 files, 35 tests)
- `pnpm --filter @kaneo/web build`
- `biome check` on changed files

The workspace-wide typecheck still reports pre-existing API and generated-client errors unrelated to this change.

Refs #1422 (board view only; list-view per-row requests and project-list payload remain, see #1423)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task cards now display labels directly and more reliably.
  * Pull request links are shown correctly when available, with improved handling when none exist.

* **Improvements**
  * Label display is now reusable across task views while preserving existing colors and badge styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
