### PR TITLE
fix: use internal URL for MCP tool requests

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 # General URLs
 KANEO_CLIENT_URL=http://localhost:5173
 # KANEO_API_URL=http://localhost:1337      # optional - defaults to KANEO_CLIENT_URL/api
+# KANEO_INTERNAL_API_URL=http://127.0.0.1:1337 # optional - internal MCP tool requests only
 # CORS_ORIGINS=                            # optional - comma-separated; defaults to KANEO_CLIENT_URL
 
 # Database

--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -43,6 +43,7 @@ For local development, the web app also supports:
 ### Optional Variables
 
 Kaneo supports many optional configuration options including:
+- `KANEO_INTERNAL_API_URL` - API origin used only for server-side requests from the built-in HTTP MCP endpoint. Defaults to `http://127.0.0.1:1337`; override it only if the API is not reachable there from its own process.
 - SSO providers (GitHub OAuth via `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET`, Google, Discord, Custom OAuth/OIDC)
 - GitHub repository integration (GitHub App: `GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`, `GITHUB_WEBHOOK_SECRET`, optional `GITHUB_APP_NAME`), separate from GitHub SSO
 - SMTP configuration for email

--- a/apps/api/src/mcp/index.ts
+++ b/apps/api/src/mcp/index.ts
@@ -28,12 +28,14 @@ import {
 } from "./schemas";
 import { registerMcpTools, toMcpToolRegistrar } from "./tools";
 
-const publicApiUrl = (
-  process.env.KANEO_API_URL || "http://localhost:1337"
-).replace(/\/api\/?$/, "");
+const publicApiUrl = (process.env.KANEO_API_URL || "http://localhost:1337")
+  .replace(/\/api\/?$/, "")
+  .replace(/\/+$/, "");
 const internalApiUrl = (
   process.env.KANEO_INTERNAL_API_URL || "http://127.0.0.1:1337"
-).replace(/\/api\/?$/, "");
+)
+  .replace(/\/api\/?$/, "")
+  .replace(/\/+$/, "");
 
 type McpSession = {
   transport: WebStandardStreamableHTTPServerTransport;

--- a/apps/api/src/mcp/index.ts
+++ b/apps/api/src/mcp/index.ts
@@ -28,10 +28,12 @@ import {
 } from "./schemas";
 import { registerMcpTools, toMcpToolRegistrar } from "./tools";
 
-const apiUrl = (process.env.KANEO_API_URL || "http://localhost:1337").replace(
-  /\/api\/?$/,
-  "",
-);
+const publicApiUrl = (
+  process.env.KANEO_API_URL || "http://localhost:1337"
+).replace(/\/api\/?$/, "");
+const internalApiUrl = (
+  process.env.KANEO_INTERNAL_API_URL || "http://127.0.0.1:1337"
+).replace(/\/api\/?$/, "");
 
 type McpSession = {
   transport: WebStandardStreamableHTTPServerTransport;
@@ -45,7 +47,7 @@ function createMcpServerForUser(token: string): LegacyMcpServer {
     name: "kaneo-mcp",
     version: "1.0.0",
   });
-  registerMcpTools(toMcpToolRegistrar(server), apiUrl, token);
+  registerMcpTools(toMcpToolRegistrar(server), internalApiUrl, token);
   return server;
 }
 
@@ -248,17 +250,17 @@ mcp.post("/mcp/token", async (c) => {
 
 mcp.get("/.well-known/oauth-protected-resource/api/mcp", (c) =>
   c.json({
-    resource: `${apiUrl}/api/mcp`,
-    authorization_servers: [`${apiUrl}/api`],
+    resource: `${publicApiUrl}/api/mcp`,
+    authorization_servers: [`${publicApiUrl}/api`],
   }),
 );
 
 mcp.get("/.well-known/oauth-authorization-server/api", (c) =>
   c.json({
-    issuer: `${apiUrl}/api`,
-    authorization_endpoint: `${apiUrl}/api/mcp/authorize`,
-    token_endpoint: `${apiUrl}/api/mcp/token`,
-    registration_endpoint: `${apiUrl}/api/mcp/register`,
+    issuer: `${publicApiUrl}/api`,
+    authorization_endpoint: `${publicApiUrl}/api/mcp/authorize`,
+    token_endpoint: `${publicApiUrl}/api/mcp/token`,
+    registration_endpoint: `${publicApiUrl}/api/mcp/register`,
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code"],
     code_challenge_methods_supported: ["S256"],
@@ -269,7 +271,7 @@ mcp.get("/.well-known/oauth-authorization-server/api", (c) =>
 mcp.all("/mcp", async (c) => {
   const authResult = await validateBearerToken(c.req.raw);
   if (!authResult) {
-    const prmUrl = `${apiUrl}/api/.well-known/oauth-protected-resource/api/mcp`;
+    const prmUrl = `${publicApiUrl}/api/.well-known/oauth-protected-resource/api/mcp`;
     c.header("WWW-Authenticate", `Bearer resource_metadata="${prmUrl}"`);
     return c.json(
       {
@@ -301,7 +303,7 @@ mcp.all("/mcp", async (c) => {
   }
 
   if (!(await isLegacyRequest(c.req.raw.clone()))) {
-    const modern = createModernMcpHandler(authResult.token, apiUrl);
+    const modern = createModernMcpHandler(authResult.token, internalApiUrl);
     return modern.fetch(c.req.raw);
   }
 

--- a/apps/docs/core/installation/environment-variables.mdx
+++ b/apps/docs/core/installation/environment-variables.mdx
@@ -13,6 +13,7 @@ The variables are split up into the following sections:
 - [General URLs](#general-urls)
 - [Database](#database)
 - [Authentication](#authentication)
+- [MCP](#mcp)
 - [Object Storage](#object-storage)
 - [Access Control](#access-control)
 - [GitHub SSO](#github-sso)
@@ -56,6 +57,12 @@ Name | Description |
 
 
 ## Optional variables
+
+### MCP
+
+Name | Description | Default |
+--- | --- | --- |
+| `KANEO_INTERNAL_API_URL` | API origin used only for server-side requests from the built-in HTTP MCP endpoint. Override it only if the API is not reachable at the default loopback address from its own process. | `http://127.0.0.1:1337` |
 
 ### Object Storage
 

--- a/tests/api/mcp-internal-api-url.test.ts
+++ b/tests/api/mcp-internal-api-url.test.ts
@@ -1,9 +1,4 @@
-import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
-
-vi.hoisted(() => {
-  vi.stubEnv("KANEO_API_URL", "http://public.test:5273/api");
-  vi.stubEnv("KANEO_INTERNAL_API_URL", undefined);
-});
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const authMocks = vi.hoisted(() => ({
   getSession: vi.fn(async () => ({ user: { id: "test-user" } })),
@@ -13,11 +8,9 @@ vi.mock("../../apps/api/src/auth", () => ({
   auth: { api: { getSession: authMocks.getSession } },
 }));
 
-import mcpRoutes from "../../apps/api/src/mcp";
-
 const protocolVersion = "2026-07-28";
 
-function toolRequest(): Request {
+function toolRequest() {
   return new Request("http://public.test:5273/mcp", {
     method: "POST",
     headers: {
@@ -48,13 +41,18 @@ function toolRequest(): Request {
   });
 }
 
+async function loadMcpRoutes(internalApiUrl?: string) {
+  vi.stubEnv("KANEO_API_URL", "http://public.test:5273/api");
+  vi.stubEnv("KANEO_INTERNAL_API_URL", internalApiUrl);
+  vi.resetModules();
+  return (await import("../../apps/api/src/mcp")).default;
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
-  authMocks.getSession.mockClear();
-});
-
-afterAll(() => {
   vi.unstubAllEnvs();
+  vi.resetModules();
+  authMocks.getSession.mockClear();
 });
 
 describe("MCP API URLs", () => {
@@ -63,6 +61,7 @@ describe("MCP API URLs", () => {
       Response.json({ user: { id: "test-user" } }),
     );
     vi.stubGlobal("fetch", apiFetch);
+    const mcpRoutes = await loadMcpRoutes();
 
     const metadataResponse = await mcpRoutes.request(
       "/.well-known/oauth-authorization-server/api",
@@ -83,6 +82,22 @@ describe("MCP API URLs", () => {
     expect(apiFetch).toHaveBeenCalledOnce();
     expect(String(apiFetch.mock.calls[0]?.[0])).toBe(
       "http://127.0.0.1:1337/api/auth/get-session",
+    );
+  });
+
+  it("uses a configured internal URL without duplicating the API path", async () => {
+    const apiFetch = vi.fn(async () =>
+      Response.json({ user: { id: "test-user" } }),
+    );
+    vi.stubGlobal("fetch", apiFetch);
+    const mcpRoutes = await loadMcpRoutes("http://api.internal:1337/api/");
+
+    const toolResponse = await mcpRoutes.request(toolRequest());
+
+    expect(toolResponse.status).toBe(200);
+    expect(apiFetch).toHaveBeenCalledOnce();
+    expect(String(apiFetch.mock.calls[0]?.[0])).toBe(
+      "http://api.internal:1337/api/auth/get-session",
     );
   });
 });

--- a/tests/api/mcp-internal-api-url.test.ts
+++ b/tests/api/mcp-internal-api-url.test.ts
@@ -85,19 +85,22 @@ describe("MCP API URLs", () => {
     );
   });
 
-  it("uses a configured internal URL without duplicating the API path", async () => {
-    const apiFetch = vi.fn(async () =>
-      Response.json({ user: { id: "test-user" } }),
-    );
-    vi.stubGlobal("fetch", apiFetch);
-    const mcpRoutes = await loadMcpRoutes("http://api.internal:1337/api/");
+  it.each(["http://api.internal:1337/api/", "http://api.internal:1337/"])(
+    "uses the configured internal URL %s without duplicate slashes",
+    async (internalApiUrl) => {
+      const apiFetch = vi.fn(async () =>
+        Response.json({ user: { id: "test-user" } }),
+      );
+      vi.stubGlobal("fetch", apiFetch);
+      const mcpRoutes = await loadMcpRoutes(internalApiUrl);
 
-    const toolResponse = await mcpRoutes.request(toolRequest());
+      const toolResponse = await mcpRoutes.request(toolRequest());
 
-    expect(toolResponse.status).toBe(200);
-    expect(apiFetch).toHaveBeenCalledOnce();
-    expect(String(apiFetch.mock.calls[0]?.[0])).toBe(
-      "http://api.internal:1337/api/auth/get-session",
-    );
-  });
+      expect(toolResponse.status).toBe(200);
+      expect(apiFetch).toHaveBeenCalledOnce();
+      expect(String(apiFetch.mock.calls[0]?.[0])).toBe(
+        "http://api.internal:1337/api/auth/get-session",
+      );
+    },
+  );
 });

--- a/tests/api/mcp-internal-api-url.test.ts
+++ b/tests/api/mcp-internal-api-url.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  vi.stubEnv("KANEO_API_URL", "http://public.test:5273/api");
+  vi.stubEnv("KANEO_INTERNAL_API_URL", undefined);
+});
+
+const authMocks = vi.hoisted(() => ({
+  getSession: vi.fn(async () => ({ user: { id: "test-user" } })),
+}));
+
+vi.mock("../../apps/api/src/auth", () => ({
+  auth: { api: { getSession: authMocks.getSession } },
+}));
+
+import mcpRoutes from "../../apps/api/src/mcp";
+
+const protocolVersion = "2026-07-28";
+
+function toolRequest(): Request {
+  return new Request("http://public.test:5273/mcp", {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      authorization: "Bearer test-token",
+      "content-type": "application/json",
+      "mcp-method": "tools/call",
+      "mcp-name": "whoami",
+      "mcp-protocol-version": protocolVersion,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "whoami",
+        arguments: {},
+        _meta: {
+          "io.modelcontextprotocol/protocolVersion": protocolVersion,
+          "io.modelcontextprotocol/clientInfo": {
+            name: "kaneo-internal-url-test",
+            version: "1.0.0",
+          },
+          "io.modelcontextprotocol/clientCapabilities": {},
+        },
+      },
+    }),
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  authMocks.getSession.mockClear();
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("MCP API URLs", () => {
+  it("advertises the public URL while fetching tools through the internal URL", async () => {
+    const apiFetch = vi.fn(async () =>
+      Response.json({ user: { id: "test-user" } }),
+    );
+    vi.stubGlobal("fetch", apiFetch);
+
+    const metadataResponse = await mcpRoutes.request(
+      "/.well-known/oauth-authorization-server/api",
+    );
+    const metadata = (await metadataResponse.json()) as {
+      issuer: string;
+      authorization_endpoint: string;
+    };
+
+    expect(metadata).toMatchObject({
+      issuer: "http://public.test:5273/api",
+      authorization_endpoint: "http://public.test:5273/api/mcp/authorize",
+    });
+
+    const toolResponse = await mcpRoutes.request(toolRequest());
+
+    expect(toolResponse.status).toBe(200);
+    expect(apiFetch).toHaveBeenCalledOnce();
+    expect(String(apiFetch.mock.calls[0]?.[0])).toBe(
+      "http://127.0.0.1:1337/api/auth/get-session",
+    );
+  });
+});


### PR DESCRIPTION
## Description

Separate the public API origin advertised through MCP OAuth metadata from the internal origin used by server-side MCP tool requests. HTTP MCP tools now call `KANEO_INTERNAL_API_URL` when set, otherwise `http://127.0.0.1:1337`. Public OAuth discovery and `WWW-Authenticate` metadata continue to use `KANEO_API_URL`.

## Root Cause

The HTTP MCP handler used one `KANEO_API_URL` value for both public client metadata and server-side fetches. In localhost Docker installations, that public URL points at a host-published port that is not reachable from inside the container, so built-in MCP tools fail with `fetch failed`.

## Impact

Self-hosted localhost deployments can use built-in MCP tools without adding an internal nginx listener or changing their public URL. Existing public-domain and OAuth URLs stay unchanged, and installations with a different internal address can override the documented default.

## Related Issue(s)

Fixes #1547

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other: API typecheck, API build, full monorepo build, and Biome CI

## Screenshots (if applicable)

Not applicable; this changes server-side MCP request routing only.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Validation completed with the repository-pinned pnpm 10.32.1:

- focused MCP tests: 30 passed, including default and configured internal URL routing
- full API unit suite: 321 passed
- API lint and typecheck
- API build and full monorepo build
- `biome ci .` (successful; only pre-existing repository warnings)

No dependent changes are required. The unchecked comment and dependent-change items are not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for separate public and internal API URLs for MCP integrations.
  - MCP metadata now uses the public API address, while server-side tool requests use the internal address.
  - Added the optional `KANEO_INTERNAL_API_URL` variable, defaulting to `http://127.0.0.1:1337`.
  - API paths are handled correctly when the configured URL includes `/api`.

- **Documentation**
  - Documented the new MCP environment variable and server-side HTTP usage.

- **Tests**
  - Added coverage for public metadata URLs and internal authentication requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->