### PR TITLE
fix: preserve time entry end time

### DIFF
--- a/apps/api/src/time-entry/controllers/update-time-entry.ts
+++ b/apps/api/src/time-entry/controllers/update-time-entry.ts
@@ -24,17 +24,21 @@ async function updateTimeEntry(params: UpdateTimeEntryParams) {
     });
   }
 
-  // Calculate duration if both startTime and endTime are provided
+  const effectiveEndTime = endTime ?? existingTimeEntry.endTime;
+
+  // Calculate duration if the entry has an endTime after this update.
   let duration: number | null = null;
-  if (endTime) {
-    duration = Math.floor((endTime.getTime() - startTime.getTime()) / 1000); // duration in seconds
+  if (effectiveEndTime) {
+    duration = Math.floor(
+      (effectiveEndTime.getTime() - startTime.getTime()) / 1000,
+    ); // duration in seconds
   }
 
   const [updatedTimeEntry] = await db
     .update(timeEntryTable)
     .set({
       startTime,
-      endTime: endTime || null,
+      endTime: effectiveEndTime,
       duration,
       ...(description !== undefined && { description }),
     })

--- a/tests/api/time-entry/update-time-entry.test.ts
+++ b/tests/api/time-entry/update-time-entry.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+const mockSelect = vi.fn();
+const mockUpdate = vi.fn();
+
+vi.mock("../../../apps/api/src/database", () => ({
+  default: {
+    select: (...args: unknown[]) => mockSelect(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+  },
+}));
+
+import updateTimeEntry from "../../../apps/api/src/time-entry/controllers/update-time-entry";
+
+function makeSelectMock(rows: unknown[]) {
+  const chain: Record<string, Mock> = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => Promise.resolve(rows)),
+  };
+  return chain;
+}
+
+function makeUpdateMock(updatedRow: unknown) {
+  const returning = vi.fn(() => Promise.resolve([updatedRow]));
+  const where = vi.fn(() => ({ returning }));
+  const set = vi.fn(() => ({ where }));
+  return { set, where, returning };
+}
+
+describe("updateTimeEntry", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("preserves a stored endTime and duration when endTime is omitted", async () => {
+    const storedStartTime = new Date("2026-08-10T10:00:00.000Z");
+    const storedEndTime = new Date("2026-08-10T11:00:00.000Z");
+    const nextStartTime = new Date("2026-08-10T10:15:00.000Z");
+    const updatedRow = {
+      id: "time-entry-1",
+      startTime: nextStartTime,
+      endTime: storedEndTime,
+      duration: 2700,
+      description: "renamed",
+    };
+    const updateChain = makeUpdateMock(updatedRow);
+
+    mockSelect.mockReturnValue(
+      makeSelectMock([
+        {
+          id: "time-entry-1",
+          startTime: storedStartTime,
+          endTime: storedEndTime,
+          duration: 3600,
+        },
+      ]),
+    );
+    mockUpdate.mockReturnValue(updateChain);
+
+    await updateTimeEntry({
+      timeEntryId: "time-entry-1",
+      startTime: nextStartTime,
+      description: "renamed",
+    });
+
+    expect(updateChain.set).toHaveBeenCalledWith({
+      startTime: nextStartTime,
+      endTime: storedEndTime,
+      duration: 2700,
+      description: "renamed",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve an existing `endTime` when `PUT /time-entry/:id` omits `endTime`.
- Recompute `duration` from the updated `startTime` and preserved/stated `endTime` instead of clearing it to `null`.
- Add a regression test covering description/start-time updates that leave completed entries completed.

## Verification
- RED: `pnpm --filter @kaneo/api test:unit -- ../../tests/api/time-entry/update-time-entry.test.ts` failed before the fix because `endTime`/`duration` were set to `null`.
- GREEN: `pnpm --filter @kaneo/api test:unit -- ../../tests/api/time-entry/update-time-entry.test.ts` (44 files / 279 tests passed)
- `pnpm --filter @kaneo/api build`
- `pnpm --filter @kaneo/api lint` (passes with existing warnings)

Note: `pnpm --filter @kaneo/api typecheck` currently fails on `src/utils/get-settings.ts` because `@kaneo/email` does not export `isSmtpConfigured`; this is unrelated to this change.

Fixes #1527.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updating a time entry without providing an end time now preserves the existing end time.
  * Duration and related details are recalculated and saved correctly when the start time changes.

* **Tests**
  * Added coverage to verify time entry updates retain the stored end time when no replacement is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->