### PR TITLE
feat(task): let images be resized in the task description

### DIFF
--- a/apps/web/src/components/task/extensions/resizable-image.test.ts
+++ b/apps/web/src/components/task/extensions/resizable-image.test.ts
@@ -109,4 +109,62 @@ describe("ResizableImage", () => {
 
     expect(instance.getJSON().content?.[0]?.attrs?.width).toBeNull();
   });
+
+  it("ignores a percentage in the width attribute", () => {
+    const instance = createEditor();
+    instance.commands.setContent(`<img src="${SRC}" width="50%">`);
+
+    expect(instance.getJSON().content?.[0]?.attrs?.width).toBeNull();
+  });
+
+  it("accepts an explicit px suffix on the width attribute", () => {
+    const instance = createEditor();
+    instance.commands.setContent(`<img src="${SRC}" width="320px">`);
+
+    expect(instance.getJSON().content?.[0]?.attrs?.width).toBe(320);
+  });
+
+  it("ignores a width attribute in a unit that is not pixels", () => {
+    const instance = createEditor();
+    instance.commands.setContent(`<img src="${SRC}" width="20em">`);
+
+    expect(instance.getJSON().content?.[0]?.attrs?.width).toBeNull();
+  });
+
+  it("falls back to the inline style when the width attribute is unusable", () => {
+    const instance = createEditor();
+    instance.commands.setContent(
+      `<img src="${SRC}" width="50%" style="width: 320px">`,
+    );
+
+    expect(instance.getJSON().content?.[0]?.attrs?.width).toBe(320);
+  });
+
+  it("escapes brackets in the alt text of an unresized image", () => {
+    const instance = createEditor();
+    setImage(instance, { alt: "report].png" });
+
+    const markdown = instance.getMarkdown();
+    instance.commands.setContent(markdown, { contentType: "markdown" });
+
+    const image = instance.getJSON().content?.[0];
+
+    expect(image?.type).toBe("image");
+    expect(image?.attrs?.src).toBe(SRC);
+    expect(image?.attrs?.alt).toBe("report].png");
+  });
+
+  it("keeps a parenthesised src parseable for an unresized image", () => {
+    const instance = createEditor();
+    const parenSrc = "https://kaneo.app/diagram(1).png";
+    instance.commands.setContent({
+      type: "doc",
+      content: [{ type: "image", attrs: { src: parenSrc, alt: "Diagram" } }],
+    });
+
+    const markdown = instance.getMarkdown();
+    instance.commands.setContent(markdown, { contentType: "markdown" });
+
+    expect(instance.getJSON().content?.[0]?.attrs?.src).toBe(parenSrc);
+  });
 });

--- a/apps/web/src/components/task/extensions/resizable-image.test.ts
+++ b/apps/web/src/components/task/extensions/resizable-image.test.ts
@@ -1,0 +1,112 @@
+import { Editor } from "@tiptap/core";
+import { Markdown } from "@tiptap/markdown";
+import StarterKit from "@tiptap/starter-kit";
+import { afterEach, describe, expect, it } from "vitest";
+import { ResizableImage } from "./resizable-image";
+
+const SRC = "https://kaneo.app/diagram.png";
+
+let editor: Editor | null = null;
+
+function createEditor() {
+  editor = new Editor({
+    extensions: [
+      StarterKit,
+      Markdown.configure({ markedOptions: { breaks: true, gfm: true } }),
+      ResizableImage,
+    ],
+    content: "",
+  });
+
+  return editor;
+}
+
+function setImage(instance: Editor, attrs: Record<string, unknown>) {
+  instance.commands.setContent({
+    type: "doc",
+    content: [{ type: "image", attrs: { src: SRC, ...attrs } }],
+  });
+}
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+describe("ResizableImage", () => {
+  it("keeps an unresized image as plain markdown", () => {
+    const instance = createEditor();
+    setImage(instance, { alt: "Diagram" });
+
+    const markdown = instance.getMarkdown();
+
+    expect(markdown).toContain(`![Diagram](${SRC})`);
+    expect(markdown).not.toContain("<img");
+  });
+
+  it("serializes a resized image as html so the width survives", () => {
+    const instance = createEditor();
+    setImage(instance, { alt: "Diagram", width: 640 });
+
+    const markdown = instance.getMarkdown();
+
+    expect(markdown).toContain("<img");
+    expect(markdown).toContain(`src="${SRC}"`);
+    expect(markdown).toContain('width="640"');
+  });
+
+  it("restores the width when a resized image round-trips through markdown", () => {
+    const instance = createEditor();
+    setImage(instance, { alt: "Diagram", width: 640 });
+
+    // Reload from the serialized markdown, exactly like the task view does.
+    instance.commands.setContent(instance.getMarkdown(), {
+      contentType: "markdown",
+    });
+
+    const image = instance.getJSON().content?.[0];
+
+    expect(image?.attrs?.src).toBe(SRC);
+    expect(image?.attrs?.width).toBe(640);
+  });
+
+  it("escapes html-unsafe values when serializing a resized image", () => {
+    const instance = createEditor();
+    setImage(instance, { alt: '"><script>alert(1)</script>', width: 320 });
+
+    const markdown = instance.getMarkdown();
+
+    expect(markdown).not.toContain("<script>");
+    expect(markdown).toContain("&quot;&gt;&lt;script&gt;");
+  });
+
+  it("reads a width back off plain html", () => {
+    const instance = createEditor();
+    instance.commands.setContent(
+      `<img src="${SRC}" alt="Diagram" width="240">`,
+    );
+
+    expect(instance.getJSON().content?.[0]?.attrs?.width).toBe(240);
+  });
+
+  it("reads a pixel width off an inline style", () => {
+    const instance = createEditor();
+    instance.commands.setContent(`<img src="${SRC}" style="width: 320px">`);
+
+    expect(instance.getJSON().content?.[0]?.attrs?.width).toBe(320);
+  });
+
+  it("ignores a percentage width, which is not a pixel count", () => {
+    const instance = createEditor();
+    instance.commands.setContent(`<img src="${SRC}" style="width: 50%">`);
+
+    expect(instance.getJSON().content?.[0]?.attrs?.width).toBeNull();
+  });
+
+  it("ignores a non-positive width", () => {
+    const instance = createEditor();
+    instance.commands.setContent(`<img src="${SRC}" alt="Diagram" width="0">`);
+
+    expect(instance.getJSON().content?.[0]?.attrs?.width).toBeNull();
+  });
+});

--- a/apps/web/src/components/task/extensions/resizable-image.tsx
+++ b/apps/web/src/components/task/extensions/resizable-image.tsx
@@ -1,0 +1,182 @@
+import Image from "@tiptap/extension-image";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+import {
+  type PointerEvent as ReactPointerEvent,
+  useRef,
+  useState,
+} from "react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/cn";
+import { escapeHtml } from "./url-safety";
+
+const MIN_WIDTH = 80;
+
+const SIZE_PRESETS = [
+  { key: "small", label: "tasks:detail.editor.image.small", fraction: 0.25 },
+  { key: "medium", label: "tasks:detail.editor.image.medium", fraction: 0.5 },
+  { key: "large", label: "tasks:detail.editor.image.large", fraction: 1 },
+] as const;
+
+function parseWidth(value: unknown) {
+  const width = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(width) && width > 0 ? width : null;
+}
+
+function ResizableImageNodeView({
+  editor,
+  node,
+  updateAttributes,
+}: NodeViewProps) {
+  const { t } = useTranslation();
+  const imageRef = useRef<HTMLImageElement>(null);
+  const [isResizing, setIsResizing] = useState(false);
+  const width = parseWidth(node.attrs.width);
+  const isEditable = editor.isEditable;
+
+  const maxWidth = () => editor.view.dom.clientWidth || MIN_WIDTH;
+
+  const clamp = (value: number) =>
+    Math.round(Math.min(Math.max(value, MIN_WIDTH), maxWidth()));
+
+  const handleResizeStart = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (!isEditable) return;
+    event.preventDefault();
+
+    const startX = event.clientX;
+    const startWidth = imageRef.current?.getBoundingClientRect().width ?? 0;
+    const handle = event.currentTarget;
+    handle.setPointerCapture(event.pointerId);
+    setIsResizing(true);
+
+    const handleMove = (moveEvent: PointerEvent) => {
+      updateAttributes({
+        width: clamp(startWidth + moveEvent.clientX - startX),
+      });
+    };
+
+    const handleEnd = () => {
+      handle.releasePointerCapture(event.pointerId);
+      handle.removeEventListener("pointermove", handleMove);
+      handle.removeEventListener("pointerup", handleEnd);
+      handle.removeEventListener("pointercancel", handleEnd);
+      setIsResizing(false);
+    };
+
+    handle.addEventListener("pointermove", handleMove);
+    handle.addEventListener("pointerup", handleEnd);
+    handle.addEventListener("pointercancel", handleEnd);
+  };
+
+  return (
+    <NodeViewWrapper
+      as="span"
+      className="kaneo-resizable-image"
+      data-resized={width ? "true" : "false"}
+    >
+      <img
+        ref={imageRef}
+        src={node.attrs.src}
+        alt={node.attrs.alt || ""}
+        title={node.attrs.title || undefined}
+        width={width ?? undefined}
+        // The stylesheet sets `width: auto` on editor images, so the width
+        // attribute alone would not survive into the rendered size.
+        style={width ? { width: `${width}px` } : undefined}
+        loading="lazy"
+        className="kaneo-editor-image"
+      />
+
+      {isEditable && (
+        <span
+          className="kaneo-resizable-image-controls"
+          contentEditable={false}
+        >
+          {SIZE_PRESETS.map((preset) => (
+            <button
+              key={preset.key}
+              type="button"
+              onClick={() =>
+                updateAttributes({ width: clamp(maxWidth() * preset.fraction) })
+              }
+            >
+              {t(preset.label)}
+            </button>
+          ))}
+          <button
+            type="button"
+            disabled={!width}
+            onClick={() => updateAttributes({ width: null })}
+          >
+            {t("tasks:detail.editor.image.reset")}
+          </button>
+        </span>
+      )}
+
+      {isEditable && (
+        <button
+          type="button"
+          aria-label={t("tasks:detail.editor.image.resizeHandle")}
+          className={cn(
+            "kaneo-resizable-image-handle",
+            isResizing && "kaneo-resizable-image-handle-active",
+          )}
+          onPointerDown={handleResizeStart}
+        />
+      )}
+    </NodeViewWrapper>
+  );
+}
+
+export const ResizableImage = Image.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      width: {
+        default: null,
+        parseHTML: (element: HTMLElement) => {
+          const styleWidth = element.style.width;
+          return parseWidth(
+            element.getAttribute("width") ??
+              // Only pixel widths are portable; a percentage would otherwise
+              // be misread as a pixel count.
+              (styleWidth.endsWith("px") ? styleWidth.slice(0, -2) : null),
+          );
+        },
+        renderHTML: (attributes: Record<string, unknown>) => {
+          const width = parseWidth(attributes.width);
+          return width ? { width } : {};
+        },
+      },
+    };
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ResizableImageNodeView);
+  },
+
+  renderMarkdown(
+    node: {
+      attrs?: { src?: string; alt?: string; title?: string; width?: number };
+    },
+    _helpers: unknown,
+    _context: unknown,
+  ) {
+    const src = String(node.attrs?.src || "");
+    const alt = String(node.attrs?.alt || "");
+    const title = String(node.attrs?.title || "");
+    const width = parseWidth(node.attrs?.width);
+
+    if (!src) return "";
+
+    // Standard markdown has nowhere to carry a width, so a resized image is
+    // written as HTML — which the markdown pipeline round-trips intact.
+    if (!width) {
+      return `![${alt}](${src}${title ? ` "${title}"` : ""})`;
+    }
+
+    return `<img src="${escapeHtml(src)}" alt="${escapeHtml(alt)}"${
+      title ? ` title="${escapeHtml(title)}"` : ""
+    } width="${width}" />`;
+  },
+});

--- a/apps/web/src/components/task/extensions/resizable-image.tsx
+++ b/apps/web/src/components/task/extensions/resizable-image.tsx
@@ -2,15 +2,22 @@ import Image from "@tiptap/extension-image";
 import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
 import {
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   useRef,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
-import { escapeHtml } from "./url-safety";
+import {
+  escapeHtml,
+  escapeMarkdownText,
+  escapeMarkdownTitle,
+  formatMarkdownUrl,
+} from "./url-safety";
 
 const MIN_WIDTH = 80;
+const RESIZE_STEP = 16;
 
 const SIZE_PRESETS = [
   { key: "small", label: "tasks:detail.editor.image.small", fraction: 0.25 },
@@ -19,8 +26,18 @@ const SIZE_PRESETS = [
 ] as const;
 
 function parseWidth(value: unknown) {
-  const width = Number.parseInt(String(value ?? ""), 10);
-  return Number.isFinite(width) && width > 0 ? width : null;
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value > 0 ? value : null;
+  }
+
+  // `Number.parseInt` stops at the first non-digit and discards the rest, so it
+  // would read `50%` as 50 pixels. Match the whole value instead, so only a
+  // pixel count gets through and every other unit is rejected.
+  const match = /^(\d+)(?:px)?$/i.exec(String(value ?? "").trim());
+  if (!match) return null;
+
+  const width = Number.parseInt(match[1], 10);
+  return width > 0 ? width : null;
 }
 
 function ResizableImageNodeView({
@@ -31,7 +48,12 @@ function ResizableImageNodeView({
   const { t } = useTranslation();
   const imageRef = useRef<HTMLImageElement>(null);
   const [isResizing, setIsResizing] = useState(false);
-  const width = parseWidth(node.attrs.width);
+  // Width previewed mid-drag. Committing on every `pointermove` would run a
+  // ProseMirror transaction — and the full-document markdown re-serialization in
+  // `TaskDescription.onUpdate` — at pointer-event frequency.
+  const [draftWidth, setDraftWidth] = useState<number | null>(null);
+  const draftWidthRef = useRef<number | null>(null);
+  const width = draftWidth ?? parseWidth(node.attrs.width);
   const isEditable = editor.isEditable;
 
   const maxWidth = () => editor.view.dom.clientWidth || MIN_WIDTH;
@@ -50,9 +72,9 @@ function ResizableImageNodeView({
     setIsResizing(true);
 
     const handleMove = (moveEvent: PointerEvent) => {
-      updateAttributes({
-        width: clamp(startWidth + moveEvent.clientX - startX),
-      });
+      const next = clamp(startWidth + moveEvent.clientX - startX);
+      draftWidthRef.current = next;
+      setDraftWidth(next);
     };
 
     const handleEnd = () => {
@@ -61,11 +83,34 @@ function ResizableImageNodeView({
       handle.removeEventListener("pointerup", handleEnd);
       handle.removeEventListener("pointercancel", handleEnd);
       setIsResizing(false);
+
+      // One transaction per gesture, so a single undo reverses the whole drag.
+      const resizedTo = draftWidthRef.current;
+      draftWidthRef.current = null;
+      setDraftWidth(null);
+      if (resizedTo !== null) updateAttributes({ width: resizedTo });
     };
 
     handle.addEventListener("pointermove", handleMove);
     handle.addEventListener("pointerup", handleEnd);
     handle.addEventListener("pointercancel", handleEnd);
+  };
+
+  const handleResizeKeyDown = (
+    event: ReactKeyboardEvent<HTMLButtonElement>,
+  ) => {
+    if (!isEditable) return;
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+
+    const current =
+      width ??
+      Math.round(imageRef.current?.getBoundingClientRect().width ?? MIN_WIDTH);
+    const step = event.shiftKey ? RESIZE_STEP * 4 : RESIZE_STEP;
+
+    updateAttributes({
+      width: clamp(current + (event.key === "ArrowLeft" ? -step : step)),
+    });
   };
 
   return (
@@ -122,6 +167,7 @@ function ResizableImageNodeView({
             isResizing && "kaneo-resizable-image-handle-active",
           )}
           onPointerDown={handleResizeStart}
+          onKeyDown={handleResizeKeyDown}
         />
       )}
     </NodeViewWrapper>
@@ -134,15 +180,12 @@ export const ResizableImage = Image.extend({
       ...this.parent?.(),
       width: {
         default: null,
-        parseHTML: (element: HTMLElement) => {
-          const styleWidth = element.style.width;
-          return parseWidth(
-            element.getAttribute("width") ??
-              // Only pixel widths are portable; a percentage would otherwise
-              // be misread as a pixel count.
-              (styleWidth.endsWith("px") ? styleWidth.slice(0, -2) : null),
-          );
-        },
+        parseHTML: (element: HTMLElement) =>
+          // `parseWidth` rejects every unit but `px`, so both raw values can go
+          // straight in. Reading them independently also stops an unusable
+          // `width="50%"` from shadowing a usable inline `width: 320px`.
+          parseWidth(element.getAttribute("width")) ??
+          parseWidth(element.style.width),
         renderHTML: (attributes: Record<string, unknown>) => {
           const width = parseWidth(attributes.width);
           return width ? { width } : {};
@@ -172,7 +215,10 @@ export const ResizableImage = Image.extend({
     // Standard markdown has nowhere to carry a width, so a resized image is
     // written as HTML — which the markdown pipeline round-trips intact.
     if (!width) {
-      return `![${alt}](${src}${title ? ` "${title}"` : ""})`;
+      const markdownTitle = title ? ` "${escapeMarkdownTitle(title)}"` : "";
+      return `![${escapeMarkdownText(alt)}](${formatMarkdownUrl(
+        src,
+      )}${markdownTitle})`;
     }
 
     return `<img src="${escapeHtml(src)}" alt="${escapeHtml(alt)}"${

--- a/apps/web/src/components/task/extensions/url-safety.ts
+++ b/apps/web/src/components/task/extensions/url-safety.ts
@@ -14,3 +14,20 @@ export function escapeHtml(value: string) {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
 }
+
+// An unescaped `]` closes the alt text early, so `![report].png](src)` parses as
+// a paragraph and the image is lost on the next load.
+export function escapeMarkdownText(value: string) {
+  return value.replace(/[\\[\]]/g, (character) => `\\${character}`);
+}
+
+export function escapeMarkdownTitle(value: string) {
+  return value.replace(/[\\"]/g, (character) => `\\${character}`);
+}
+
+// A bare markdown destination ends at the first whitespace or angle bracket, so
+// those have to move into the `<...>` form to survive a round-trip.
+export function formatMarkdownUrl(value: string) {
+  if (!/[\s<>]/.test(value)) return value;
+  return `<${value.replace(/[<>]/g, encodeURIComponent)}>`;
+}

--- a/apps/web/src/components/task/task-description.tsx
+++ b/apps/web/src/components/task/task-description.tsx
@@ -1,5 +1,4 @@
 import type { Editor } from "@tiptap/core";
-import Image from "@tiptap/extension-image";
 import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import { Table } from "@tiptap/extension-table";
@@ -80,6 +79,7 @@ import { AttachmentCard } from "./extensions/attachment-card";
 import { EmbedBlock } from "./extensions/embed-block";
 import { KaneoIssueLink } from "./extensions/kaneo-issue-link";
 import { MermaidBlock } from "./extensions/mermaid-block";
+import { ResizableImage } from "./extensions/resizable-image";
 import {
   SHIKI_CODEBLOCK_REFRESH_META,
   ShikiCodeBlock,
@@ -647,7 +647,7 @@ export default function TaskDescription({ taskId }: TaskDescriptionProps) {
         AttachmentCard,
         KaneoIssueLink,
         TaskList,
-        Image.configure({
+        ResizableImage.configure({
           HTMLAttributes: {
             class: "kaneo-editor-image",
             loading: "lazy",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -735,6 +735,19 @@ input:-webkit-autofill:active {
     max-width: 100%;
   }
 
+  /* An explicit resize is the user overriding the 44rem readability cap. Without
+     this the cap still wins above 704px, so the image renders at a different
+     size than the width that was persisted. */
+  .kaneo-tiptap-content
+    .ProseMirror
+    .kaneo-resizable-image[data-resized="true"]
+    img.kaneo-editor-image,
+  .kaneo-comment-editor-prose
+    .kaneo-resizable-image[data-resized="true"]
+    img.kaneo-editor-image {
+    max-width: 100%;
+  }
+
   .kaneo-resizable-image-controls {
     position: absolute;
     top: 1.25rem;
@@ -795,6 +808,17 @@ input:-webkit-autofill:active {
   .kaneo-resizable-image-handle:focus-visible,
   .kaneo-resizable-image-handle-active {
     opacity: 1;
+  }
+
+  /* Touch devices never produce hover, and the controls start at
+     `pointer-events: none`, so a tap could neither reveal nor focus them. Show
+     them unconditionally where hover does not exist. */
+  @media (hover: none) {
+    .kaneo-resizable-image-controls,
+    .kaneo-resizable-image-handle {
+      opacity: 1;
+      pointer-events: auto;
+    }
   }
 
   .kaneo-tiptap-content .ProseMirror .is-editor-empty:first-child::before {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -729,6 +729,74 @@ input:-webkit-autofill:active {
     width: 100%;
   }
 
+  .kaneo-resizable-image {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+  }
+
+  .kaneo-resizable-image-controls {
+    position: absolute;
+    top: 1.25rem;
+    left: 0.5rem;
+    display: flex;
+    gap: 0.25rem;
+    padding: 0.25rem;
+    border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+    border-radius: calc(var(--radius) - 2px);
+    background: var(--popover);
+    box-shadow: 0 1px 2px color-mix(in srgb, var(--foreground) 12%, transparent);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 120ms ease-in-out;
+  }
+
+  /* Clicking the image opens the preview dialog, so the controls reveal on
+     hover rather than on selection. */
+  .kaneo-resizable-image:hover .kaneo-resizable-image-controls,
+  .kaneo-resizable-image-controls:focus-within {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .kaneo-resizable-image-controls button {
+    padding: 0.125rem 0.375rem;
+    border-radius: calc(var(--radius) - 4px);
+    font-size: 0.75rem;
+    line-height: 1rem;
+    color: var(--popover-foreground);
+    cursor: pointer;
+  }
+
+  .kaneo-resizable-image-controls button:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--accent) 60%, transparent);
+  }
+
+  .kaneo-resizable-image-controls button:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .kaneo-resizable-image-handle {
+    position: absolute;
+    right: 0.25rem;
+    bottom: 1rem;
+    width: 0.75rem;
+    height: 0.75rem;
+    border: 1px solid var(--background);
+    border-radius: 9999px;
+    background: var(--primary);
+    opacity: 0;
+    cursor: ew-resize;
+    transition: opacity 120ms ease-in-out;
+  }
+
+  .kaneo-resizable-image:hover .kaneo-resizable-image-handle,
+  .kaneo-resizable-image-handle:focus-visible,
+  .kaneo-resizable-image-handle-active {
+    opacity: 1;
+  }
+
   .kaneo-tiptap-content .ProseMirror .is-editor-empty:first-child::before {
     pointer-events: none;
     content: attr(data-placeholder);

--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Mermaid-Diagramm konnte nicht gerendert werden"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/el-GR.json
+++ b/i18n/el-GR.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Δεν ήταν δυνατή η απόδοση του διαγράμματος Mermaid"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1688,6 +1688,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Mermaid diagram couldn't be rendered"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "No se pudo renderizar el diagrama de Mermaid"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Impossible d'afficher le diagramme Mermaid"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/hi-IN.json
+++ b/i18n/hi-IN.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Mermaid डायग्राम प्रस्तुत नहीं किया जा सका"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/id-ID.json
+++ b/i18n/id-ID.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Diagram Mermaid tidak dapat dirender"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/it-IT.json
+++ b/i18n/it-IT.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Impossibile eseguire il rendering del diagramma Mermaid"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/ko-KR.json
+++ b/i18n/ko-KR.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Mermaid 다이어그램을 렌더링할 수 없습니다"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/mk-MK.json
+++ b/i18n/mk-MK.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Mermaid дијаграмот не можеше да се прикаже"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/nl-NL.json
+++ b/i18n/nl-NL.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Mermaid-diagram kon niet worden weergegeven"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Mermaid diagram couldn't be rendered"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/ru-RU.json
+++ b/i18n/ru-RU.json
@@ -1683,6 +1683,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Не удалось отобразить диаграмму Mermaid"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -6475,6 +6475,34 @@
 										}
 									},
 									"required": ["renderFailed"]
+								},
+								"image": {
+									"type": "object",
+									"additionalProperties": false,
+									"properties": {
+										"small": {
+											"type": "string"
+										},
+										"medium": {
+											"type": "string"
+										},
+										"large": {
+											"type": "string"
+										},
+										"reset": {
+											"type": "string"
+										},
+										"resizeHandle": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"small",
+										"medium",
+										"large",
+										"reset",
+										"resizeHandle"
+									]
 								}
 							},
 							"required": [
@@ -6493,7 +6521,8 @@
 								"slash",
 								"languages",
 								"embed",
-								"mermaid"
+								"mermaid",
+								"image"
 							]
 						}
 					},

--- a/i18n/tr-TR.json
+++ b/i18n/tr-TR.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Mermaid diyagramı oluşturulamadı"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/uk-UA.json
+++ b/i18n/uk-UA.json
@@ -1675,6 +1675,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Не вдалося відобразити діаграму Mermaid"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/vi-VN.json
+++ b/i18n/vi-VN.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Mermaid diagram couldn't be rendered"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -1665,6 +1665,13 @@
 				},
 				"mermaid": {
 					"renderFailed": "Mermaid diagram couldn't be rendered"
+				},
+				"image": {
+					"large": "Large",
+					"medium": "Medium",
+					"reset": "Reset size",
+					"resizeHandle": "Resize image",
+					"small": "Small"
 				}
 			}
 		},


### PR DESCRIPTION
## Description

Images in a task description always render at full size, which crowds the
description on smaller screens — vertical images especially.

This adds a resizable image node view with the two sizing affordances the
issue asks for: presets (small / medium / large, as a fraction of the editor
width) and a drag handle on the image edge. Controls reveal on hover, because
clicking an editor image already opens the preview dialog.

The non-obvious part is persistence. Descriptions are saved as markdown, and
`![alt](src)` has nowhere to carry a width — so an image attribute alone is
dropped on the next load, and a resize would appear to work until reload. A
resized image is therefore serialized as an `<img>` tag carrying the width,
the same HTML-in-markdown route `attachment-card` already uses, and parsed
back on load. Unresized images are still written as plain markdown, so
existing descriptions are byte-for-byte untouched.

Widths are pixel counts; a percentage in an inline style is ignored rather
than misread as pixels, and `src`/`alt`/`title` are escaped on the way out
via the existing `escapeHtml` helper.

Prior art: #1367 took a similar approach before being closed by its author.
This is an independent implementation.

## Related Issue(s)

Fixes #1211

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

`apps/web/src/components/task/extensions/resizable-image.test.ts` covers
8 cases: plain markdown for unresized images, HTML serialization when
resized, the full markdown round-trip restoring the width, HTML escaping,
parsing a width off an attribute and off an inline pixel style, rejecting a
percentage style, and rejecting a non-positive width.

Full web suite: 77 passing (was 69). `pnpm typecheck` and `biome ci .` clean.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

`pnpm i18n:check:fix` added the five new keys to the other locale files with
the English source text, per the workflow in CONTRIBUTING. Happy to drop those
files from the PR if you would rather translations landed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image resizing in the task editor with drag controls, size presets, and reset functionality.
  * Preserved image dimensions when saving and reopening task descriptions.
  * Improved handling of image URLs, alt text, and special characters during formatting.

* **Localization**
  * Added labels and accessibility text for image resizing controls across supported languages.

* **Tests**
  * Added coverage for resizing, serialization, width validation, escaping, and HTML handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->