### PR TITLE
fix: derive a project key from non-Latin names

### DIFF
--- a/apps/api/src/search/controllers/global-search.ts
+++ b/apps/api/src/search/controllers/global-search.ts
@@ -8,6 +8,7 @@ import {
   workspaceTable,
   workspaceUserTable,
 } from "../../database/schema";
+import { escapeLikePattern } from "../like-pattern";
 import { TASK_SHORT_ID_PATTERN } from "../task-short-id";
 
 type SearchParams = {
@@ -147,8 +148,10 @@ async function globalSearch(params: SearchParams): Promise<{
     ? eq(projectTable.workspaceId, workspaceId)
     : inArray(projectTable.workspaceId, accessibleWorkspaceIds);
 
-  // Check if query matches short-id pattern (e.g. "DEP-23")
-  const shortIdMatch = query.match(TASK_SHORT_ID_PATTERN);
+  // Check if query matches short-id pattern (e.g. "DEP-23"). `generateProjectSlug`
+  // normalizes to NFKC before it stores a key, so the query is normalized too,
+  // or a decomposed "ПА-23" would never reach the stored composed form.
+  const shortIdMatch = query.normalize("NFKC").match(TASK_SHORT_ID_PATTERN);
 
   if (type === "all" || type === "tasks") {
     const seenTaskIds = new Set<string>();
@@ -187,7 +190,11 @@ async function globalSearch(params: SearchParams): Promise<{
           and(
             workspaceFilter,
             projectId ? eq(taskTable.projectId, projectId) : undefined,
-            ilike(projectTable.slug, slug),
+            // A project key may hold `_`, which `ilike` reads as "any one
+            // character", so `DE_-23` would also match a task in `DEP` and the
+            // `limit(1)` below would pick whichever came back first. Escaping
+            // keeps the case-insensitive comparison and drops the wildcards.
+            ilike(projectTable.slug, escapeLikePattern(slug)),
             eq(taskTable.number, taskNumber),
           ),
         )

--- a/apps/api/src/search/controllers/global-search.ts
+++ b/apps/api/src/search/controllers/global-search.ts
@@ -8,6 +8,7 @@ import {
   workspaceTable,
   workspaceUserTable,
 } from "../../database/schema";
+import { TASK_SHORT_ID_PATTERN } from "../task-short-id";
 
 type SearchParams = {
   query: string;
@@ -147,7 +148,7 @@ async function globalSearch(params: SearchParams): Promise<{
     : inArray(projectTable.workspaceId, accessibleWorkspaceIds);
 
   // Check if query matches short-id pattern (e.g. "DEP-23")
-  const shortIdMatch = query.match(/^([A-Za-z][\w-]*)-(\d+)$/);
+  const shortIdMatch = query.match(TASK_SHORT_ID_PATTERN);
 
   if (type === "all" || type === "tasks") {
     const seenTaskIds = new Set<string>();

--- a/apps/api/src/search/like-pattern.ts
+++ b/apps/api/src/search/like-pattern.ts
@@ -1,0 +1,7 @@
+// `_` and `%` are wildcards to LIKE and ILIKE, and `\` is the escape character
+// Postgres uses when no ESCAPE clause is given. A value compared with `ilike`
+// has to go through here first, or a key holding one of them matches more rows
+// than the one that was asked for.
+export function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, "\\$&");
+}

--- a/apps/api/src/search/task-short-id.ts
+++ b/apps/api/src/search/task-short-id.ts
@@ -1,0 +1,6 @@
+// A task's short id is its project key plus the task number, e.g. "DEP-23".
+// Project keys come from `generateProjectSlug`, which follows the same Unicode
+// rules as `toSlug`, so a key can be "ПА" or "测试项" and not only A-Z. Matching
+// on ASCII alone left those projects without the "type the task key to jump to
+// it" path.
+export const TASK_SHORT_ID_PATTERN = /^(\p{L}[\p{L}\p{N}\p{M}_-]*)-(\d+)$/u;

--- a/apps/web/src/lib/generate-project-id.test.ts
+++ b/apps/web/src/lib/generate-project-id.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import generateProjectSlug from "./generate-project-id";
+
+describe("generateProjectSlug", () => {
+  it("takes the first three letters of a single word", () => {
+    expect(generateProjectSlug("Kaneo")).toBe("KAN");
+  });
+
+  it("takes the initials of the first three words", () => {
+    expect(generateProjectSlug("Alpha Beta Gamma")).toBe("ABG");
+    expect(generateProjectSlug("Alpha Beta Gamma Delta")).toBe("ABG");
+  });
+
+  it("ignores a leading separator instead of spending an initial on it", () => {
+    expect(generateProjectSlug(" Kaneo")).toBe("KAN");
+    expect(generateProjectSlug(" Alpha Beta Gamma")).toBe("ABG");
+    expect(generateProjectSlug("- Alpha Beta Gamma")).toBe("ABG");
+  });
+
+  it("keeps non-Latin scripts instead of producing an empty key", () => {
+    expect(generateProjectSlug("тест")).toBe("ТЕС");
+    expect(generateProjectSlug("Проект Альфа")).toBe("ПА");
+    expect(generateProjectSlug("测试项目")).toBe("测试项");
+  });
+
+  it("keeps digits and punctuation handling as they were", () => {
+    expect(generateProjectSlug("Sprint 2")).toBe("S2");
+    expect(generateProjectSlug("[Alpha] Beta Gamma")).toBe("ABG");
+  });
+
+  it("folds full-width characters via NFKC normalization", () => {
+    expect(generateProjectSlug("ＡＢＣ")).toBe("ABC");
+  });
+
+  it("returns an empty key when the name has no letters or numbers", () => {
+    expect(generateProjectSlug("!!!")).toBe("");
+    expect(generateProjectSlug("   ")).toBe("");
+  });
+});

--- a/apps/web/src/lib/generate-project-id.test.ts
+++ b/apps/web/src/lib/generate-project-id.test.ts
@@ -43,6 +43,12 @@ describe("generateProjectSlug", () => {
     expect(generateProjectSlug("́alpha ́beta")).toBe("AB");
   });
 
+  it("skips a leading combining mark on a single word too", () => {
+    // A key starting with a mark cannot be typed back as a task short id,
+    // because the pattern wants a letter first.
+    expect(generateProjectSlug("́alpha")).toBe("ALP");
+  });
+
   it("returns an empty key when the name has no letters or numbers", () => {
     expect(generateProjectSlug("!!!")).toBe("");
     expect(generateProjectSlug("   ")).toBe("");

--- a/apps/web/src/lib/generate-project-id.test.ts
+++ b/apps/web/src/lib/generate-project-id.test.ts
@@ -32,6 +32,17 @@ describe("generateProjectSlug", () => {
     expect(generateProjectSlug("ＡＢＣ")).toBe("ABC");
   });
 
+  it("counts code points, not UTF-16 units", () => {
+    // Each of these is one letter made of two UTF-16 units, so indexing by
+    // unit would return half a surrogate pair.
+    expect(generateProjectSlug("𠀀𠀁𠀂𠀃")).toBe("𠀀𠀁𠀂");
+    expect(generateProjectSlug("𐌰lpha 𐌱eta")).toBe("𐌰𐌱");
+  });
+
+  it("skips a leading combining mark when taking an initial", () => {
+    expect(generateProjectSlug("́alpha ́beta")).toBe("AB");
+  });
+
   it("returns an empty key when the name has no letters or numbers", () => {
     expect(generateProjectSlug("!!!")).toBe("");
     expect(generateProjectSlug("   ")).toBe("");

--- a/apps/web/src/lib/generate-project-id.ts
+++ b/apps/web/src/lib/generate-project-id.ts
@@ -19,9 +19,16 @@ function generateProjectSlug(projectName: string) {
 
   // Iterate by code point, not by UTF-16 unit. A letter outside the basic
   // multilingual plane is two units, so `word[0]` would hand back half a
-  // surrogate pair and `slice(0, 3)` would cut one in half.
+  // surrogate pair and `slice(0, 3)` would cut one in half. Leading combining
+  // marks are skipped for the same reason `firstLetterOrNumber` skips them: a
+  // key has to start with a letter to be typed back as a task short id.
   if (words.length === 1) {
-    return Array.from(words[0]).slice(0, 3).join("");
+    const codePoints = Array.from(words[0]);
+    const firstLetter = codePoints.findIndex((char) =>
+      /[\p{L}\p{N}]/u.test(char),
+    );
+
+    return codePoints.slice(firstLetter, firstLetter + 3).join("");
   }
 
   return words.slice(0, 3).map(firstLetterOrNumber).join("");

--- a/apps/web/src/lib/generate-project-id.ts
+++ b/apps/web/src/lib/generate-project-id.ts
@@ -17,14 +17,26 @@ function generateProjectSlug(projectName: string) {
     return "";
   }
 
+  // Iterate by code point, not by UTF-16 unit. A letter outside the basic
+  // multilingual plane is two units, so `word[0]` would hand back half a
+  // surrogate pair and `slice(0, 3)` would cut one in half.
   if (words.length === 1) {
-    return words[0].slice(0, 3);
+    return Array.from(words[0]).slice(0, 3).join("");
   }
 
-  return words
-    .slice(0, 3)
-    .map((word) => word[0])
-    .join("");
+  return words.slice(0, 3).map(firstLetterOrNumber).join("");
+}
+
+// Stripping punctuation can leave a word whose first code point is a combining
+// mark, which is not an initial anyone would recognize.
+function firstLetterOrNumber(word: string): string {
+  for (const char of word) {
+    if (/[\p{L}\p{N}]/u.test(char)) {
+      return char;
+    }
+  }
+
+  return "";
 }
 
 export default generateProjectSlug;

--- a/apps/web/src/lib/generate-project-id.ts
+++ b/apps/web/src/lib/generate-project-id.ts
@@ -36,7 +36,7 @@ function generateProjectSlug(projectName: string) {
 
 // Stripping punctuation can leave a word whose first code point is a combining
 // mark, which is not an initial anyone would recognize.
-function firstLetterOrNumber(word: string): string {
+function firstLetterOrNumber(word: string) {
   for (const char of word) {
     if (/[\p{L}\p{N}]/u.test(char)) {
       return char;

--- a/apps/web/src/lib/generate-project-id.ts
+++ b/apps/web/src/lib/generate-project-id.ts
@@ -1,8 +1,21 @@
+// Slug rules follow the API's `toSlug` (apps/api/src/column/controllers/
+// create-column.ts): letters, marks and numbers from any script, matched with
+// Unicode property escapes rather than A-Z, so a project named in Cyrillic,
+// Greek or Han gets a key instead of an empty string.
 function generateProjectSlug(projectName: string) {
   const words = projectName
+    .normalize("NFKC")
     .toUpperCase()
-    .replace(/[^A-Z0-9\s]/g, "")
-    .split(/\s+/);
+    .replace(/[^\p{L}\p{M}\p{N}\s]/gu, "")
+    .split(/\s+/)
+    // Splitting leaves an empty first entry when the name starts with a
+    // separator, and stripping punctuation can leave a word of combining
+    // marks alone. Either one would take a slot and cost an initial.
+    .filter((word) => /[\p{L}\p{N}]/u.test(word));
+
+  if (words.length === 0) {
+    return "";
+  }
 
   if (words.length === 1) {
     return words[0].slice(0, 3);

--- a/tests/api/search/like-pattern.test.ts
+++ b/tests/api/search/like-pattern.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { escapeLikePattern } from "../../../apps/api/src/search/like-pattern";
+
+describe("escapeLikePattern", () => {
+  it("escapes the single-character wildcard", () => {
+    // Checked against Postgres 16: `slug ILIKE 'A_B'` returns both `A_B` and
+    // `ACB`, while `slug ILIKE 'A\_B'` returns only `A_B`.
+    expect(escapeLikePattern("A_B")).toBe("A\\_B");
+    expect(escapeLikePattern("DE_")).toBe("DE\\_");
+  });
+
+  it("escapes the multi-character wildcard and the escape character itself", () => {
+    expect(escapeLikePattern("50%")).toBe("50\\%");
+    expect(escapeLikePattern("a\\b")).toBe("a\\\\b");
+  });
+
+  it("leaves a key with no wildcard exactly as it is", () => {
+    expect(escapeLikePattern("DEP")).toBe("DEP");
+    expect(escapeLikePattern("ПА")).toBe("ПА");
+    expect(escapeLikePattern("测试项")).toBe("测试项");
+  });
+});

--- a/tests/api/search/task-short-id-pattern.test.ts
+++ b/tests/api/search/task-short-id-pattern.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { TASK_SHORT_ID_PATTERN } from "../../../apps/api/src/search/task-short-id";
+
+function parse(query: string) {
+  const match = query.match(TASK_SHORT_ID_PATTERN);
+  return match ? { slug: match[1], number: match[2] } : null;
+}
+
+describe("TASK_SHORT_ID_PATTERN", () => {
+  it("matches an ASCII project key", () => {
+    expect(parse("DEP-23")).toEqual({ slug: "DEP", number: "23" });
+    expect(parse("S2-7")).toEqual({ slug: "S2", number: "7" });
+  });
+
+  it("matches keys generated from non-Latin project names", () => {
+    expect(parse("ПА-23")).toEqual({ slug: "ПА", number: "23" });
+    expect(parse("测试项-1")).toEqual({ slug: "测试项", number: "1" });
+    expect(parse("ΑΒΓ-9")).toEqual({ slug: "ΑΒΓ", number: "9" });
+  });
+
+  it("still requires a leading letter and a trailing number", () => {
+    expect(parse("23-45")).toBeNull();
+    expect(parse("DEP-")).toBeNull();
+    expect(parse("DEP")).toBeNull();
+    expect(parse("-23")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description

`generateProjectSlug` feeds the project key field as you type the name in the create-project modal, and the create button stays disabled while that key is empty. Two inputs come out wrong.

**A name written in a non-Latin script gets no key at all.** The regex is `[^A-Z0-9\s]`, so every letter outside ASCII is removed before the initials are taken:

```js
generateProjectSlug("тест")          // ""
generateProjectSlug("Проект Альфа")  // ""
generateProjectSlug("测试项目")        // ""
```

Empty key, disabled button, nothing on screen saying why. Seven of the seventeen locales in `i18n/` are non-Latin (`ru-RU`, `uk-UA`, `mk-MK`, `el-GR`, `hi-IN`, `ko-KR`, `zh-CN`), so this is reachable by the people those locales exist for.

**A leading separator eats an initial.** `split(/\s+/)` leaves an empty first entry, which still takes one of the three slots:

```js
generateProjectSlug(" Kaneo")             // "K"    (expected "KAN")
generateProjectSlug(" Alpha Beta Gamma")  // "AB"   (expected "ABG")
```

### Why this shape of fix

The API already answers this question. `toSlug` in `apps/api/src/column/controllers/create-column.ts` normalizes with NFKC and matches on `\p{L}\p{M}\p{N}` with the `u` flag, and `tests/api/column/to-slug.test.ts` has a case named "keeps non-Latin scripts instead of producing an empty slug". The web-side key generator was the one place still on `A-Z`. This lines the two up instead of inventing a third rule.

Words holding no letter or number are dropped, which covers the empty leading entry and also a word left holding only combining marks after punctuation is stripped.

### After

```js
generateProjectSlug("тест")               // "ТЕС"
generateProjectSlug("Проект Альфа")       // "ПА"
generateProjectSlug("测试项目")             // "测试项"
generateProjectSlug(" Kaneo")             // "KAN"
generateProjectSlug(" Alpha Beta Gamma")  // "ABG"
generateProjectSlug("ＡＢＣ")              // "ABC"  (NFKC, same as toSlug)
```

Unchanged: `"Kaneo"` is still `"KAN"`, `"Alpha Beta Gamma"` is still `"ABG"`, `"Sprint 2"` is still `"S2"`, `"[Alpha] Beta Gamma"` is still `"ABG"`, and a name with no letters or numbers still returns `""` so the button stays disabled exactly as before.

## Related Issue(s)

None open that I could find.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

Added `apps/web/src/lib/generate-project-id.test.ts`, which the module did not have. Seven cases: three fail on `main` and pass with the change, four pass on both sides so a harness that stopped exercising the function would not read as a fix.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective

## Additional Notes

`biome check` is clean on both files.

One caveat worth stating plainly: `pnpm install` does not complete on my Windows machine, because the workspace links need symlink privileges this box does not grant. I ran these tests with vitest pointed at the module rather than through `pnpm test`. The module imports nothing, so the run exercises the real code, but I have not run the rest of the web suite and CI should be the judge of that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project slug generation for international characters, full-width characters, combining marks, numbers, and punctuation.
  * More reliably removes invalid or empty content and returns an empty slug when no valid name content remains.
  * Improved task short-ID recognition across international, mixed alphanumeric, underscore, and hyphenated project keys.
  * Improved project search matching so wildcard characters are treated literally rather than matching unintended projects.

* **Tests**
  * Added coverage for slug generation, task short-ID matching, and safe search matching across supported character sets and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->