### PR TITLE
fix(web): omit unassigned userId when creating tasks

### DIFF
--- a/apps/web/src/fetchers/task/create-task.test.ts
+++ b/apps/web/src/fetchers/task/create-task.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import createTask from "./create-task";
+
+const mocks = vi.hoisted(() => ({
+  post: vi.fn(),
+}));
+
+vi.mock("@kaneo/libs", () => ({
+  client: {
+    task: {
+      ":projectId": {
+        $post: mocks.post,
+      },
+    },
+  },
+}));
+
+describe("createTask", () => {
+  beforeEach(() => {
+    mocks.post.mockReset();
+    mocks.post.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "task-1" }),
+    });
+  });
+
+  it.each([undefined, ""])(
+    "omits the assignee when userId is %s",
+    async (userId) => {
+      await createTask(
+        "Unassigned task",
+        "",
+        "project-1",
+        userId,
+        "to-do",
+        undefined,
+        undefined,
+        "no-priority",
+      );
+
+      expect(mocks.post).toHaveBeenCalledWith({
+        json: {
+          title: "Unassigned task",
+          description: "",
+          status: "to-do",
+          startDate: undefined,
+          dueDate: undefined,
+          priority: "no-priority",
+        },
+        param: { projectId: "project-1" },
+      });
+    },
+  );
+
+  it("preserves an assigned userId", async () => {
+    await createTask(
+      "Assigned task",
+      "",
+      "project-1",
+      "user-1",
+      "to-do",
+      undefined,
+      undefined,
+      "no-priority",
+    );
+
+    expect(mocks.post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({ userId: "user-1" }),
+      }),
+    );
+  });
+});

--- a/apps/web/src/fetchers/task/create-task.ts
+++ b/apps/web/src/fetchers/task/create-task.ts
@@ -10,7 +10,7 @@ async function createTask(
   title: string,
   description: string,
   projectId: string,
-  userId: string,
+  userId: string | undefined,
   status: string,
   startDate: Date | undefined,
   dueDate: Date | undefined,
@@ -24,7 +24,7 @@ async function createTask(
     json: {
       title,
       description,
-      userId,
+      ...(userId ? { userId } : {}),
       status,
       startDate: startDate?.toISOString() || undefined,
       dueDate: dueDate?.toISOString() || undefined,

--- a/apps/web/src/hooks/mutations/task/use-create-task.ts
+++ b/apps/web/src/hooks/mutations/task/use-create-task.ts
@@ -21,7 +21,7 @@ function useCreateTask() {
         title,
         description,
         projectId,
-        userId ?? "",
+        userId,
         status,
         startDate ? new Date(startDate) : undefined,
         dueDate ? new Date(dueDate) : undefined,


### PR DESCRIPTION
## Summary

- preserve an omitted assignee through the create-task mutation
- leave `userId` out of create requests when the task is unassigned
- add request-level regression coverage for undefined, empty, and assigned user IDs

Fixes #1550

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @kaneo/site exec next build --webpack`
- pre-commit Web/API/package builds passed; the default site Turbopack build cannot bind its internal localhost port in the execution sandbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task creation now works correctly when no user is assigned.
  * Unassigned tasks no longer send an empty user ID.
  * Assigned user IDs continue to be preserved when creating tasks.

* **Tests**
  * Added coverage for task creation with and without an assigned user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->