### PR TITLE
fix(web): correct link to the API reference in the nav menu

### DIFF
--- a/apps/site/components/landing/navbar.tsx
+++ b/apps/site/components/landing/navbar.tsx
@@ -79,7 +79,7 @@ const navigationLinks: NavigationLink[] = [
       { href: "/docs/core", label: "Quick Start" },
       { href: "/docs/core/installation", label: "Installation" },
       { href: "/docs/core/functional", label: "Functional Guide" },
-      { href: "/docs/api", label: "API Reference" },
+      { href: "/docs/api-reference/introduction", label: "API Reference" },
     ],
     label: "Docs",
     submenu: true,


### PR DESCRIPTION
## Description
Fixes the broken "API Reference" link in the landing navbar. It now points to `/docs/api-reference/introduction`, the same URL defined on the 404 page.

## Related Issue(s)
None

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
Single-line change in `apps/site/components/landing/navbar.tsx`: `/docs/api` → `/docs/api-reference/introduction`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Docs navigation link for API Reference to point to the correct destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->