### PR TITLE
fix(auth): secure cookies on HTTPS deployments

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -41,6 +41,7 @@ import { checkRegistrationAllowed } from "./utils/check-registration-allowed";
 import { checkWorkspaceName } from "./utils/check-workspace-name";
 import { mapCustomOAuthProfileToUser } from "./utils/custom-oauth-profile";
 import { generateDemoName } from "./utils/generate-demo-name";
+import { getDefaultCookieAttributes } from "./utils/get-default-cookie-attributes";
 import { getInvitationEmailSubject } from "./utils/get-invitation-email-subject";
 import { getWorkspaceInvitationEmailCopy } from "./utils/get-workspace-invitation-email-copy";
 import { getGithubSsoOAuthCredentials } from "./utils/github-sso-env";
@@ -74,20 +75,6 @@ function isOAuthCallbackPath(path: unknown): boolean {
 
 const apiUrl = process.env.KANEO_API_URL || "http://localhost:1337";
 const clientUrl = process.env.KANEO_CLIENT_URL || "http://localhost:5173";
-const isHttps = apiUrl.startsWith("https://");
-const isCrossSubdomain = (() => {
-  try {
-    const apiHost = new URL(apiUrl).hostname;
-    const clientHost = new URL(clientUrl).hostname;
-    return (
-      apiHost !== clientHost &&
-      apiHost !== "localhost" &&
-      clientHost !== "localhost"
-    );
-  } catch {
-    return false;
-  }
-})();
 
 const trustedOrigins = [clientUrl];
 try {
@@ -759,13 +746,10 @@ export const auth = betterAuth({
       ipAddressHeaders: ["cf-connecting-ip", "x-forwarded-for"],
       trustedProxies: trustedProxies(),
     },
-    defaultCookieAttributes: {
-      // For cross-subdomain auth with HTTPS, use sameSite: "none" with secure: true
-      // For same-domain or HTTP deployments, use sameSite: "lax" with secure: false
-      sameSite: isCrossSubdomain && isHttps ? "none" : "lax",
-      secure: isCrossSubdomain && isHttps, // must be true when sameSite is "none"
-      partitioned: isCrossSubdomain && isHttps,
-      domain: process.env.COOKIE_DOMAIN || undefined, // Optional: e.g., ".andrej.com" for explicit cross-subdomain cookies
-    },
+    defaultCookieAttributes: getDefaultCookieAttributes({
+      apiUrl,
+      clientUrl,
+      cookieDomain: process.env.COOKIE_DOMAIN,
+    }),
   },
 });

--- a/apps/api/src/utils/get-default-cookie-attributes.ts
+++ b/apps/api/src/utils/get-default-cookie-attributes.ts
@@ -1,0 +1,34 @@
+interface CookieAttributeUrls {
+  apiUrl: string;
+  clientUrl: string;
+  cookieDomain?: string;
+}
+
+export function getDefaultCookieAttributes({
+  apiUrl,
+  clientUrl,
+  cookieDomain,
+}: CookieAttributeUrls) {
+  const isHttps = apiUrl.startsWith("https://");
+  const isCrossSubdomain = (() => {
+    try {
+      const apiHost = new URL(apiUrl).hostname;
+      const clientHost = new URL(clientUrl).hostname;
+      return (
+        apiHost !== clientHost &&
+        apiHost !== "localhost" &&
+        clientHost !== "localhost"
+      );
+    } catch {
+      return false;
+    }
+  })();
+
+  return {
+    sameSite:
+      isCrossSubdomain && isHttps ? ("none" as const) : ("lax" as const),
+    secure: isHttps,
+    partitioned: isCrossSubdomain && isHttps,
+    domain: cookieDomain || undefined,
+  };
+}

--- a/apps/api/src/utils/get-default-cookie-attributes.ts
+++ b/apps/api/src/utils/get-default-cookie-attributes.ts
@@ -1,20 +1,28 @@
-interface CookieAttributeUrls {
+type CookieAttributeUrls = {
   apiUrl: string;
   clientUrl: string;
   cookieDomain?: string;
-}
+};
 
 export function getDefaultCookieAttributes({
   apiUrl,
   clientUrl,
   cookieDomain,
 }: CookieAttributeUrls) {
-  const isHttps = apiUrl.startsWith("https://");
+  const parsedApiUrl = (() => {
+    try {
+      return new URL(apiUrl);
+    } catch {
+      return undefined;
+    }
+  })();
+  const isHttps = parsedApiUrl?.protocol === "https:";
   const isCrossSubdomain = (() => {
     try {
-      const apiHost = new URL(apiUrl).hostname;
+      const apiHost = parsedApiUrl?.hostname;
       const clientHost = new URL(clientUrl).hostname;
       return (
+        apiHost !== undefined &&
         apiHost !== clientHost &&
         apiHost !== "localhost" &&
         clientHost !== "localhost"

--- a/tests/api/utils/get-default-cookie-attributes.test.ts
+++ b/tests/api/utils/get-default-cookie-attributes.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { getDefaultCookieAttributes } from "../../../apps/api/src/utils/get-default-cookie-attributes";
+
+describe("getDefaultCookieAttributes", () => {
+  it("marks same-domain HTTPS cookies as secure", () => {
+    expect(
+      getDefaultCookieAttributes({
+        apiUrl: "https://kaneo.example.com/api",
+        clientUrl: "https://kaneo.example.com",
+      }),
+    ).toEqual({
+      sameSite: "lax",
+      secure: true,
+      partitioned: false,
+      domain: undefined,
+    });
+  });
+
+  it("uses cross-subdomain attributes for HTTPS deployments", () => {
+    expect(
+      getDefaultCookieAttributes({
+        apiUrl: "https://api.example.com",
+        clientUrl: "https://app.example.com",
+        cookieDomain: ".example.com",
+      }),
+    ).toEqual({
+      sameSite: "none",
+      secure: true,
+      partitioned: true,
+      domain: ".example.com",
+    });
+  });
+
+  it("keeps local HTTP cookies compatible with development", () => {
+    expect(
+      getDefaultCookieAttributes({
+        apiUrl: "http://localhost:1337",
+        clientUrl: "http://localhost:5173",
+      }),
+    ).toEqual({
+      sameSite: "lax",
+      secure: false,
+      partitioned: false,
+      domain: undefined,
+    });
+  });
+});

--- a/tests/api/utils/get-default-cookie-attributes.test.ts
+++ b/tests/api/utils/get-default-cookie-attributes.test.ts
@@ -3,12 +3,12 @@ import { getDefaultCookieAttributes } from "../../../apps/api/src/utils/get-defa
 
 describe("getDefaultCookieAttributes", () => {
   it("marks same-domain HTTPS cookies as secure", () => {
-    expect(
-      getDefaultCookieAttributes({
-        apiUrl: "https://kaneo.example.com/api",
-        clientUrl: "https://kaneo.example.com",
-      }),
-    ).toEqual({
+    const attributes = getDefaultCookieAttributes({
+      apiUrl: "https://kaneo.example.com/api",
+      clientUrl: "https://kaneo.example.com",
+    });
+
+    expect(attributes).toEqual({
       sameSite: "lax",
       secure: true,
       partitioned: false,
@@ -17,13 +17,13 @@ describe("getDefaultCookieAttributes", () => {
   });
 
   it("uses cross-subdomain attributes for HTTPS deployments", () => {
-    expect(
-      getDefaultCookieAttributes({
-        apiUrl: "https://api.example.com",
-        clientUrl: "https://app.example.com",
-        cookieDomain: ".example.com",
-      }),
-    ).toEqual({
+    const attributes = getDefaultCookieAttributes({
+      apiUrl: "https://api.example.com",
+      clientUrl: "https://app.example.com",
+      cookieDomain: ".example.com",
+    });
+
+    expect(attributes).toEqual({
       sameSite: "none",
       secure: true,
       partitioned: true,
@@ -32,15 +32,29 @@ describe("getDefaultCookieAttributes", () => {
   });
 
   it("keeps local HTTP cookies compatible with development", () => {
-    expect(
-      getDefaultCookieAttributes({
-        apiUrl: "http://localhost:1337",
-        clientUrl: "http://localhost:5173",
-      }),
-    ).toEqual({
+    const attributes = getDefaultCookieAttributes({
+      apiUrl: "http://localhost:1337",
+      clientUrl: "http://localhost:5173",
+    });
+
+    expect(attributes).toEqual({
       sameSite: "lax",
       secure: false,
       partitioned: false,
+      domain: undefined,
+    });
+  });
+
+  it("handles uppercase HTTPS schemes", () => {
+    const attributes = getDefaultCookieAttributes({
+      apiUrl: "HTTPS://api.example.com",
+      clientUrl: "HTTPS://app.example.com",
+    });
+
+    expect(attributes).toEqual({
+      sameSite: "none",
+      secure: true,
+      partitioned: true,
       domain: undefined,
     });
   });


### PR DESCRIPTION
## Description

Set the `Secure` attribute on authentication cookies whenever `KANEO_API_URL` uses HTTPS.

The previous configuration enabled `Secure` only when the API and client used different hostnames. A common same-domain deployment such as `https://kaneo.example.com` therefore issued authentication cookies without the HTTPS-only protection.

The cookie attribute calculation now lives in a small helper with coverage for same-domain HTTPS, cross-subdomain HTTPS, and local HTTP development.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test addition or update

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

Validation performed with Node.js 24:

- focused cookie attribute tests (3 passed)
- `pnpm typecheck`
- `pnpm build`
- Biome check for all changed files

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing relevant tests pass locally with my changes

## Additional Notes

Local HTTP development keeps `secure: false`. Cross-subdomain HTTPS deployments retain `SameSite=None` and partitioned cookies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication cookie behavior across local, same-domain, and cross-subdomain deployments.
  * Cookies now use secure cross-subdomain settings only when HTTPS is configured correctly.
  * Invalid URLs and empty cookie domains are handled safely, reducing authentication issues in varied deployment environments.
  * Local HTTP development continues to use compatible cookie settings.

* **Tests**
  * Added coverage for HTTPS, cross-subdomain, same-domain, and local development scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->