### PR TITLE
feat(github): move the task back when an issue is reopened

### DIFF
--- a/apps/api/src/plugins/github/webhook-handler.ts
+++ b/apps/api/src/plugins/github/webhook-handler.ts
@@ -4,6 +4,7 @@ import { handleIssueCommentCreated } from "./webhooks/issue-comment-created";
 import { handleIssueEdited } from "./webhooks/issue-edited";
 import { handleIssueLabeled } from "./webhooks/issue-labeled";
 import { handleIssueOpened } from "./webhooks/issue-opened";
+import { handleIssueReopened } from "./webhooks/issue-reopened";
 import { handleLabelCreated } from "./webhooks/label-created";
 import { handlePullRequestClosed } from "./webhooks/pull-request-closed";
 import { handlePullRequestOpened } from "./webhooks/pull-request-opened";
@@ -82,6 +83,19 @@ export function setupWebhookHandlers() {
       console.log("[GitHub Webhook] issues.closed handled successfully");
     } catch (error) {
       console.error("[GitHub Webhook] issues.closed handler error:", error);
+      throw error;
+    }
+  });
+
+  githubApp.webhooks.on("issues.reopened", async ({ payload }) => {
+    console.log("[GitHub Webhook] Handling issues.reopened");
+    try {
+      await handleIssueReopened(
+        payload as Parameters<typeof handleIssueReopened>[0],
+      );
+      console.log("[GitHub Webhook] issues.reopened handled successfully");
+    } catch (error) {
+      console.error("[GitHub Webhook] issues.reopened handler error:", error);
       throw error;
     }
   });

--- a/apps/api/src/plugins/github/webhooks/issue-reopened.ts
+++ b/apps/api/src/plugins/github/webhooks/issue-reopened.ts
@@ -53,9 +53,21 @@ export async function handleIssueReopened(payload: IssueReopenedPayload) {
       continue;
     }
 
-    const existingMetadata = externalLink.metadata
-      ? JSON.parse(externalLink.metadata)
-      : {};
+    let existingMetadata: Record<string, unknown> = {};
+    if (externalLink.metadata) {
+      try {
+        existingMetadata = JSON.parse(externalLink.metadata) as Record<
+          string,
+          unknown
+        >;
+      } catch (error) {
+        console.warn("Failed to parse GitHub issue metadata for reopen sync", {
+          externalLinkId: externalLink.id,
+          metadata: externalLink.metadata,
+          error,
+        });
+      }
+    }
 
     if (existingMetadata.createdFrom === "kaneo") {
       continue;
@@ -90,7 +102,5 @@ export async function handleIssueReopened(payload: IssueReopenedPayload) {
         state: "open",
       },
     });
-
-    return;
   }
 }

--- a/apps/api/src/plugins/github/webhooks/issue-reopened.ts
+++ b/apps/api/src/plugins/github/webhooks/issue-reopened.ts
@@ -1,0 +1,96 @@
+import { and, eq } from "drizzle-orm";
+import db from "../../../database";
+import { externalLinkTable, taskTable } from "../../../database/schema";
+import { publishEvent } from "../../../events";
+import { updateExternalLink } from "../services/link-manager";
+import {
+  findAllIntegrationsByRepo,
+  updateTaskStatus,
+} from "../services/task-service";
+import { resolveTargetStatus } from "../utils/resolve-column";
+
+type IssueReopenedPayload = {
+  action: string;
+  issue: {
+    number: number;
+    title: string;
+    html_url: string;
+    state: string;
+  };
+  repository: {
+    owner: { login: string };
+    name: string;
+    full_name: string;
+  };
+};
+
+export async function handleIssueReopened(payload: IssueReopenedPayload) {
+  const { issue, repository } = payload;
+
+  const integrations = await findAllIntegrationsByRepo(
+    repository.owner.login,
+    repository.name,
+  );
+
+  for (const integration of integrations) {
+    const externalLink = await db.query.externalLinkTable.findFirst({
+      where: and(
+        eq(externalLinkTable.integrationId, integration.id),
+        eq(externalLinkTable.resourceType, "issue"),
+        eq(externalLinkTable.externalId, issue.number.toString()),
+      ),
+    });
+
+    if (!externalLink) {
+      continue;
+    }
+
+    const task = await db.query.taskTable.findFirst({
+      where: eq(taskTable.id, externalLink.taskId),
+    });
+
+    if (!task) {
+      continue;
+    }
+
+    const existingMetadata = externalLink.metadata
+      ? JSON.parse(externalLink.metadata)
+      : {};
+
+    if (existingMetadata.createdFrom === "kaneo") {
+      continue;
+    }
+
+    const targetStatus = await resolveTargetStatus(
+      task.projectId,
+      "issue_reopened",
+      "to-do",
+    );
+
+    const statusResult = await updateTaskStatus(task.id, targetStatus);
+    if (
+      statusResult.applied &&
+      statusResult.before.status !== statusResult.after.status
+    ) {
+      await publishEvent("task.status_changed", {
+        taskId: statusResult.after.id,
+        projectId: statusResult.after.projectId,
+        userId: null,
+        oldStatus: statusResult.before.status,
+        newStatus: statusResult.after.status,
+        title: statusResult.after.title,
+        assigneeId: statusResult.after.userId,
+        type: "status_changed",
+      });
+    }
+
+    await updateExternalLink(externalLink.id, {
+      metadata: {
+        ...existingMetadata,
+        state: "open",
+      },
+    });
+
+    return;
+  }
+}


### PR DESCRIPTION
## Description

Reopening a GitHub issue now moves every linked Kaneo task back to the status selected for the `issue_reopened` workflow. Previously, the GitHub integration handled issue closure but had no matching reopen subscription, so the board could remain out of sync with GitHub.

The handler follows the existing `issue-closed.ts` path: it loads each matching integration, finds the external link and task, respects the `createdFrom === "kaneo"` guard, updates the task status, publishes `task.status_changed`, and records the link state as open. The webhook registration now listens for `issues.reopened`.

This branch was also cleaned up so the PR contains only the two webhook files. The unrelated project-key commits that had entered the branch are no longer part of the diff.

## Testing

Validated in a Linux container with Node 22 and pnpm 10.32.1:

- Biome passed on both changed files.
- `@kaneo/email` and `@kaneo/permissions` built successfully.
- `@kaneo/api` typecheck passed.
- All 267 API unit tests passed.
- The API production build completed successfully.

A live GitHub webhook was not sent because that requires an installed GitHub App and repository credentials. The local validation covers compilation, handler wiring, existing API behavior, and the production bundle.

## Type of Change

- [x] New feature with no breaking API change

## Checklist

- [x] The diff is limited to the GitHub reopen handler and its registration.
- [x] The code follows the existing close-handler conventions.
- [x] Typecheck, unit tests, formatting checks, and build pass.
