### PR TITLE
fix(web): use Shiki's JavaScript regex engine to avoid WebAssembly

### DIFF
--- a/apps/web/src/lib/shiki-highlighter.ts
+++ b/apps/web/src/lib/shiki-highlighter.ts
@@ -1,4 +1,5 @@
 import { createHighlighter, type Highlighter } from "shiki";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
 let shikiHighlighterPromise: Promise<Highlighter> | null = null;
 
@@ -45,6 +46,15 @@ export function getSharedShikiHighlighter() {
     shikiHighlighterPromise = createHighlighter({
       themes: ["github-dark", "github-light"],
       langs: [...SHIKI_LANGUAGES],
+      // The default oniguruma engine runs on WebAssembly, which Chrome
+      // enterprise policies (e.g. JavaScriptJitDisabled) can disable. With
+      // WASM disabled, createHighlighter rejects and views waiting on it
+      // never render.
+      // The JavaScript engine doesn't require WASM. `forgiving` means a
+      // pattern that can't be translated to a native RegExp stops matching
+      // (worst case: one token type unhighlighted) instead of throwing at
+      // creation. All bundled grammars translate as of Shiki 3.9.1.
+      engine: createJavaScriptRegexEngine({ forgiving: true }),
     });
   }
 


### PR DESCRIPTION
## Description

Opening a task's full-page view on a machine where Chrome enterprise policies disable the JIT (e.g. `JavaScriptJitDisabled`) shows loading skeletons forever. Those policies also disable WebAssembly, and Shiki's default oniguruma engine initializes from a WASM binary, so `createHighlighter` rejects. The full-page task route waits on that promise before rendering anything, so the page never loads. The board's task drawer doesn't gate on the highlighter, which is why only the full-page view breaks.

The fix switches the shared highlighter to Shiki's JavaScript regex engine, which doesn't require WASM. The engine ships inside the `shiki` package already (no new dependency) and supports all bundled grammars since Shiki 3.9.1. `forgiving: true` makes a grammar pattern that can't be translated to a native RegExp stop matching (worst case: one token type unhighlighted) instead of throwing at creation. Side benefit: the ~600 kB inlined oniguruma WASM chunk is no longer downloaded the first time something highlights.

## Related Issue(s)

None filed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing
- [x] Other (please describe):

**The highlighter initializes without WebAssembly (`node --jitless`, which disables WASM the same way the Chrome policy does).** With the default engine, `createHighlighter` rejects with `WebAssembly is not defined`; with this change it resolves, and all 35 languages the app registers load and highlight.

**The full-page view renders on an affected setup (manual).** Built the production image, seeded a task whose description contains TypeScript/Python/SQL code blocks, and opened its full-page view: it renders with syntax highlighting and no `.wasm` request.

Existing web test suite (64 tests) and `vite build` pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Before replacing the engine we looked for a reason WASM was chosen and found none: the highlighter was introduced in the task-details redesign (d2bebe8) calling `createHighlighter` with no `engine` option, which silently selects the oniguruma default, and searching this repo's issues and PRs for "shiki", "wasm", and "oniguruma" turns up only dependency bumps. If there is a specific reason to keep the oniguruma engine that we missed and this change conflicts with it, please say so and recommend the approach you'd prefer for making the task page work where WebAssembly is disabled — happy to rework the PR.
