### PR TITLE
feat(web): let admins copy a workspace invitation link

### DIFF
--- a/apps/web/src/components/team/invitation-link-field.test.tsx
+++ b/apps/web/src/components/team/invitation-link-field.test.tsx
@@ -1,0 +1,74 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import InvitationLinkField from "./invitation-link-field";
+
+const copyToClipboard = vi.fn();
+const success = vi.fn();
+const error = vi.fn();
+
+vi.mock("@/lib/copy-to-clipboard", () => ({
+  copyToClipboard: (text: string) => copyToClipboard(text),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    success: (msg: string) => success(msg),
+    error: (msg: string) => error(msg),
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("InvitationLinkField", () => {
+  it("shows the full accept URL so it can be read and copied by hand", () => {
+    render(<InvitationLinkField invitationId="inv-1" />);
+
+    expect(screen.getByRole("textbox")).toHaveValue(
+      `${window.location.origin}/invitation/accept/inv-1`,
+    );
+  });
+
+  it("copies the link and confirms it", async () => {
+    copyToClipboard.mockResolvedValue(true);
+    render(<InvitationLinkField invitationId="inv-1" />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(copyToClipboard).toHaveBeenCalledWith(
+      `${window.location.origin}/invitation/accept/inv-1`,
+    );
+    await waitFor(() =>
+      expect(success).toHaveBeenCalledWith("team:invitations.linkCopied"),
+    );
+    expect(screen.getByRole("button")).toHaveTextContent(
+      "team:invitations.linkCopied",
+    );
+  });
+
+  it("selects the input and tells the user to copy by hand when copying fails", async () => {
+    copyToClipboard.mockResolvedValue(false);
+    render(<InvitationLinkField invitationId="inv-1" />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    await waitFor(() =>
+      expect(error).toHaveBeenCalledWith("team:invitations.copyFailed"),
+    );
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+});

--- a/apps/web/src/components/team/invitation-link-field.tsx
+++ b/apps/web/src/components/team/invitation-link-field.tsx
@@ -1,0 +1,51 @@
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useCopyInvitationLink } from "@/hooks/use-copy-invitation-link";
+import { buildInvitationLink } from "@/lib/invitation-link";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+
+type Props = {
+  invitationId: string;
+};
+
+function InvitationLinkField({ invitationId }: Props) {
+  const { t } = useTranslation();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { copy, copied } = useCopyInvitationLink();
+
+  return (
+    <div className="flex items-center gap-2">
+      <Input
+        ref={inputRef}
+        value={buildInvitationLink(invitationId)}
+        readOnly
+        aria-label={t("team:invitations.linkLabel")}
+        className="font-mono text-xs"
+        onFocus={(event) => event.currentTarget.select()}
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="shrink-0 gap-1.5"
+        onClick={() => copy(invitationId, inputRef.current)}
+      >
+        {copied ? (
+          <>
+            <CheckIcon className="size-3 text-success-foreground" />
+            {t("team:invitations.linkCopied")}
+          </>
+        ) : (
+          <>
+            <CopyIcon className="size-3" />
+            {t("team:invitations.copyLink")}
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}
+
+export default InvitationLinkField;

--- a/apps/web/src/components/team/invite-team-member-modal.tsx
+++ b/apps/web/src/components/team/invite-team-member-modal.tsx
@@ -1,5 +1,6 @@
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { z } from "zod/v4";
@@ -26,6 +27,7 @@ import {
   FormMessage,
 } from "../ui/form";
 import { Input } from "../ui/input";
+import InvitationLinkField from "./invitation-link-field";
 
 type Props = {
   open: boolean;
@@ -46,6 +48,10 @@ function InviteTeamMemberModal({ open, onClose }: Props) {
   const workspaceId = workspace?.id;
   const { canInviteUsers } = useWorkspacePermission();
   const canInvite = canInviteUsers();
+  const [createdInvitation, setCreatedInvitation] = useState<{
+    id: string;
+    email: string;
+  } | null>(null);
 
   const form = useForm<TeamMemberFormValues>({
     resolver: standardSchemaResolver(teamMemberSchema),
@@ -67,12 +73,25 @@ function InviteTeamMemberModal({ open, onClose }: Props) {
       return;
     }
     try {
-      await mutateAsync({ email, workspaceId, role: "member" }); // TODO: role and email
+      const invitation = await mutateAsync({
+        email,
+        workspaceId,
+        role: "member",
+      }); // TODO: role and email
       await queryClient.refetchQueries({
         queryKey: ["workspace-users", workspaceId],
       });
 
       toast.success(t("team:inviteModal.success"));
+
+      // The link is the only delivery channel when SMTP is unconfigured, so the
+      // modal stays open on it instead of closing. If the API ever stops
+      // returning an id, fall back to the previous close-on-success behaviour.
+      if (invitation?.id) {
+        setCreatedInvitation({ id: invitation.id, email });
+        form.reset();
+        return;
+      }
 
       resetInviteTeamMember();
       onClose();
@@ -93,6 +112,7 @@ function InviteTeamMemberModal({ open, onClose }: Props) {
   };
 
   const resetAndCloseModal = () => {
+    setCreatedInvitation(null);
     resetInviteTeamMember();
     onClose();
   };
@@ -101,47 +121,69 @@ function InviteTeamMemberModal({ open, onClose }: Props) {
     <Dialog open={open} onOpenChange={resetAndCloseModal}>
       <DialogPopup className="w-full max-w-md">
         <DialogHeader>
-          <DialogTitle>{t("team:inviteModal.title")}</DialogTitle>
+          <DialogTitle>
+            {createdInvitation
+              ? t("team:inviteModal.createdTitle")
+              : t("team:inviteModal.title")}
+          </DialogTitle>
         </DialogHeader>
 
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="contents">
-            <DialogPanel>
-              <FormField
-                control={form.control}
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t("team:inviteModal.emailLabel")}</FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        placeholder={t("team:inviteModal.emailPlaceholder")}
-                        autoFocus
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+        {createdInvitation ? (
+          <>
+            <DialogPanel className="space-y-3">
+              <p className="text-sm text-muted-foreground">
+                {t("team:inviteModal.shareLinkDescription", {
+                  email: createdInvitation.email,
+                })}
+              </p>
+              <InvitationLinkField invitationId={createdInvitation.id} />
             </DialogPanel>
-
             <DialogFooter>
-              <DialogClose
-                render={<Button variant="outline" size="sm" type="button" />}
-              >
-                {t("common:actions.cancel")}
-              </DialogClose>
-              <Button
-                type="submit"
-                size="sm"
-                disabled={!workspaceId || !canInvite}
-              >
-                {t("team:inviteModal.sendInvitation")}
+              <Button size="sm" onClick={resetAndCloseModal}>
+                {t("team:inviteModal.done")}
               </Button>
             </DialogFooter>
-          </form>
-        </Form>
+          </>
+        ) : (
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="contents">
+              <DialogPanel>
+                <FormField
+                  control={form.control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t("team:inviteModal.emailLabel")}</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          placeholder={t("team:inviteModal.emailPlaceholder")}
+                          autoFocus
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </DialogPanel>
+
+              <DialogFooter>
+                <DialogClose
+                  render={<Button variant="outline" size="sm" type="button" />}
+                >
+                  {t("common:actions.cancel")}
+                </DialogClose>
+                <Button
+                  type="submit"
+                  size="sm"
+                  disabled={!workspaceId || !canInvite}
+                >
+                  {t("team:inviteModal.sendInvitation")}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        )}
       </DialogPopup>
     </Dialog>
   );

--- a/apps/web/src/components/team/members-table.test.tsx
+++ b/apps/web/src/components/team/members-table.test.tsx
@@ -1,0 +1,164 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  WorkspaceUser,
+  WorkspaceUserInvitation,
+} from "@/types/workspace-user";
+import MembersTable from "./members-table";
+
+const copyToClipboard = vi.fn();
+const success = vi.fn();
+const error = vi.fn();
+
+vi.mock("@/lib/copy-to-clipboard", () => ({
+  copyToClipboard: (text: string) => copyToClipboard(text),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    success: (msg: string) => success(msg),
+    error: (msg: string) => error(msg),
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/lib/format", () => ({
+  formatDateMedium: () => "Sep 1, 2026",
+}));
+
+vi.mock("@/hooks/mutations/workspace-user/use-cancel-invitation", () => ({
+  default: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/mutations/workspace-user/use-delete-workspace-user", () => ({
+  default: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock(
+  "@/hooks/mutations/workspace-user/use-update-workspace-user-role",
+  () => ({
+    default: () => ({ mutateAsync: vi.fn() }),
+  }),
+);
+
+vi.mock("@/hooks/queries/workspace/use-workspace-roles", () => ({
+  default: () => ({ data: [] }),
+}));
+
+const canInviteUsers = vi.fn(() => true);
+
+vi.mock("@/hooks/use-workspace-permission", () => ({
+  useWorkspacePermission: () => ({
+    canManageTeam: () => true,
+    canRemoveMembers: () => true,
+    canInviteUsers: () => canInviteUsers(),
+  }),
+}));
+
+vi.mock("../providers/auth-provider/hooks/use-auth", () => ({
+  useAuth: () => ({ user: { id: "current-user" } }),
+}));
+
+beforeEach(() => {
+  canInviteUsers.mockReturnValue(true);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const pendingInvitation = {
+  id: "invite-1",
+  email: "invitee@example.com",
+  role: "member",
+  status: "pending",
+  expiresAt: "2026-09-01T00:00:00.000Z",
+} as unknown as WorkspaceUserInvitation;
+
+describe("MembersTable pending invitation row menu", () => {
+  it("copies the invitation link for that invitation when 'Copy link' is clicked", async () => {
+    copyToClipboard.mockResolvedValue(true);
+
+    render(
+      <MembersTable
+        workspaceId="workspace-1"
+        invitations={[pendingInvitation]}
+        users={[] as WorkspaceUser[]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "team:membersTable.ariaInvitationActions",
+      }),
+    );
+
+    fireEvent.click(
+      await screen.findByRole("menuitem", {
+        name: "team:invitations.copyLink",
+      }),
+    );
+
+    expect(copyToClipboard).toHaveBeenCalledWith(
+      `${window.location.origin}/invitation/accept/invite-1`,
+    );
+    await waitFor(() =>
+      expect(success).toHaveBeenCalledWith("team:invitations.linkCopied"),
+    );
+  });
+
+  it("still opens the cancel confirmation dialog instead of cancelling directly", async () => {
+    render(
+      <MembersTable
+        workspaceId="workspace-1"
+        invitations={[pendingInvitation]}
+        users={[] as WorkspaceUser[]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "team:membersTable.ariaInvitationActions",
+      }),
+    );
+
+    fireEvent.click(
+      await screen.findByRole("menuitem", {
+        name: "team:membersTable.cancelInvitation",
+      }),
+    );
+
+    expect(
+      await screen.findByText("team:membersTable.cancelDialogTitle"),
+    ).toBeVisible();
+    expect(copyToClipboard).not.toHaveBeenCalled();
+  });
+
+  it("hides the row menu entirely when the user lacks canInvite", () => {
+    canInviteUsers.mockReturnValue(false);
+
+    render(
+      <MembersTable
+        workspaceId="workspace-1"
+        invitations={[pendingInvitation]}
+        users={[] as WorkspaceUser[]}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", {
+        name: "team:membersTable.ariaInvitationActions",
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/components/team/members-table.tsx
+++ b/apps/web/src/components/team/members-table.tsx
@@ -1,11 +1,18 @@
 import { DEFAULT_ROLE_NAMES } from "@kaneo/permissions";
-import { EllipsisIcon, MailIcon, ShieldIcon, TrashIcon } from "lucide-react";
+import {
+  CopyIcon,
+  EllipsisIcon,
+  MailIcon,
+  ShieldIcon,
+  TrashIcon,
+} from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import useCancelInvitation from "@/hooks/mutations/workspace-user/use-cancel-invitation";
 import useDeleteWorkspaceUser from "@/hooks/mutations/workspace-user/use-delete-workspace-user";
 import useUpdateWorkspaceUserRole from "@/hooks/mutations/workspace-user/use-update-workspace-user-role";
 import useWorkspaceRoles from "@/hooks/queries/workspace/use-workspace-roles";
+import { useCopyInvitationLink } from "@/hooks/use-copy-invitation-link";
 import { useWorkspacePermission } from "@/hooks/use-workspace-permission";
 import { cn } from "@/lib/cn";
 import { formatDateMedium } from "@/lib/format";
@@ -97,6 +104,7 @@ function MembersTable({ workspaceId, invitations, users }: Props) {
   const { mutateAsync: cancelInvitation, isPending: isCancelling } =
     useCancelInvitation();
   const { mutateAsync: updateMemberRole } = useUpdateWorkspaceUserRole();
+  const { copy: copyInvitationLink } = useCopyInvitationLink();
   const { data: allWorkspaceRoles = [] } = useWorkspaceRoles(workspaceId);
   const { canManageTeam, canRemoveMembers, canInviteUsers } =
     useWorkspacePermission();
@@ -357,15 +365,36 @@ function MembersTable({ workspaceId, invitations, users }: Props) {
               </TableCell>
               <TableCell className="pe-6 py-3 text-right">
                 {canInvite ? (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => setInvitationToCancel(invitation)}
-                    className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                    aria-label={t("team:membersTable.ariaCancelInvitation")}
-                  >
-                    <TrashIcon className="size-4" />
-                  </Button>
+                  <Menu>
+                    <MenuTrigger
+                      render={
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 text-muted-foreground"
+                          aria-label={t(
+                            "team:membersTable.ariaInvitationActions",
+                          )}
+                        />
+                      }
+                    >
+                      <EllipsisIcon className="size-4" />
+                    </MenuTrigger>
+                    <MenuPopup align="end">
+                      <MenuItem
+                        onClick={() => copyInvitationLink(invitation.id)}
+                      >
+                        <CopyIcon className="size-4" />
+                        {t("team:invitations.copyLink")}
+                      </MenuItem>
+                      <MenuItem
+                        onClick={() => setInvitationToCancel(invitation)}
+                      >
+                        <TrashIcon className="size-4" />
+                        {t("team:membersTable.cancelInvitation")}
+                      </MenuItem>
+                    </MenuPopup>
+                  </Menu>
                 ) : null}
               </TableCell>
             </TableRow>

--- a/apps/web/src/hooks/use-copy-invitation-link.ts
+++ b/apps/web/src/hooks/use-copy-invitation-link.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { buildInvitationLink } from "@/lib/invitation-link";
+import { toast } from "@/lib/toast";
+
+const COPIED_RESET_MS = 2000;
+
+/**
+ * Copy behaviour shared by the invite modal and the members table row menu.
+ *
+ * `fallbackInput` is optional because the row menu has no input to select; when
+ * present and copying failed outright, the text is selected so Ctrl+C works.
+ */
+export function useCopyInvitationLink() {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  const copy = useCallback(
+    async (invitationId: string, fallbackInput?: HTMLInputElement | null) => {
+      const link = buildInvitationLink(invitationId);
+      const ok = await copyToClipboard(link);
+
+      if (!ok) {
+        fallbackInput?.select();
+        toast.error(t("team:invitations.copyFailed"));
+        return;
+      }
+
+      setCopied(true);
+      toast.success(t("team:invitations.linkCopied"));
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => setCopied(false), COPIED_RESET_MS);
+    },
+    [t],
+  );
+
+  return { copy, copied };
+}

--- a/apps/web/src/lib/copy-to-clipboard.test.ts
+++ b/apps/web/src/lib/copy-to-clipboard.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { copyToClipboard } from "./copy-to-clipboard";
+
+const originalClipboard = navigator.clipboard;
+const originalExecCommand = document.execCommand;
+
+afterEach(() => {
+  Object.defineProperty(navigator, "clipboard", {
+    value: originalClipboard,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(document, "execCommand", {
+    value: originalExecCommand,
+    configurable: true,
+    writable: true,
+  });
+  vi.restoreAllMocks();
+});
+
+function setClipboard(value: unknown) {
+  Object.defineProperty(navigator, "clipboard", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe("copyToClipboard", () => {
+  it("uses the async clipboard API when it is available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard({ writeText });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to execCommand when the clipboard API is missing", async () => {
+    // Plain-HTTP self-hosted instances land here: not a secure context.
+    setClipboard(undefined);
+    const textareaState: {
+      value?: string;
+      selectionStart?: number;
+      selectionEnd?: number;
+    } = {};
+    const execCommand = vi.fn(function (this: Document, _cmd: string) {
+      // Capture textarea state at the moment execCommand is called (before removal)
+      const textarea = document.querySelector("textarea");
+      if (textarea) {
+        textareaState.value = textarea.value;
+        textareaState.selectionStart = textarea.selectionStart;
+        textareaState.selectionEnd = textarea.selectionEnd;
+      }
+      return true;
+    });
+    Object.defineProperty(document, "execCommand", {
+      value: execCommand,
+      configurable: true,
+      writable: true,
+    });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    // Verify the textarea had the correct text and was selected at copy time
+    expect(textareaState.value).toBe("hello");
+    expect(textareaState.selectionStart).toBe(0);
+    expect(textareaState.selectionEnd).toBe("hello".length);
+  });
+
+  it("falls back to execCommand when the clipboard API rejects", async () => {
+    setClipboard({ writeText: vi.fn().mockRejectedValue(new Error("denied")) });
+    const textareaState: {
+      value?: string;
+      selectionStart?: number;
+      selectionEnd?: number;
+    } = {};
+    const execCommand = vi.fn(function (this: Document, _cmd: string) {
+      // Capture textarea state at the moment execCommand is called
+      const textarea = document.querySelector("textarea");
+      if (textarea) {
+        textareaState.value = textarea.value;
+        textareaState.selectionStart = textarea.selectionStart;
+        textareaState.selectionEnd = textarea.selectionEnd;
+      }
+      return true;
+    });
+    Object.defineProperty(document, "execCommand", {
+      value: execCommand,
+      configurable: true,
+      writable: true,
+    });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    // Verify the textarea had the correct text and was selected at copy time
+    expect(textareaState.value).toBe("hello");
+    expect(textareaState.selectionStart).toBe(0);
+    expect(textareaState.selectionEnd).toBe("hello".length);
+  });
+
+  it("reports failure when neither path works", async () => {
+    setClipboard(undefined);
+    Object.defineProperty(document, "execCommand", {
+      value: vi.fn().mockReturnValue(false),
+      configurable: true,
+      writable: true,
+    });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(false);
+  });
+
+  it("leaves no scratch node behind", async () => {
+    setClipboard(undefined);
+    Object.defineProperty(document, "execCommand", {
+      value: vi.fn().mockReturnValue(true),
+      configurable: true,
+      writable: true,
+    });
+
+    await copyToClipboard("hello");
+    expect(document.querySelectorAll("textarea")).toHaveLength(0);
+  });
+
+  it("cleans up the scratch node when execCommand throws", async () => {
+    setClipboard(undefined);
+    Object.defineProperty(document, "execCommand", {
+      value: vi.fn(() => {
+        throw new Error("copy operation failed");
+      }),
+      configurable: true,
+      writable: true,
+    });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(false);
+    // Verify the scratch node was removed despite the exception
+    expect(document.querySelectorAll("textarea")).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/copy-to-clipboard.ts
+++ b/apps/web/src/lib/copy-to-clipboard.ts
@@ -1,0 +1,39 @@
+/**
+ * Copies text to the clipboard, degrading gracefully outside secure contexts.
+ *
+ * navigator.clipboard is only defined over HTTPS or on localhost. A self-hosted
+ * instance reached over plain HTTP — a normal deployment for this project — has
+ * no such API, so the deprecated execCommand path is the only one that works
+ * there and is kept deliberately.
+ *
+ * Returns whether the text made it to the clipboard by either route.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Permission denied or a transient failure — fall through to the legacy path.
+    }
+  }
+
+  const scratch = document.createElement("textarea");
+  scratch.value = text;
+  scratch.setAttribute("readonly", "");
+  // Kept off-screen rather than hidden: execCommand ignores nodes that are not
+  // rendered, so display:none or visibility:hidden would break the copy.
+  scratch.style.position = "fixed";
+  scratch.style.top = "-9999px";
+  scratch.style.opacity = "0";
+  document.body.appendChild(scratch);
+
+  try {
+    scratch.select();
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    scratch.remove();
+  }
+}

--- a/apps/web/src/lib/invitation-link.test.ts
+++ b/apps/web/src/lib/invitation-link.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { buildInvitationLink } from "./invitation-link";
+
+describe("buildInvitationLink", () => {
+  it("builds the accept route from the given origin", () => {
+    expect(buildInvitationLink("inv-1", "https://kaneo.example.com")).toBe(
+      "https://kaneo.example.com/invitation/accept/inv-1",
+    );
+  });
+
+  it("keeps a non-standard port", () => {
+    expect(buildInvitationLink("inv-2", "http://192.168.1.10:5173")).toBe(
+      "http://192.168.1.10:5173/invitation/accept/inv-2",
+    );
+  });
+
+  it("does not double the separator when the origin has a trailing slash", () => {
+    expect(buildInvitationLink("inv-3", "https://kaneo.example.com/")).toBe(
+      "https://kaneo.example.com/invitation/accept/inv-3",
+    );
+  });
+
+  it("falls back to the browser origin when none is given", () => {
+    // jsdom serves the suite from http://localhost:3000
+    expect(buildInvitationLink("inv-4")).toBe(
+      `${window.location.origin}/invitation/accept/inv-4`,
+    );
+  });
+});

--- a/apps/web/src/lib/invitation-link.ts
+++ b/apps/web/src/lib/invitation-link.ts
@@ -1,0 +1,16 @@
+/**
+ * Builds the public URL an invitee opens to accept a workspace invitation.
+ *
+ * The origin defaults to the browser's own origin rather than KANEO_CLIENT_URL:
+ * whoever copies the link is already reaching the app through a URL that works,
+ * while KANEO_CLIENT_URL is a server-side setting that can be stale or wrong on
+ * a self-hosted instance — producing a link the admin cannot notice is broken.
+ *
+ * The `origin` parameter exists so this stays testable without a DOM.
+ */
+export function buildInvitationLink(
+  invitationId: string,
+  origin: string = window.location.origin,
+): string {
+  return `${origin.replace(/\/+$/, "")}/invitation/accept/${invitationId}`;
+}

--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -1794,13 +1794,22 @@
 			"pageTitle": "Mitglieder",
 			"inviteMember": "Mitglied einladen"
 		},
+		"invitations": {
+			"linkLabel": "Invitation link",
+			"copyLink": "Copy link",
+			"linkCopied": "Invitation link copied",
+			"copyFailed": "Couldn't copy automatically. Select the link and press Ctrl+C."
+		},
 		"inviteModal": {
 			"title": "Teammitglied einladen",
 			"emailLabel": "E-Mail",
 			"emailPlaceholder": "kollege@firma.com",
 			"sendInvitation": "Einladung senden",
 			"success": "Einladung erfolgreich gesendet",
-			"error": "Teammitglied konnte nicht eingeladen werden"
+			"error": "Teammitglied konnte nicht eingeladen werden",
+			"createdTitle": "Invitation created",
+			"shareLinkDescription": "Share this link with {{email}} so they can join the workspace.",
+			"done": "Done"
 		},
 		"membersTable": {
 			"emptyTitle": "Noch keine Teammitglieder",
@@ -1823,7 +1832,8 @@
 			"removeSuccess": "Teammitglied erfolgreich entfernt",
 			"removeError": "Teammitglied konnte nicht entfernt werden",
 			"cancelInviteSuccess": "Einladung erfolgreich abgebrochen",
-			"cancelInviteError": "Einladung konnte nicht abgebrochen werden"
+			"cancelInviteError": "Einladung konnte nicht abgebrochen werden",
+			"ariaInvitationActions": "Invitation actions"
 		}
 	},
 	"publicProject": {

--- a/i18n/el-GR.json
+++ b/i18n/el-GR.json
@@ -1752,13 +1752,22 @@
 			"pageTitle": "Μέλη",
 			"inviteMember": "Πρόσκληση μέλους"
 		},
+		"invitations": {
+			"linkLabel": "Invitation link",
+			"copyLink": "Copy link",
+			"linkCopied": "Invitation link copied",
+			"copyFailed": "Couldn't copy automatically. Select the link and press Ctrl+C."
+		},
 		"inviteModal": {
 			"title": "Πρόσκληση μέλους ομάδας",
 			"emailLabel": "Email",
 			"emailPlaceholder": "colleague@company.com",
 			"sendInvitation": "Αποστολή πρόσκλησης",
 			"success": "Η πρόσκληση στάλθηκε με επιτυχία",
-			"error": "Αποτυχία πρόσκλησης μέλους ομάδας"
+			"error": "Αποτυχία πρόσκλησης μέλους ομάδας",
+			"createdTitle": "Invitation created",
+			"shareLinkDescription": "Share this link with {{email}} so they can join the workspace.",
+			"done": "Done"
 		},
 		"membersTable": {
 			"emptyTitle": "Δεν υπάρχουν ακόμα μέλη ομάδας",
@@ -1781,7 +1790,8 @@
 			"removeSuccess": "Το μέλος της ομάδας αφαιρέθηκε με επιτυχία",
 			"removeError": "Αποτυχία αφαίρεσης μέλους ομάδας",
 			"cancelInviteSuccess": "Η πρόσκληση ακυρώθηκε με επιτυχία",
-			"cancelInviteError": "Αποτυχία ακύρωσης πρόσκλησης"
+			"cancelInviteError": "Αποτυχία ακύρωσης πρόσκλησης",
+			"ariaInvitationActions": "Invitation actions"
 		}
 	},
 	"publicProject": {

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1964,7 +1964,11 @@
 		},
 		"invitations": {
 			"pendingBadge": "pending",
-			"expires": "Expires {{date}}"
+			"expires": "Expires {{date}}",
+			"linkLabel": "Invitation link",
+			"copyLink": "Copy link",
+			"linkCopied": "Invitation link copied",
+			"copyFailed": "Couldn't copy automatically. Select the link and press Ctrl+C."
 		},
 		"inviteModal": {
 			"title": "Invite Team Member",
@@ -1972,7 +1976,10 @@
 			"emailPlaceholder": "colleague@company.com",
 			"sendInvitation": "Send Invitation",
 			"success": "Invitation sent successfully",
-			"error": "Failed to invite team member"
+			"error": "Failed to invite team member",
+			"createdTitle": "Invitation created",
+			"shareLinkDescription": "Share this link with {{email}} so they can join the workspace.",
+			"done": "Done"
 		},
 		"membersTable": {
 			"emptyTitle": "No team members yet",
@@ -1985,6 +1992,7 @@
 			},
 			"memberRolePending": "{{role}} (Pending)",
 			"ariaCancelInvitation": "Cancel invitation",
+			"ariaInvitationActions": "Invitation actions",
 			"ariaRemoveMember": "Remove member",
 			"removeDialogTitle": "Remove Team Member?",
 			"removeDialogDescription": "Are you sure you want to remove {{name}} from the workspace? This action cannot be undone.",

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -1526,13 +1526,22 @@
 			"pageTitle": "Miembros",
 			"inviteMember": "Invitar miembro"
 		},
+		"invitations": {
+			"linkLabel": "Enlace de invitación",
+			"copyLink": "Copiar enlace",
+			"linkCopied": "Enlace de invitación copiado",
+			"copyFailed": "No se pudo copiar automáticamente. Seleccioná el enlace y presioná Ctrl+C."
+		},
 		"inviteModal": {
 			"title": "Invitar miembro al equipo",
 			"emailLabel": "Email",
 			"emailPlaceholder": "compi@company.com",
 			"sendInvitation": "Enviar invitación",
 			"success": "Invitación enviada correctamente",
-			"error": "Error al invitar miembro al equipo"
+			"error": "Error al invitar miembro al equipo",
+			"createdTitle": "Invitación creada",
+			"shareLinkDescription": "Compartí este enlace con {{email}} para que se una al espacio de trabajo.",
+			"done": "Listo"
 		},
 		"membersTable": {
 			"emptyTitle": "No hay miembros en el equipo aún",
@@ -1545,6 +1554,7 @@
 			},
 			"memberRolePending": "{{role}} (Pendiente)",
 			"ariaCancelInvitation": "Cancelar invitacion",
+			"ariaInvitationActions": "Acciones de invitación",
 			"ariaRemoveMember": "Eliminar miembro",
 			"removeDialogTitle": "¿Eliminar miembro del equipo?",
 			"removeDialogDescription": "¿Estás seguro de que quieres eliminar a {{name}} del espacio de trabajo? Esta acción no puede deshacerse.",

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -1766,7 +1766,11 @@
 		},
 		"invitations": {
 			"pendingBadge": "En attente",
-			"expires": "Expire {{date}}"
+			"expires": "Expire {{date}}",
+			"linkLabel": "Invitation link",
+			"copyLink": "Copy link",
+			"linkCopied": "Invitation link copied",
+			"copyFailed": "Couldn't copy automatically. Select the link and press Ctrl+C."
 		},
 		"inviteModal": {
 			"title": "Inviter un membre de l'équipe",
@@ -1774,7 +1778,10 @@
 			"emailPlaceholder": "collegue@entreprise.fr",
 			"sendInvitation": "Envoyer l'invitation",
 			"success": "Invitation envoyée avec succès",
-			"error": "Échec de l'envoi de l'invitation"
+			"error": "Échec de l'envoi de l'invitation",
+			"createdTitle": "Invitation created",
+			"shareLinkDescription": "Share this link with {{email}} so they can join the workspace.",
+			"done": "Done"
 		},
 		"membersTable": {
 			"emptyTitle": "Aucun membre de l'équipe pour le moment",
@@ -1799,7 +1806,8 @@
 			"cancelInviteSuccess": "Invitation annulée avec succès",
 			"cancelInviteError": "Échec de l'annulation de l'invitation",
 			"roleUpdateSuccess": "Rôle mis à jour",
-			"roleUpdateError": "Échec de la mise à jour du rôle"
+			"roleUpdateError": "Échec de la mise à jour du rôle",
+			"ariaInvitationActions": "Invitation actions"
 		}
 	},
 	"publicProject": {

--- a/i18n/id-ID.json
+++ b/i18n/id-ID.json
@@ -1900,13 +1900,22 @@
 			"pageTitle": "Anggota",
 			"inviteMember": "Undang anggota"
 		},
+		"invitations": {
+			"linkLabel": "Invitation link",
+			"copyLink": "Copy link",
+			"linkCopied": "Invitation link copied",
+			"copyFailed": "Couldn't copy automatically. Select the link and press Ctrl+C."
+		},
 		"inviteModal": {
 			"title": "Undang Anggota Tim",
 			"emailLabel": "Email",
 			"emailPlaceholder": "rekan@perusahaan.com",
 			"sendInvitation": "Kirim Undangan",
 			"success": "Undangan berhasil dikirim",
-			"error": "Gagal mengundang anggota tim"
+			"error": "Gagal mengundang anggota tim",
+			"createdTitle": "Invitation created",
+			"shareLinkDescription": "Share this link with {{email}} so they can join the workspace.",
+			"done": "Done"
 		},
 		"membersTable": {
 			"emptyTitle": "Belum ada anggota tim",
@@ -1931,7 +1940,8 @@
 			"cancelInviteSuccess": "Undangan berhasil dibatalkan",
 			"cancelInviteError": "Gagal membatalkan undangan",
 			"roleUpdateSuccess": "Peran diperbarui",
-			"roleUpdateError": "Gagal memperbarui peran"
+			"roleUpdateError": "Gagal memperbarui peran",
+			"ariaInvitationActions": "Invitation actions"
 		}
 	},
 	"publicProject": {

--- a/i18n/ko-KR.json
+++ b/i18n/ko-KR.json
@@ -1754,13 +1754,22 @@
 			"pageTitle": "멤버",
 			"inviteMember": "멤버 초대"
 		},
+		"invitations": {
+			"linkLabel": "Invitation link",
+			"copyLink": "Copy link",
+			"linkCopied": "Invitation link copied",
+			"copyFailed": "Couldn't copy automatically. Select the link and press Ctrl+C."
+		},
 		"inviteModal": {
 			"title": "팀 멤버 초대",
 			"emailLabel": "이메일",
 			"emailPlaceholder": "colleague@company.com",
 			"sendInvitation": "초대 전송",
 			"success": "초대가 전송되었습니다",
-			"error": "팀 멤버 초대에 실패했습니다"
+			"error": "팀 멤버 초대에 실패했습니다",
+			"createdTitle": "Invitation created",
+			"shareLinkDescription": "Share this link with {{email}} so they can join the workspace.",
+			"done": "Done"
 		},
 		"membersTable": {
 			"emptyTitle": "아직 팀 멤버가 없습니다",
@@ -1783,7 +1792,8 @@
 			"removeSuccess": "팀 멤버가 제거되었습니다",
 			"removeError": "팀 멤버 제거에 실패했습니다",
 			"cancelInviteSuccess": "초대가 취소되었습니다",
-			"cancelInviteError": "초대 취소에 실패했습니다"
+			"cancelInviteError": "초대 취소에 실패했습니다",
+			"ariaInvitationActions": "Invitation actions"
 		}
 	},
 	"publicProject": {

--- a/i18n/mk-MK.json
+++ b/i18n/mk-MK.json
@@ -1752,13 +1752,22 @@
 			"pageTitle": "Членови",
 			"inviteMember": "Покани член"
 		},
+		"invitations": {
+			"linkLabel": "Invitation link",
+			"copyLink": "Copy link",
+			"linkCopied": "Invitation link copied",
+			"copyFailed": "Couldn't copy automatically. Select the link and press Ctrl+C."
+		},
 		"inviteModal": {
 			"title": "Покани член на тим",
 			"emailLabel": "Е-пошта",
 			"emailPlaceholder": "kolega@kompanija.com",
 			"sendInvitation": "Испрати покана",
 			"success": "Поканата е успешно испратена",
-			"error": "Неуспешно поканување на член на тим"
+			"error": "Неуспешно поканување на член на тим",
+			"createdTitle": "Invitation created",
+			"shareLinkDescription": "Share this link with {{email}} so they can join the workspace.",
+			"done": "Done"
 		},
 		"membersTable": {
 			"emptyTitle": "Нема членови на тим засега",
@@ -1781,7 +1790,8 @@
 			"removeSuccess": "Членот на тимот е успешно отстранет",
 			"removeError": "Неуспешно отстранување на член на тим",
 			"cancelInviteSuccess": "Поканата е успешно откажана",
-			"cancelInviteError": "Неуспешно откажување на покана"
+			"cancelInviteError": "Неуспешно откажување на покана",
+			"ariaInvitationActions": "Invitation actions"
 		}
 	},
 	"publicProject": {

--- a/i18n/nl-NL.json
+++ b/i18n/nl-NL.json
@@ -1527,13 +1527,22 @@
 			"pageTitle": "Leden",
 			"inviteMember": "Lid uitnodigen"
 		},
+		"invitations": {
+			"linkLabel": "Invitation link",
+			"copyLink": "Copy link",
+			"linkCopied": "Invitation link copied",
+			"copyFailed": "Couldn't copy automatically. Select the link and press Ctrl+C."
+		},
 		"inviteModal": {
 			"title": "Teamlid uitnodigen",
 			"emailLabel": "E-mailadres",
 			"emailPlaceholder": "collega@bedrijf.nl",
 			"sendInvitation": "Uitnodiging versturen",
 			"success": "Uitnodiging succesvol verzonden",
-			"error": "Uitnodigen teamlid mislukt"
+			"error": "Uitnodigen teamlid mislukt",
+			"createdTitle": "Invitation created",
+			"shareLinkDescription": "Share this link with {{email}} so they can join the workspace.",
+			"done": "Done"
 		},
 		"membersTable": {
 			"emptyTitle": "Nog geen teamleden",
@@ -1556,7 +1565,8 @@
 			"removeSuccess": "Teamlid succesvol verwijderd",
 			"removeError": "Verwijderen teamlid mislukt",
 			"cancelInviteSuccess": "Uitnodiging succesvol geannuleerd",
-			"cancelInviteError": "Annuleren uitnodiging mislukt"
+			"cancelInviteError": "Annuleren uitnodiging mislukt",
+			"ariaInvitationActions": "Invitation actions"
 		}
 	},
 	"publicProject": {

--- a/i18n/ru-RU.json
+++ b/i18n/ru-RU.json
@@ -1795,13 +1795,22 @@
 			"pageTitle": "Участники",
 			"inviteMember": "Пригласить участника"
 		},
+		"invitations": {
+			"linkLabel": "Invitation link",
+			"copyLink": "Copy link",
+			"linkCopied": "Invitation link copied",
+			"copyFailed": "Couldn't copy automatically. Select the link and press Ctrl+C."
+		},
 		"inviteModal": {
 			"title": "Пригласить участника команды",
 			"emailLabel": "Электронная почта",
 			"emailPlaceholder": "colleague@company.com",
 			"sendInvitation": "Отправить приглашение",
 			"success": "Приглашение успешно отправлено",
-			"error": "Не удалось пригласить участника команды"
+			"error": "Не удалось пригласить участника команды",
+			"createdTitle": "Invitation created",
+			"shareLinkDescription": "Share this link with {{email}} so they can join the workspace.",
+			"done": "Done"
 		},
 		"membersTable": {
 			"emptyTitle": "Участников команды пока нет",
@@ -1824,7 +1833,8 @@
 			"removeSuccess": "Участник команды успешно удалён",
 			"removeError": "Не удалось удалить участника команды",
 			"cancelInviteSuccess": "Приглашение успешно отменено",
-			"cancelInviteError": "Не удалось отменить приглашение"
+			"cancelInviteError": "Не удалось отменить приглашение",
+			"ariaInvitationActions": "Invitation actions"
 		}
 	},
 	"publicProject": {

--- a/i18n/tr-TR.json
+++ b/i18n/tr-TR.json
@@ -1752,13 +1752,22 @@
 			"pageTitle": "Üyeler",
 			"inviteMember": "Üye davet et"
 		},
+		"invitations": {
+			"linkLabel": "Invitation link",
+			"copyLink": "Copy link",
+			"linkCopied": "Invitation link copied",
+			"copyFailed": "Couldn't copy automatically. Select the link and press Ctrl+C."
+		},
 		"inviteModal": {
 			"title": "Ekip Üyesi Davet Et",
 			"emailLabel": "E-posta",
 			"emailPlaceholder": "arkadas@sirket.com",
 			"sendInvitation": "Davet Gönder",
 			"success": "Davet başarıyla gönderildi",
-			"error": "Ekip üyesi davet edilemedi"
+			"error": "Ekip üyesi davet edilemedi",
+			"createdTitle": "Invitation created",
+			"shareLinkDescription": "Share this link with {{email}} so they can join the workspace.",
+			"done": "Done"
 		},
 		"membersTable": {
 			"emptyTitle": "Henüz ekip üyesi yok",
@@ -1783,7 +1792,8 @@
 			"cancelInviteSuccess": "Davet başarıyla iptal edildi",
 			"cancelInviteError": "Davet iptal edilemedi",
 			"roleUpdateSuccess": "Rol güncellendi",
-			"roleUpdateError": "Rol güncellenemedi"
+			"roleUpdateError": "Rol güncellenemedi",
+			"ariaInvitationActions": "Invitation actions"
 		}
 	},
 	"publicProject": {

--- a/i18n/uk-UA.json
+++ b/i18n/uk-UA.json
@@ -1753,13 +1753,22 @@
 			"pageTitle": "Учасники",
 			"inviteMember": "Запросити учасника"
 		},
+		"invitations": {
+			"linkLabel": "Invitation link",
+			"copyLink": "Copy link",
+			"linkCopied": "Invitation link copied",
+			"copyFailed": "Couldn't copy automatically. Select the link and press Ctrl+C."
+		},
 		"inviteModal": {
 			"title": "Запросити учасника команди",
 			"emailLabel": "Електронна пошта",
 			"emailPlaceholder": "colleague@company.com",
 			"sendInvitation": "Надіслати запрошення",
 			"success": "Запрошення успішно надіслано",
-			"error": "Не вдалося запросити учасника команди"
+			"error": "Не вдалося запросити учасника команди",
+			"createdTitle": "Invitation created",
+			"shareLinkDescription": "Share this link with {{email}} so they can join the workspace.",
+			"done": "Done"
 		},
 		"membersTable": {
 			"emptyTitle": "Учасників команди ще немає",
@@ -1782,7 +1791,8 @@
 			"removeSuccess": "Учасника команди успішно видалено",
 			"removeError": "Не вдалося видалити учасника команди",
 			"cancelInviteSuccess": "Запрошення успішно скасовано",
-			"cancelInviteError": "Не вдалося скасувати запрошення"
+			"cancelInviteError": "Не вдалося скасувати запрошення",
+			"ariaInvitationActions": "Invitation actions"
 		}
 	},
 	"publicProject": {


### PR DESCRIPTION
## Problem

On a self-hosted instance without SMTP, inviting someone to a workspace is a dead end. The invitation row is created, but the accept link only ever leaves through an email that is never sent. The code already knows this happens:

```
apps/api/src/auth.ts:431
console.warn("Invitation created but email not sent due to SMTP not being configured");
```

The admin is left with a pending invitation in the members table and no way to deliver it, short of querying Postgres for the id and assembling the URL by hand.

## What this changes

Nothing in the backend. The link is already built (`apps/api/src/auth.ts:404`), `/invitation/accept/$inviteId` already exists, and `check-registration-allowed.ts` already lets an invitee without an account sign up against that `invitationId`. The id even already reaches the client — `members-table.tsx` uses it to cancel invitations.

The only missing piece was surfacing it:

- **Creating an invitation** keeps the modal open on the link with a copy button, instead of closing.
- **Each pending invitation row** gains a `⋯` menu with *Copy link* alongside the existing *Cancel invitation*, replacing the bare trash button.

Both are shown unconditionally. The frontend cannot know whether SMTP is configured without a new endpoint, and the link is useful either way — a shortcut for resending through another channel when SMTP works, the only path when it does not. The copy is worded neutrally so it is correct in both cases.

## Why `document.execCommand` is in here on purpose

`navigator.clipboard` only exists in secure contexts. A self-hosted instance reached over plain HTTP on a LAN address — the deployment this feature exists for — has no such API, so a copy button built on it alone would silently do nothing exactly where it is needed most.

`apps/web/src/lib/copy-to-clipboard.ts` therefore tries the modern API first and falls back to an off-screen `<textarea>` plus `document.execCommand("copy")`. The fallback is the primary production path for HTTP deployments, not an edge case, and the file carries a comment saying so. Verified working in Chrome over plain HTTP on a real instance.

## Link origin

`buildInvitationLink` derives the URL from `window.location.origin` rather than `KANEO_CLIENT_URL`. Whoever copies the link is already reaching the app through a URL that demonstrably works, while `KANEO_CLIENT_URL` is a server-side setting that can be stale or wrong on a self-hosted box — producing a broken link the admin has no way to notice. The backend keeps using `KANEO_CLIENT_URL` for emails, where there is no browser to derive an origin from.

## Testing

16 new tests, 50 passing in total across the web app (was 34). Coverage includes the link builder's edge cases, all three clipboard branches (modern API, `execCommand` fallback, total failure) including scratch-node cleanup on the throwing path, the copy field, and the row menu — the last exercising the real hook and asserting the exact link that reaches the clipboard.

Also verified end to end against a live instance with no SMTP configured: invite created → link copied → opened by a user with no account → signed up → workspace member.

## Notes for reviewers

- **Scope.** `apps/web` only. No API changes, no migrations, no new endpoints, no new dependencies.
- **i18n.** Eight new keys, backfilled into the other ten locales with the English source text per `CONTRIBUTING.md`. The pre-existing gaps in those files were deliberately left alone.
- **Deliberately out of scope.** Ten existing `navigator.clipboard.writeText` call sites elsewhere in the app (`api-key-created-modal`, `copy-url-button`, `task-properties-sidebar`, and others) fail the same way on plain HTTP. `copyToClipboard` is the obvious home for them, but migrating them is a separate change and is not attempted here.
- **Not addressed.** Generic "anyone with this link can join" workspace links. better-auth models invitations per email, so that would need its own table, endpoint, revocation and rate limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a shareable invitation-link view after successfully inviting a team member.
  - Added one-click invitation-link copying with success and error feedback.
  - Added invitation actions to copy links or cancel pending invitations.
  - Added fallback copying and automatic URL selection for manual copying.

- **Localization**
  - Added invitation-link and sharing translations across supported languages.

- **Tests**
  - Added coverage for invitation sharing, copying, fallback behavior, and pending-invitation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->