### PR TITLE
fix(helm): set postgresql Deployment update strategy to Recreate

### DIFF
--- a/charts/kaneo/templates/postgresql-deployment.yaml
+++ b/charts/kaneo/templates/postgresql-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     app.kubernetes.io/component: postgresql
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "kaneo.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->

Set `strategy.type: Recreate` on the bundled postgresql `Deployment` in `charts/kaneo/templates/postgresql-deployment.yaml`.  It was suggested in #1508 

The Deployment used the default `RollingUpdate` with `replicas: 1` and a single shared PVC. On image tag bumps (example `16-alpine` to `16.14-alpine`) the new pod started and mounted the PVC before the old one terminated. Therefore, two postmasters writing to the same PGDATA, potentially leading to corruption. 


## Related Issue(s)
<!-- Link to the related issue(s) this PR addresses -->
Fixes #1508

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any other context about the PR here -->

   | | `strategy: Recreate` | `StatefulSet` |
   |---|---|---|
   | Diff | 2 lines, 1 file | New kind, possible PVC migration |
   | Existing data | Untouched - PVC name unchanged | Risk of orphaned PVC unless data is migrated to `<name>-postgresql-0` |
   | Service selector | Unchanged | Unchanged |
   | Backup docs (`kubectl exec deployment/...`) | Still valid | Need `sts/...` in NOTES.txt + README |
