### PR TITLE
fix(web): make settings navigation responsive on mobile

### DIFF
--- a/apps/web/src/components/SettingsSidebar.tsx
+++ b/apps/web/src/components/SettingsSidebar.tsx
@@ -1,6 +1,11 @@
 import { useNavigate } from "@tanstack/react-router";
 import { ChevronLeft } from "lucide-react";
-import type { ReactNode } from "react";
+import {
+  createContext,
+  type ReactElement,
+  type ReactNode,
+  useContext,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import {
@@ -9,12 +14,31 @@ import {
   SheetPopup,
   SheetTitle,
 } from "@/components/ui/sheet";
-import useActiveWorkspace from "@/hooks/queries/workspace/use-active-workspace";
 
-export default function SettingsSidebar({ children }: { children: ReactNode }) {
+const SettingsWorkspaceIdContext = createContext<string | undefined>(undefined);
+
+export function SettingsSidebarProvider({
+  children,
+  workspaceId,
+}: {
+  children: ReactNode;
+  workspaceId?: string;
+}): ReactElement {
+  return (
+    <SettingsWorkspaceIdContext.Provider value={workspaceId}>
+      {children}
+    </SettingsWorkspaceIdContext.Provider>
+  );
+}
+
+export default function SettingsSidebar({
+  children,
+}: {
+  children: ReactNode;
+}): ReactElement {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { data: workspace } = useActiveWorkspace();
+  const workspaceId = useContext(SettingsWorkspaceIdContext);
 
   return (
     <>
@@ -33,13 +57,16 @@ export default function SettingsSidebar({ children }: { children: ReactNode }) {
           <Button
             variant="ghost"
             size="sm"
+            disabled={!workspaceId}
             className="w-full justify-start text-sm font-normal"
-            onClick={() =>
+            onClick={() => {
+              if (!workspaceId) return;
+
               navigate({
                 to: "/dashboard/workspace/$workspaceId",
-                params: { workspaceId: workspace?.id ?? "" },
-              })
-            }
+                params: { workspaceId },
+              });
+            }}
           >
             <ChevronLeft aria-hidden="true" className="size-4" />
             {t("navigation:page.backToWorkspace")}

--- a/apps/web/src/components/settings-sidebar.tsx
+++ b/apps/web/src/components/settings-sidebar.tsx
@@ -1,0 +1,52 @@
+import { useNavigate } from "@tanstack/react-router";
+import { ChevronLeft } from "lucide-react";
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import {
+  SheetDescription,
+  SheetHeader,
+  SheetPopup,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import useActiveWorkspace from "@/hooks/queries/workspace/use-active-workspace";
+
+export default function SettingsSidebar({ children }: { children: ReactNode }) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { data: workspace } = useActiveWorkspace();
+
+  return (
+    <>
+      <aside className="hidden w-64 shrink-0 md:block">{children}</aside>
+      <SheetPopup
+        side="left"
+        className="w-64 bg-sidebar p-0 text-sidebar-foreground md:hidden"
+      >
+        <SheetHeader className="sr-only">
+          <SheetTitle>{t("common:sidebar.title")}</SheetTitle>
+          <SheetDescription>
+            {t("common:sidebar.mobileDescription")}
+          </SheetDescription>
+        </SheetHeader>
+        <div className="border-b border-sidebar-border p-2 pr-14">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start text-sm font-normal"
+            onClick={() =>
+              navigate({
+                to: "/dashboard/workspace/$workspaceId",
+                params: { workspaceId: workspace?.id ?? "" },
+              })
+            }
+          >
+            <ChevronLeft aria-hidden="true" className="size-4" />
+            {t("navigation:page.backToWorkspace")}
+          </Button>
+        </div>
+        {children}
+      </SheetPopup>
+    </>
+  );
+}

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/settings.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/settings.tsx
@@ -4,13 +4,16 @@ import {
   useLocation,
   useNavigate,
 } from "@tanstack/react-router";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, PanelLeftIcon } from "lucide-react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import PageTitle from "@/components/page-title";
 import { Button } from "@/components/ui/button";
+import { Sheet, SheetTrigger } from "@/components/ui/sheet";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import useGetProjects from "@/hooks/queries/project/use-get-projects";
 import useActiveWorkspace from "@/hooks/queries/workspace/use-active-workspace";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 export const Route = createFileRoute(
   "/_layout/_authenticated/dashboard/settings",
@@ -22,6 +25,8 @@ function SettingsLayout() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
+  const isMobile = useIsMobile();
+  const [settingsMenuOpen, setSettingsMenuOpen] = useState(false);
   const { data: workspace } = useActiveWorkspace();
   const { data: projects } = useGetProjects({
     workspaceId: workspace?.id ?? "",
@@ -43,46 +48,91 @@ function SettingsLayout() {
 
   const activeTab = getActiveTab();
 
-  return (
-    <>
-      <PageTitle title={t("navigation:page.settingsTitle")} />
-      <div className="flex flex-col gap-4 p-4 bg-sidebar w-full h-full">
-        <div className="flex flex-col gap-4 bg-card h-full border border-border rounded-md p-4 relative overflow-hidden">
-          <div>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() =>
-                navigate({
-                  to: "/dashboard/workspace/$workspaceId",
-                  params: { workspaceId: workspace?.id ?? "" },
-                })
-              }
-            >
-              <ChevronLeft className=" border border-border rounded-md p-1 size-6" />
-              {t("navigation:page.backToWorkspace")}
-            </Button>
+  useEffect(() => {
+    if (location.pathname) {
+      setSettingsMenuOpen(false);
+    }
+  }, [location.pathname]);
 
-            <h1 className="text-2xl font-semibold pl-2 mt-2">
+  useEffect(() => {
+    if (!isMobile) {
+      setSettingsMenuOpen(false);
+    }
+  }, [isMobile]);
+
+  return (
+    <Sheet open={settingsMenuOpen} onOpenChange={setSettingsMenuOpen}>
+      <PageTitle title={t("navigation:page.settingsTitle")} />
+
+      <div className="flex h-full w-full flex-col bg-sidebar p-2 sm:p-4">
+        <div className="relative flex h-full min-h-0 flex-col gap-4 overflow-hidden rounded-md border border-border bg-card p-3 sm:p-4">
+          <div className="shrink-0">
+            <div className="flex items-center">
+              <SheetTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    className="shrink-0 md:hidden"
+                    aria-label="Open settings menu"
+                    title="Open settings menu"
+                  />
+                }
+              >
+                <PanelLeftIcon className="size-4" />
+              </SheetTrigger>
+
+              <div className="flex items-center gap-1 md:hidden">
+                <ChevronLeft className="size-4 text-muted-foreground" />
+                <span className="text-lg font-semibold">
+                  {t("navigation:page.settingsTitle")}
+                </span>
+              </div>
+
+              <Button
+                variant="ghost"
+                size="sm"
+                className="hidden md:inline-flex"
+                onClick={() =>
+                  navigate({
+                    to: "/dashboard/workspace/$workspaceId",
+                    params: {
+                      workspaceId: workspace?.id ?? "",
+                    },
+                  })
+                }
+              >
+                <ChevronLeft />
+
+                {t("navigation:page.backToWorkspace")}
+              </Button>
+            </div>
+
+            <h1 className="mt-4 hidden pl-1 text-2xl font-semibold md:block">
               {t("navigation:page.settingsTitle")}
             </h1>
 
             <Tabs value={activeTab} className="w-[400px] pt-2">
               <TabsList className="bg-sidebar gap-2">
                 <TabsTrigger
-                  className="[&[data-state=active]]:border [&[data-state=active]]:border-border [&[data-state=active]]:rounded-md [&[data-state=active]]:bg-card"
                   value="account"
+                  className="[&[data-state=active]]:rounded-md [&[data-state=active]]:border [&[data-state=active]]:border-border [&[data-state=active]]:bg-card"
                   onClick={() =>
-                    navigate({ to: "/dashboard/settings/account/information" })
+                    navigate({
+                      to: "/dashboard/settings/account/information",
+                    })
                   }
                 >
                   {t("settings:account")}
                 </TabsTrigger>
                 <TabsTrigger
                   value="workspace"
-                  className="[&[data-state=active]]:border [&[data-state=active]]:border-border [&[data-state=active]]:rounded-md [&[data-state=active]]:bg-card"
+                  className="[&[data-state=active]]:rounded-md [&[data-state=active]]:border [&[data-state=active]]:border-border [&[data-state=active]]:bg-card"
                   onClick={() =>
-                    navigate({ to: "/dashboard/settings/workspace/general" })
+                    navigate({
+                      to: "/dashboard/settings/workspace/general",
+                    })
                   }
                 >
                   {t("navigation:page.settingsWorkspaceTab")}
@@ -90,9 +140,11 @@ function SettingsLayout() {
                 <TabsTrigger
                   disabled={projects?.length === 0}
                   value="project"
-                  className="[&[data-state=active]]:border [&[data-state=active]]:border-border [&[data-state=active]]:rounded-md [&[data-state=active]]:bg-card"
+                  className="[&[data-state=active]]:rounded-md [&[data-state=active]]:border [&[data-state=active]]:border-border [&[data-state=active]]:bg-card"
                   onClick={() =>
-                    navigate({ to: "/dashboard/settings/projects" })
+                    navigate({
+                      to: "/dashboard/settings/projects",
+                    })
                   }
                 >
                   {t("navigation:sidebar.projects")}
@@ -101,11 +153,11 @@ function SettingsLayout() {
             </Tabs>
           </div>
 
-          <div className="flex-1 overflow-y-auto">
+          <div className="min-h-0 flex-1 overflow-y-auto">
             <Outlet />
           </div>
         </div>
       </div>
-    </>
+    </Sheet>
   );
 }

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/settings.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/settings.tsx
@@ -5,9 +5,10 @@ import {
   useNavigate,
 } from "@tanstack/react-router";
 import { ChevronLeft, PanelLeftIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import PageTitle from "@/components/page-title";
+import { SettingsSidebarProvider } from "@/components/SettingsSidebar";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetTrigger } from "@/components/ui/sheet";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -54,7 +55,7 @@ function SettingsLayout() {
     }
   }, [location.pathname]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isMobile) {
       setSettingsMenuOpen(false);
     }
@@ -65,7 +66,7 @@ function SettingsLayout() {
       <PageTitle title={t("navigation:page.settingsTitle")} />
 
       <div className="flex h-full w-full flex-col bg-sidebar p-2 sm:p-4">
-        <div className="relative flex h-full min-h-0 flex-col gap-4 overflow-hidden rounded-md border border-border bg-card p-3 sm:p-4">
+        <div className="relative flex h-full min-h-0 flex-col gap-6 overflow-hidden rounded-md border border-border bg-card p-3 md:gap-4 sm:p-4">
           <div className="shrink-0">
             <div className="flex items-center">
               <SheetTrigger
@@ -93,15 +94,16 @@ function SettingsLayout() {
               <Button
                 variant="ghost"
                 size="sm"
+                disabled={!workspace?.id}
                 className="hidden md:inline-flex"
-                onClick={() =>
+                onClick={() => {
+                  if (!workspace?.id) return;
+
                   navigate({
                     to: "/dashboard/workspace/$workspaceId",
-                    params: {
-                      workspaceId: workspace?.id ?? "",
-                    },
-                  })
-                }
+                    params: { workspaceId: workspace.id },
+                  });
+                }}
               >
                 <ChevronLeft />
 
@@ -113,7 +115,10 @@ function SettingsLayout() {
               {t("navigation:page.settingsTitle")}
             </h1>
 
-            <Tabs value={activeTab} className="w-[400px] pt-2">
+            <Tabs
+              value={activeTab}
+              className="w-full pt-4 md:w-[400px] md:pt-2"
+            >
               <TabsList className="bg-sidebar gap-2">
                 <TabsTrigger
                   value="account"
@@ -154,7 +159,9 @@ function SettingsLayout() {
           </div>
 
           <div className="min-h-0 flex-1 overflow-y-auto">
-            <Outlet />
+            <SettingsSidebarProvider workspaceId={workspace?.id}>
+              <Outlet />
+            </SettingsSidebarProvider>
           </div>
         </div>
       </div>

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/settings/account.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/settings/account.tsx
@@ -7,7 +7,7 @@ import {
 import { Bell, Code, Settings, User } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import useAuth from "@/components/providers/auth-provider/hooks/use-auth";
-import SettingsSidebar from "@/components/settings-sidebar";
+import SettingsSidebar from "@/components/SettingsSidebar";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -60,9 +60,11 @@ function RouteComponent() {
                 {getInitials(user?.name)}
               </AvatarFallback>
             </Avatar>
-            <div className="flex flex-col">
-              <p className="text-sm">{user?.name}</p>
-              <p className="text-xs text-sidebar-foreground/70">
+            <div className="flex min-w-0 flex-col md:min-w-fit">
+              <p className="truncate text-sm md:overflow-visible md:text-clip md:whitespace-normal">
+                {user?.name}
+              </p>
+              <p className="truncate text-xs text-sidebar-foreground/70 md:overflow-visible md:text-clip md:whitespace-normal">
                 {user?.email}
               </p>
             </div>

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/settings/account.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/settings/account.tsx
@@ -7,6 +7,7 @@ import {
 import { Bell, Code, Settings, User } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import useAuth from "@/components/providers/auth-provider/hooks/use-auth";
+import SettingsSidebar from "@/components/settings-sidebar";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -50,7 +51,7 @@ function RouteComponent() {
 
   return (
     <div className="flex gap-6 h-full">
-      <aside className="w-64 flex-shrink-0">
+      <SettingsSidebar>
         <div className="p-2">
           <div className="mb-1 flex items-center gap-3 rounded-md px-2 py-2">
             <Avatar className="h-9 w-9">
@@ -119,7 +120,7 @@ function RouteComponent() {
             </SidebarGroupContent>
           </SidebarGroup>
         </div>
-      </aside>
+      </SettingsSidebar>
 
       <div className="flex-1 min-w-0 overflow-y-auto">
         <Outlet />

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/settings/projects.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/settings/projects.tsx
@@ -8,7 +8,7 @@ import {
 import { Eye, GitBranch, Plug, Settings } from "lucide-react";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import SettingsSidebar from "@/components/settings-sidebar";
+import SettingsSidebar from "@/components/SettingsSidebar";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -111,9 +111,11 @@ function RouteComponent() {
                 {workspaceInitials}
               </AvatarFallback>
             </Avatar>
-            <div className="flex flex-col">
-              <p className="text-sm">{workspace?.name}</p>
-              <p className="text-[11px] text-sidebar-foreground/60 capitalize">
+            <div className="flex min-w-0 flex-col md:min-w-fit">
+              <p className="truncate text-sm md:overflow-visible md:text-clip md:whitespace-normal">
+                {workspace?.name}
+              </p>
+              <p className="truncate text-[11px] text-sidebar-foreground/60 capitalize md:overflow-visible md:text-clip md:whitespace-normal">
                 {t(`team:roles.${role}`, { defaultValue: role })}
               </p>
             </div>

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/settings/projects.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/settings/projects.tsx
@@ -8,6 +8,7 @@ import {
 import { Eye, GitBranch, Plug, Settings } from "lucide-react";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import SettingsSidebar from "@/components/settings-sidebar";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -98,7 +99,7 @@ function RouteComponent() {
 
   return (
     <div className="flex gap-6 h-full">
-      <aside className="w-64 flex-shrink-0">
+      <SettingsSidebar>
         <div className="p-2">
           <div className="mb-1 flex items-center gap-3 rounded-md px-2 py-2">
             <Avatar className="h-8 w-8">
@@ -202,7 +203,7 @@ function RouteComponent() {
             </SidebarGroupContent>
           </SidebarGroup>
         </div>
-      </aside>
+      </SettingsSidebar>
 
       <div className="flex-1 min-w-0 overflow-y-auto">
         <Outlet />

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/settings/workspace.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/settings/workspace.tsx
@@ -7,7 +7,7 @@ import {
 } from "@tanstack/react-router";
 import { CreditCard, Settings, Shield, Tag } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import SettingsSidebar from "@/components/settings-sidebar";
+import SettingsSidebar from "@/components/SettingsSidebar";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -97,9 +97,11 @@ function RouteComponent() {
                 {workspaceInitials}
               </AvatarFallback>
             </Avatar>
-            <div className="flex flex-col">
-              <p className="text-sm">{workspace?.name}</p>
-              <p className="text-[11px] text-sidebar-foreground/60 capitalize">
+            <div className="flex min-w-0 flex-col md:min-w-fit">
+              <p className="truncate text-sm md:overflow-visible md:text-clip md:whitespace-normal">
+                {workspace?.name}
+              </p>
+              <p className="truncate text-[11px] text-sidebar-foreground/60 capitalize md:overflow-visible md:text-clip md:whitespace-normal">
                 {t(`team:roles.${role}`, { defaultValue: role })}
               </p>
             </div>

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/settings/workspace.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/settings/workspace.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-router";
 import { CreditCard, Settings, Shield, Tag } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import SettingsSidebar from "@/components/settings-sidebar";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -84,7 +85,7 @@ function RouteComponent() {
 
   return (
     <div className="flex gap-6 h-full">
-      <aside className="w-64 flex-shrink-0">
+      <SettingsSidebar>
         <div className="p-2">
           <div className="mb-1 flex items-center gap-3 rounded-md px-2 py-2">
             <Avatar className="h-8 w-8">
@@ -131,7 +132,7 @@ function RouteComponent() {
             </SidebarGroupContent>
           </SidebarGroup>
         </div>
-      </aside>
+      </SettingsSidebar>
 
       <div className="flex-1 min-w-0 overflow-y-auto">
         <Outlet />


### PR DESCRIPTION
## Description

Settings pages use secondary navigation sidebars for Account, Workspace, and Project settings. On screens below the `md` breakpoint, these sidebars need to be hidden to preserve space for the main settings content. However, hiding them also made important nested settings pages inaccessible on mobile.

This PR adds a mobile settings navigation experience that:

- Displays a mobile-only sidebar button alongside a clear “Settings” indicator.
- Opens the relevant Account, Workspace, or Project settings navigation in a sheet from the left.
- Reuses the existing settings navigation content instead of maintaining a separate mobile navigation list.
- Keeps the existing fixed-width settings sidebar visible at `md` and above.
- Places “Back to Workspace” inside the mobile sheet.
- Closes the sheet when:
  - The close button is selected.
  - The backdrop outside the sheet is selected.
  - A different settings page is selected.
  - The page is refreshed.
  - The viewport is resized to `md` or wider.
- Removes the backdrop when transitioning from mobile to desktop while the sheet is open.

### UI/UX rationale

The sidebar icon provides a familiar navigation affordance, while the adjacent “Settings” label makes the control easier to discover for first-time users.

A left-side sheet was chosen because it preserves the same navigation model used on desktop without reducing the limited mobile content area. Users continue to see the same Account, Workspace, or Project navigation items in the same order and style.

Moving “Back to Workspace” into the sheet keeps contextual navigation together and avoids using valuable space in the mobile page header.

## Related Issue(s)

Fixes #1446

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Other:
  - Production build
  - TypeScript typecheck
  - Focused Biome check

Manual verification included:

- Account settings routes on mobile.
- Workspace settings routes on mobile.
- Project settings routes on mobile.
- Opening the appropriate navigation from the left.
- Closing through the close button and backdrop.
- Navigating through settings links.
- Returning through “Back to Workspace.”
- Refreshing while on a settings route.
- Resizing from mobile to desktop while the sheet is open.
- Confirming the backdrop is removed after resizing.
- Confirming the desktop sidebar remains fixed-width and does not overlap the content.

Automated verification:

- `pnpm --filter @kaneo/web test` — 61 tests passed across 21 files.
- `pnpm --filter @kaneo/web typecheck`
- `pnpm --filter @kaneo/web build`
- Focused Biome check for all changed files.

## Screenshots


<img width="850" height="1350" alt="mobile-one" src="https://github.com/user-attachments/assets/8e577be5-cfe0-44bf-abae-17fd2ea65092" />
&nbsp;
<img width="850" height="1350" alt="mobile-two" src="https://github.com/user-attachments/assets/177fea10-8b18-4388-84d9-3b6cbb63f8a6" />

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (not applicable; no documentation changes required)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (not applicable; no dependent changes)

## Additional Notes

The mobile sheet and desktop sidebar render the same existing Account, Workspace, and Project navigation content. This avoids duplicated navigation definitions and keeps the mobile and desktop experiences synchronized.

No new custom sidebar system was introduced. The implementation reuses the existing Sheet component and its built-in backdrop, focus management, dismissal, and close behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive settings navigation for mobile and desktop layouts.
  * Added mobile menu controls, titles, and a back-to-workspace action.
  * Improved settings navigation consistency across account, project, and workspace pages.

* **Bug Fixes**
  * Improved handling of long names, email addresses, and roles on smaller screens.
  * Settings navigation now resets appropriately when routes or viewport sizes change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->