### PR TITLE
fix(security): block the shared address space in webhook destinations

### DIFF
--- a/apps/api/src/utils/assert-public-destination.ts
+++ b/apps/api/src/utils/assert-public-destination.ts
@@ -13,6 +13,10 @@ function isDisallowedIpv4(ip: string): boolean {
     a === 0 ||
     a === 10 ||
     a === 127 ||
+    // 100.64.0.0/10, RFC 6598. Several hosted Kubernetes offerings put pod
+    // and service networks in here, where it reaches the same neighbours
+    // 10/8 does on a plain VPC.
+    (a === 100 && b >= 64 && b <= 127) ||
     (a === 169 && b === 254) ||
     (a === 172 && b >= 16 && b <= 31) ||
     (a === 192 && b === 168)

--- a/tests/api/utils/assert-public-destination.test.ts
+++ b/tests/api/utils/assert-public-destination.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { isDisallowedAddress } from "../../../apps/api/src/utils/assert-public-destination";
+
+describe("isDisallowedAddress", () => {
+  it("blocks the ranges a webhook must never reach", () => {
+    expect(isDisallowedAddress("localhost")).toBe(true);
+    expect(isDisallowedAddress("127.0.0.1")).toBe(true);
+    expect(isDisallowedAddress("10.0.0.1")).toBe(true);
+    expect(isDisallowedAddress("172.16.0.1")).toBe(true);
+    expect(isDisallowedAddress("192.168.1.1")).toBe(true);
+    expect(isDisallowedAddress("169.254.169.254")).toBe(true);
+    expect(isDisallowedAddress("[::1]")).toBe(true);
+    expect(isDisallowedAddress("[::ffff:7f00:1]")).toBe(true);
+  });
+
+  // RFC 6598. Several hosted Kubernetes offerings put pod and service
+  // networks in here, so on those clusters it reaches the same neighbours
+  // 10/8 does on a plain VPC.
+  it("blocks the shared address space", () => {
+    expect(isDisallowedAddress("100.64.0.0")).toBe(true);
+    expect(isDisallowedAddress("100.64.0.1")).toBe(true);
+    expect(isDisallowedAddress("100.100.100.100")).toBe(true);
+    expect(isDisallowedAddress("100.127.255.255")).toBe(true);
+  });
+
+  it("leaves the rest of 100.0.0.0/8 alone", () => {
+    expect(isDisallowedAddress("100.63.255.255")).toBe(false);
+    expect(isDisallowedAddress("100.128.0.0")).toBe(false);
+    expect(isDisallowedAddress("100.0.0.1")).toBe(false);
+  });
+
+  it("allows a routable address", () => {
+    expect(isDisallowedAddress("8.8.8.8")).toBe(false);
+    expect(isDisallowedAddress("93.184.216.34")).toBe(false);
+    expect(isDisallowedAddress("example.com")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

`isDisallowedIpv4` in `assert-public-destination.ts` refuses `0/8`, `10/8`, `127/8`, `169.254/16`, `172.16/12` and `192.168/16`, which covers the usual ones including the cloud metadata endpoint. It does not refuse **`100.64.0.0/10`**.

```
isDisallowedAddress("10.0.0.1")        // true
isDisallowedAddress("169.254.169.254") // true
isDisallowedAddress("100.64.0.1")      // false
isDisallowedAddress("100.100.100.100") // false
```

RFC 6598 set that range aside for carrier-grade NAT, and several hosted Kubernetes offerings put pod and service networks in it. On one of those clusters, a webhook aimed at `100.64.x.x` reaches the same neighbours one aimed at `10.x.x.x` would, and that one is already refused.

It applies to resolved addresses too, not just to a literal in the URL: `assertPublicDestination` runs the same check over every entry `lookup` returns, so a hostname pointing into the range takes the same path.

## The change

One clause in the same shape as the ones beside it. `100.63.255.255` and `100.128.0.0` stay allowed, since the range is `/10` rather than the whole `100/8`.

I left the other special-purpose ranges out on purpose. `192.0.0.0/24` and `198.18.0.0/15` are also non-routable and also missing, but they do not sit in front of anything a real deployment runs, so widening the list further felt like a decision for you rather than a fix.

## Related Issue(s)

None. Found by reading the guard.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

New file `tests/api/utils/assert-public-destination.test.ts`. There was no direct coverage of `isDisallowedAddress`, so it starts with the ranges that already worked, then the shared address space, then the boundaries either side of it, then a routable address.

```
sem a correcao:  Tests  1 failed | 3 passed (4)
com a correcao:  Tests  4 passed (4)
```

Three of the four pass on both sides, so the group is not just asserting the change back at itself.

Full API suite: 42 files, 271 tests, 0 failures. `biome check` clean on both files.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked shared IPv4 addresses in the reserved `100.64.0.0/10` range from being treated as public destinations.
  * Preserved access to valid public IP addresses and hostnames while continuing to block private, local, and other restricted addresses.

* **Tests**
  * Added coverage for restricted and permitted IPv4 and IPv6 address scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->