### PR TITLE
Adds a per-project monthly calendar view alongside board, backlog and gantt.

### DIFF
--- a/apps/web/src/components/calendar/calendar-task-bar.test.tsx
+++ b/apps/web/src/components/calendar/calendar-task-bar.test.tsx
@@ -1,0 +1,91 @@
+import enUS from "@i18n/en-US.json";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import CalendarTaskBar from "./calendar-task-bar";
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+});
+
+// Formats from local parts, so the expected label does not move with the
+// runner's timezone the way toISOString would.
+vi.mock("@/lib/format", () => ({
+  formatDateShort: (value: Date) =>
+    [
+      value.getFullYear(),
+      String(value.getMonth() + 1).padStart(2, "0"),
+      String(value.getDate()).padStart(2, "0"),
+    ].join("-"),
+}));
+
+/**
+ * Resolves against the real en-US bundle and applies i18next-style
+ * interpolation, so the assertions fail if the key stops passing a value the
+ * source string expects.
+ */
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      const [namespace, path] = key.split(":");
+      const source = path
+        .split(".")
+        .reduce<unknown>(
+          (accumulator, part) =>
+            (accumulator as Record<string, unknown> | undefined)?.[part],
+          (enUS as Record<string, unknown>)[namespace],
+        );
+
+      if (typeof source !== "string") return key;
+
+      return source.replace(/\{\{(\w+)\}\}/g, (_match, name: string) =>
+        String(options?.[name] ?? `{{${name}}}`),
+      );
+    },
+  }),
+}));
+
+const segment = {
+  task: {
+    id: "t1",
+    title: "Design review",
+    number: 12,
+    scheduleStart: new Date(2026, 7, 10),
+    scheduleEnd: new Date(2026, 7, 12),
+  },
+  lane: 0,
+  columnStart: 1,
+  columnEnd: 4,
+  continuesBefore: false,
+  continuesAfter: false,
+};
+
+describe("CalendarTaskBar", () => {
+  it("announces the task title and its scheduled range", () => {
+    render(
+      <CalendarTaskBar
+        segment={segment}
+        projectSlug="KAN"
+        onOpenTask={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button")).toHaveAccessibleName(
+      "Design review, 2026-08-10 – 2026-08-12: open task",
+    );
+  });
+
+  it("leaves no interpolation placeholder unresolved", () => {
+    render(
+      <CalendarTaskBar
+        segment={segment}
+        projectSlug="KAN"
+        onOpenTask={vi.fn()}
+      />,
+    );
+
+    const label = screen.getByRole("button").getAttribute("aria-label") ?? "";
+
+    expect(label).not.toMatch(/\{\{\w+\}\}/);
+  });
+});

--- a/apps/web/src/components/calendar/calendar-task-bar.tsx
+++ b/apps/web/src/components/calendar/calendar-task-bar.tsx
@@ -52,7 +52,10 @@ export default function CalendarTaskBar({
           ? `${taskKey} · ${task.title} · ${range}`
           : `${task.title} · ${range}`
       }
-      aria-label={t("tasks:calendar.taskAriaLabel", { title: task.title })}
+      aria-label={t("tasks:calendar.taskAriaLabel", {
+        title: task.title,
+        range,
+      })}
       onClick={() => onOpenTask(task.id)}
       className={cn(
         "z-10 mb-0.5 flex h-6 min-w-0 items-center overflow-hidden border border-primary/25 bg-primary/12 px-1.5 text-left text-[11px] font-medium leading-none text-foreground transition-colors hover:border-primary/40 hover:bg-primary/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:h-5",

--- a/apps/web/src/components/calendar/calendar-task-bar.tsx
+++ b/apps/web/src/components/calendar/calendar-task-bar.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
 import { formatDateShort } from "@/lib/format";
@@ -18,7 +19,7 @@ export default function CalendarTaskBar({
   segment,
   projectSlug,
   onOpenTask,
-}: CalendarTaskBarProps) {
+}: CalendarTaskBarProps): JSX.Element {
   const { t } = useTranslation();
   const {
     task,

--- a/apps/web/src/components/calendar/calendar-task-bar.tsx
+++ b/apps/web/src/components/calendar/calendar-task-bar.tsx
@@ -1,0 +1,67 @@
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/cn";
+import { formatDateShort } from "@/lib/format";
+import type { PackableTask, WeekSegment } from "./month-grid-model";
+
+export type CalendarTask = PackableTask & {
+  title: string;
+  number: number | null;
+};
+
+type CalendarTaskBarProps = {
+  segment: WeekSegment<CalendarTask>;
+  projectSlug?: string;
+  onOpenTask: (taskId: string) => void;
+};
+
+export default function CalendarTaskBar({
+  segment,
+  projectSlug,
+  onOpenTask,
+}: CalendarTaskBarProps) {
+  const { t } = useTranslation();
+  const {
+    task,
+    lane,
+    columnStart,
+    columnEnd,
+    continuesBefore,
+    continuesAfter,
+  } = segment;
+
+  const taskKey =
+    projectSlug && task.number != null
+      ? `${projectSlug}-${task.number}`
+      : undefined;
+
+  const range = `${formatDateShort(task.scheduleStart)} – ${formatDateShort(
+    task.scheduleEnd,
+  )}`;
+
+  return (
+    <button
+      type="button"
+      style={{
+        gridColumn: `${columnStart} / ${columnEnd}`,
+        // Row 1 holds the date numbers, so lanes start at row 2.
+        gridRow: lane + 2,
+      }}
+      title={
+        taskKey
+          ? `${taskKey} · ${task.title} · ${range}`
+          : `${task.title} · ${range}`
+      }
+      aria-label={t("tasks:calendar.taskAriaLabel", { title: task.title })}
+      onClick={() => onOpenTask(task.id)}
+      className={cn(
+        "z-10 mb-0.5 flex h-6 min-w-0 items-center overflow-hidden border border-primary/25 bg-primary/12 px-1.5 text-left text-[11px] font-medium leading-none text-foreground transition-colors hover:border-primary/40 hover:bg-primary/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:h-5",
+        // Bars that run past a week edge lose their cap there so the two halves
+        // read as one continuous span across rows.
+        continuesBefore ? "rounded-l-none border-l-0" : "ml-1 rounded-l-md",
+        continuesAfter ? "rounded-r-none border-r-0" : "mr-1 rounded-r-md",
+      )}
+    >
+      <span className="truncate">{task.title}</span>
+    </button>
+  );
+}

--- a/apps/web/src/components/calendar/calendar-toolbar.tsx
+++ b/apps/web/src/components/calendar/calendar-toolbar.tsx
@@ -1,0 +1,67 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { formatDate } from "@/lib/format";
+
+type CalendarToolbarProps = {
+  visibleMonth: Date;
+  onPreviousMonth: () => void;
+  onNextMonth: () => void;
+  onToday: () => void;
+};
+
+export default function CalendarToolbar({
+  visibleMonth,
+  onPreviousMonth,
+  onNextMonth,
+  onToday,
+}: CalendarToolbarProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="border-b border-border/80 px-3 py-3 sm:px-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <h1 className="truncate text-sm font-semibold text-foreground">
+            {t("tasks:calendar.title")}
+          </h1>
+          <span
+            className="truncate text-sm text-muted-foreground"
+            data-testid="calendar-month-label"
+          >
+            {formatDate(visibleMonth, { month: "long", year: "numeric" })}
+          </span>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            variant="outline"
+            size="icon-xs"
+            className="min-h-11 touch-manipulation sm:min-h-0"
+            aria-label={t("tasks:calendar.previousMonth")}
+            onClick={onPreviousMonth}
+          >
+            <ChevronLeft />
+          </Button>
+          <Button
+            variant="outline"
+            size="xs"
+            className="min-h-11 touch-manipulation sm:min-h-0"
+            onClick={onToday}
+          >
+            {t("tasks:calendar.today")}
+          </Button>
+          <Button
+            variant="outline"
+            size="icon-xs"
+            className="min-h-11 touch-manipulation sm:min-h-0"
+            aria-label={t("tasks:calendar.nextMonth")}
+            onClick={onNextMonth}
+          >
+            <ChevronRight />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/calendar/calendar-toolbar.tsx
+++ b/apps/web/src/components/calendar/calendar-toolbar.tsx
@@ -1,4 +1,5 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { JSX } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { formatDate } from "@/lib/format";
@@ -15,7 +16,7 @@ export default function CalendarToolbar({
   onPreviousMonth,
   onNextMonth,
   onToday,
-}: CalendarToolbarProps) {
+}: CalendarToolbarProps): JSX.Element {
   const { t } = useTranslation();
 
   return (

--- a/apps/web/src/components/calendar/day-overflow-popover.test.tsx
+++ b/apps/web/src/components/calendar/day-overflow-popover.test.tsx
@@ -1,0 +1,156 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CalendarTask } from "./calendar-task-bar";
+import DayOverflowPopover from "./day-overflow-popover";
+import MonthGrid from "./month-grid";
+import { buildMonthWeeks } from "./month-grid-model";
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/lib/format", () => ({
+  formatDate: () => "Monday, August 10",
+  formatDateShort: (value: Date) => value.toISOString().slice(0, 10),
+}));
+
+const TRIGGER_NAME = "tasks:calendar.dayTasksAriaLabel";
+
+function task(
+  id: string,
+  title: string,
+  number: number | null,
+  start: Date,
+  end: Date,
+): CalendarTask {
+  return { id, title, number, scheduleStart: start, scheduleEnd: end };
+}
+
+const AUGUST_10 = new Date(2026, 7, 10);
+
+const dayTasks = [
+  task("t1", "Design review", 12, new Date(2026, 7, 10), new Date(2026, 7, 12)),
+  task("t2", "Ship release", 13, new Date(2026, 7, 10), new Date(2026, 7, 10)),
+  task("t3", "Write docs", null, new Date(2026, 7, 9), new Date(2026, 7, 11)),
+];
+
+describe("DayOverflowPopover", () => {
+  it("keeps the task list closed until the overflow label is clicked", () => {
+    render(
+      <DayOverflowPopover
+        day={AUGUST_10}
+        tasks={dayTasks}
+        hiddenCount={2}
+        projectSlug="KAN"
+        onOpenTask={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: TRIGGER_NAME })).toBeVisible();
+    expect(screen.queryByText("Design review")).toBeNull();
+  });
+
+  it("lists every task for the day, not only the hidden ones", async () => {
+    render(
+      <DayOverflowPopover
+        day={AUGUST_10}
+        tasks={dayTasks}
+        hiddenCount={2}
+        projectSlug="KAN"
+        onOpenTask={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: TRIGGER_NAME }));
+
+    expect(await screen.findByText("Design review")).toBeVisible();
+    expect(screen.getByText("Ship release")).toBeVisible();
+    expect(screen.getByText("Write docs")).toBeVisible();
+    expect(screen.getByText("KAN-12")).toBeVisible();
+  });
+
+  it("opens the task and closes the popover when an entry is clicked", async () => {
+    const onOpenTask = vi.fn();
+
+    render(
+      <DayOverflowPopover
+        day={AUGUST_10}
+        tasks={dayTasks}
+        hiddenCount={2}
+        projectSlug="KAN"
+        onOpenTask={onOpenTask}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: TRIGGER_NAME }));
+    fireEvent.click(await screen.findByText("Ship release"));
+
+    expect(onOpenTask).toHaveBeenCalledTimes(1);
+    expect(onOpenTask).toHaveBeenCalledWith("t2");
+    expect(screen.queryByText("Design review")).toBeNull();
+  });
+
+  it("omits the task key when the project slug is unknown", async () => {
+    render(
+      <DayOverflowPopover
+        day={AUGUST_10}
+        tasks={dayTasks}
+        hiddenCount={2}
+        onOpenTask={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: TRIGGER_NAME }));
+
+    expect(await screen.findByText("Design review")).toBeVisible();
+    expect(screen.queryByText("KAN-12")).toBeNull();
+  });
+});
+
+describe("MonthGrid overflow wiring", () => {
+  const weeks = buildMonthWeeks(AUGUST_10, 1);
+
+  it("surfaces hidden tasks through the overflow popover", async () => {
+    const onOpenTask = vi.fn();
+
+    render(
+      <MonthGrid
+        weeks={weeks}
+        tasks={dayTasks}
+        visibleMonth={AUGUST_10}
+        maxLanes={1}
+        projectSlug="KAN"
+        onOpenTask={onOpenTask}
+      />,
+    );
+
+    // Only one lane fits, so the other two tasks on Aug 10 have to overflow.
+    const trigger = screen.getAllByRole("button", { name: TRIGGER_NAME })[0];
+    expect(trigger).toBeVisible();
+
+    fireEvent.click(trigger);
+    fireEvent.click(await screen.findByText("Ship release"));
+
+    expect(onOpenTask).toHaveBeenCalledWith("t2");
+  });
+
+  it("renders no overflow trigger when every task fits", () => {
+    render(
+      <MonthGrid
+        weeks={weeks}
+        tasks={dayTasks}
+        visibleMonth={AUGUST_10}
+        maxLanes={5}
+        projectSlug="KAN"
+        onOpenTask={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: TRIGGER_NAME })).toBeNull();
+  });
+});

--- a/apps/web/src/components/calendar/day-overflow-popover.tsx
+++ b/apps/web/src/components/calendar/day-overflow-popover.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { formatDate, formatDateShort } from "@/lib/format";
+import type { CalendarTask } from "./calendar-task-bar";
+
+type DayOverflowPopoverProps = {
+  day: Date;
+  /** Every task on this day, not just the ones the lane cap hid. */
+  tasks: CalendarTask[];
+  hiddenCount: number;
+  projectSlug?: string;
+  onOpenTask: (taskId: string) => void;
+};
+
+export default function DayOverflowPopover({
+  day,
+  tasks,
+  hiddenCount,
+  projectSlug,
+  onOpenTask,
+}: DayOverflowPopoverProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  const dayLabel = formatDate(day, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
+
+  const handleSelectTask = (taskId: string) => {
+    setOpen(false);
+    onOpenTask(taskId);
+  };
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger
+        aria-label={t("tasks:calendar.dayTasksAriaLabel", { date: dayLabel })}
+        className="w-full truncate rounded-sm px-1.5 pb-1 text-left text-[10px] leading-tight text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {t("tasks:calendar.moreTasks", { count: hiddenCount })}
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-64 p-2">
+        <div className="space-y-1">
+          <p className="px-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            {dayLabel}
+          </p>
+          <div className="max-h-64 space-y-0.5 overflow-y-auto">
+            {tasks.map((task) => (
+              <button
+                key={task.id}
+                type="button"
+                onClick={() => handleSelectTask(task.id)}
+                className="flex w-full min-w-0 flex-col items-start gap-0.5 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                {projectSlug && task.number != null ? (
+                  <span className="truncate text-[10px] text-muted-foreground">
+                    {projectSlug}-{task.number}
+                  </span>
+                ) : null}
+                <span className="w-full truncate text-xs font-medium text-foreground">
+                  {task.title}
+                </span>
+                <span className="w-full truncate text-[11px] text-muted-foreground">
+                  {formatDateShort(task.scheduleStart)} –{" "}
+                  {formatDateShort(task.scheduleEnd)}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/calendar/day-overflow-popover.tsx
+++ b/apps/web/src/components/calendar/day-overflow-popover.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { type JSX, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Popover,
@@ -23,7 +23,7 @@ export default function DayOverflowPopover({
   hiddenCount,
   projectSlug,
   onOpenTask,
-}: DayOverflowPopoverProps) {
+}: DayOverflowPopoverProps): JSX.Element {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 

--- a/apps/web/src/components/calendar/month-grid-model.test.ts
+++ b/apps/web/src/components/calendar/month-grid-model.test.ts
@@ -1,0 +1,255 @@
+import { addDays } from "date-fns";
+import { describe, expect, it } from "vitest";
+import {
+  buildMonthWeeks,
+  DAYS_PER_WEEK,
+  packWeekLanes,
+  type WeekStartsOn,
+} from "./month-grid-model";
+
+/** Local-time dates keep the assertions independent of the runner timezone. */
+function day(year: number, monthIndex: number, dayOfMonth: number) {
+  return new Date(year, monthIndex, dayOfMonth);
+}
+
+function scheduled(id: string, start: Date, end: Date) {
+  return { id, scheduleStart: start, scheduleEnd: end };
+}
+
+// Saturday 2026-08-01 through Monday 2026-08-31.
+const AUGUST_2026 = day(2026, 7, 1);
+
+describe("buildMonthWeeks", () => {
+  it("returns whole weeks that start on the preferred weekday", () => {
+    for (const weekStartsOn of [0, 1, 6] as WeekStartsOn[]) {
+      const weeks = buildMonthWeeks(AUGUST_2026, weekStartsOn);
+
+      expect(weeks.length).toBeGreaterThanOrEqual(5);
+      for (const week of weeks) {
+        expect(week).toHaveLength(DAYS_PER_WEEK);
+        expect(week[0].getDay()).toBe(weekStartsOn);
+      }
+    }
+  });
+
+  it("covers every day of the visible month", () => {
+    const days = buildMonthWeeks(AUGUST_2026, 1).flat();
+    const august = days.filter(
+      (entry) => entry.getMonth() === 7 && entry.getFullYear() === 2026,
+    );
+
+    expect(august).toHaveLength(31);
+  });
+
+  it("pads the grid with neighbouring-month days", () => {
+    const days = buildMonthWeeks(AUGUST_2026, 1).flat();
+
+    expect(days.some((entry) => entry.getMonth() === 6)).toBe(true);
+    expect(days.some((entry) => entry.getMonth() === 8)).toBe(true);
+  });
+});
+
+describe("packWeekLanes", () => {
+  // Sunday 2026-08-02 through Saturday 2026-08-08.
+  const week = Array.from({ length: DAYS_PER_WEEK }, (_, index) =>
+    day(2026, 7, 2 + index),
+  );
+
+  it("maps a task to inclusive-start, exclusive-end grid lines", () => {
+    const task = scheduled("a", day(2026, 7, 2), day(2026, 7, 3));
+    const { segments } = packWeekLanes(week, [task], 3);
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0].columnStart).toBe(1);
+    expect(segments[0].columnEnd).toBe(3);
+    expect(segments[0].lane).toBe(0);
+    expect(segments[0].continuesBefore).toBe(false);
+    expect(segments[0].continuesAfter).toBe(false);
+  });
+
+  it("gives a single-day task a one-column span", () => {
+    const task = scheduled("a", day(2026, 7, 4), day(2026, 7, 4));
+    const { segments } = packWeekLanes(week, [task], 3);
+
+    expect(segments[0].columnStart).toBe(3);
+    expect(segments[0].columnEnd).toBe(4);
+  });
+
+  it("reuses a lane for tasks that do not overlap", () => {
+    const tasks = [
+      scheduled("a", day(2026, 7, 2), day(2026, 7, 3)),
+      scheduled("b", day(2026, 7, 5), day(2026, 7, 6)),
+    ];
+    const { segments } = packWeekLanes(week, tasks, 3);
+
+    expect(segments.map((segment) => segment.lane)).toEqual([0, 0]);
+  });
+
+  it("stacks overlapping tasks into separate lanes", () => {
+    const tasks = [
+      scheduled("a", day(2026, 7, 2), day(2026, 7, 5)),
+      scheduled("b", day(2026, 7, 3), day(2026, 7, 6)),
+      scheduled("c", day(2026, 7, 4), day(2026, 7, 7)),
+    ];
+    const { segments } = packWeekLanes(week, tasks, 5);
+    const lanesById = new Map(
+      segments.map((segment) => [segment.task.id, segment.lane]),
+    );
+
+    expect(lanesById.get("a")).toBe(0);
+    expect(lanesById.get("b")).toBe(1);
+    expect(lanesById.get("c")).toBe(2);
+  });
+
+  it("clips a task that starts before the week and flags the continuation", () => {
+    const task = scheduled("a", day(2026, 6, 31), day(2026, 7, 4));
+    const { segments } = packWeekLanes(week, [task], 3);
+
+    expect(segments[0].columnStart).toBe(1);
+    expect(segments[0].columnEnd).toBe(4);
+    expect(segments[0].continuesBefore).toBe(true);
+    expect(segments[0].continuesAfter).toBe(false);
+  });
+
+  it("clips a task that runs past the week and flags the continuation", () => {
+    const task = scheduled("a", day(2026, 7, 6), day(2026, 7, 12));
+    const { segments } = packWeekLanes(week, [task], 3);
+
+    expect(segments[0].columnStart).toBe(5);
+    expect(segments[0].columnEnd).toBe(8);
+    expect(segments[0].continuesBefore).toBe(false);
+    expect(segments[0].continuesAfter).toBe(true);
+  });
+
+  it("flags both sides for a task spanning the whole week", () => {
+    const task = scheduled("a", day(2026, 7, 1), day(2026, 7, 20));
+    const { segments } = packWeekLanes(week, [task], 3);
+
+    expect(segments[0].columnStart).toBe(1);
+    expect(segments[0].columnEnd).toBe(8);
+    expect(segments[0].continuesBefore).toBe(true);
+    expect(segments[0].continuesAfter).toBe(true);
+  });
+
+  it("excludes tasks that do not touch the week", () => {
+    const tasks = [
+      scheduled("before", day(2026, 6, 20), day(2026, 6, 25)),
+      scheduled("after", day(2026, 7, 15), day(2026, 7, 18)),
+    ];
+    const { segments, hiddenCountByDay } = packWeekLanes(week, tasks, 3);
+
+    expect(segments).toEqual([]);
+    expect(hiddenCountByDay).toEqual(new Array(DAYS_PER_WEEK).fill(0));
+  });
+
+  it("counts overflow per day once the lane budget is spent", () => {
+    const tasks = [
+      scheduled("a", day(2026, 7, 2), day(2026, 7, 3)),
+      scheduled("c", day(2026, 7, 3), day(2026, 7, 5)),
+    ];
+    const { segments, hiddenCountByDay } = packWeekLanes(week, tasks, 1);
+
+    expect(segments.map((segment) => segment.task.id)).toEqual(["a"]);
+    expect(hiddenCountByDay).toEqual([0, 1, 1, 1, 0, 0, 0]);
+  });
+
+  it("is deterministic for tasks sharing a start column and span", () => {
+    const tasks = [
+      scheduled("b", day(2026, 7, 2), day(2026, 7, 3)),
+      scheduled("a", day(2026, 7, 2), day(2026, 7, 3)),
+    ];
+    const { segments } = packWeekLanes(week, tasks, 3);
+
+    expect(segments.map((segment) => segment.task.id)).toEqual(["a", "b"]);
+  });
+
+  it("returns an empty layout for an empty week", () => {
+    const { segments, hiddenCountByDay } = packWeekLanes(
+      [],
+      [scheduled("a", day(2026, 7, 2), day(2026, 7, 3))],
+      3,
+    );
+
+    expect(segments).toEqual([]);
+    expect(hiddenCountByDay).toEqual(new Array(DAYS_PER_WEEK).fill(0));
+  });
+
+  it("does not clip a task that starts exactly on the first day of the week", () => {
+    // Regression: a bar starting on the week's own first column must keep its
+    // left cap, otherwise it reads as continuing from the previous week.
+    for (const weekStartsOn of [0, 1, 6] as WeekStartsOn[]) {
+      const weeks = buildMonthWeeks(AUGUST_2026, weekStartsOn);
+      const targetWeek = weeks.find((candidate) =>
+        candidate.some((entry) => entry.getDate() === 10),
+      );
+      if (!targetWeek) throw new Error("expected a week containing Aug 10");
+
+      const firstDay = targetWeek[0];
+      const task = scheduled("p2-3", firstDay, addDays(firstDay, 4));
+      const { segments } = packWeekLanes(targetWeek, [task], 3);
+
+      expect(segments[0].continuesBefore).toBe(false);
+      expect(segments[0].columnStart).toBe(1);
+    }
+  });
+
+  it("keeps continuesBefore true only when the task really starts earlier", () => {
+    const startsOnWeekStart = packWeekLanes(
+      week,
+      [scheduled("a", week[0], day(2026, 7, 6))],
+      3,
+    );
+    const startsBeforeWeek = packWeekLanes(
+      week,
+      [scheduled("b", day(2026, 7, 1), day(2026, 7, 6))],
+      3,
+    );
+
+    expect(startsOnWeekStart.segments[0].continuesBefore).toBe(false);
+    expect(startsBeforeWeek.segments[0].continuesBefore).toBe(true);
+  });
+});
+
+describe("packWeekLanes tasksByDay", () => {
+  const week = Array.from({ length: DAYS_PER_WEEK }, (_, index) =>
+    day(2026, 7, 2 + index),
+  );
+
+  it("lists every task overlapping each day, hidden ones included", () => {
+    const tasks = [
+      scheduled("a", day(2026, 7, 2), day(2026, 7, 3)),
+      scheduled("b", day(2026, 7, 3), day(2026, 7, 4)),
+      scheduled("c", day(2026, 7, 3), day(2026, 7, 3)),
+    ];
+    const { tasksByDay, hiddenCountByDay } = packWeekLanes(week, tasks, 1);
+
+    expect(tasksByDay[0].map((entry) => entry.id)).toEqual(["a"]);
+    expect(tasksByDay[1].map((entry) => entry.id)).toEqual(["a", "b", "c"]);
+    expect(tasksByDay[2].map((entry) => entry.id)).toEqual(["b"]);
+    expect(tasksByDay[3]).toEqual([]);
+    // Two of the three tasks on Aug 3 did not fit the single lane.
+    expect(hiddenCountByDay[1]).toBe(2);
+  });
+
+  it("includes days covered by a task clipped at the week edges", () => {
+    const { tasksByDay } = packWeekLanes(
+      week,
+      [scheduled("wide", day(2026, 6, 28), day(2026, 7, 20))],
+      3,
+    );
+
+    for (const dayTasks of tasksByDay) {
+      expect(dayTasks.map((entry) => entry.id)).toEqual(["wide"]);
+    }
+  });
+
+  it("is empty for a week with no overlapping tasks", () => {
+    const { tasksByDay } = packWeekLanes(
+      week,
+      [scheduled("far", day(2026, 8, 10), day(2026, 8, 12))],
+      3,
+    );
+
+    expect(tasksByDay.every((entry) => entry.length === 0)).toBe(true);
+  });
+});

--- a/apps/web/src/components/calendar/month-grid-model.ts
+++ b/apps/web/src/components/calendar/month-grid-model.ts
@@ -1,0 +1,168 @@
+import {
+  differenceInCalendarDays,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
+
+export const DAYS_PER_WEEK = 7;
+
+export type WeekStartsOn = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+/**
+ * Any task already normalized by `toScheduledTasks`. Kept minimal so the layout
+ * math stays independent of the task payload.
+ */
+export type PackableTask = {
+  id: string;
+  scheduleStart: Date;
+  scheduleEnd: Date;
+};
+
+export type WeekSegment<TTask extends PackableTask> = {
+  task: TTask;
+  lane: number;
+  /** 1-based CSS grid line where the bar starts. */
+  columnStart: number;
+  /** Exclusive CSS grid line where the bar ends. */
+  columnEnd: number;
+  continuesBefore: boolean;
+  continuesAfter: boolean;
+};
+
+export type WeekLayout<TTask extends PackableTask> = {
+  segments: Array<WeekSegment<TTask>>;
+  /** Per weekday index, how many tasks did not fit within `maxLanes`. */
+  hiddenCountByDay: number[];
+  /**
+   * Per weekday index, every task overlapping that day — visible or not — in
+   * the same order the lanes were packed. Backs the overflow popover.
+   */
+  tasksByDay: TTask[][];
+};
+
+/**
+ * Week-aligned month grid: always whole weeks, so the first and last row can
+ * carry days from the neighbouring months.
+ */
+export function buildMonthWeeks(
+  visibleMonth: Date,
+  weekStartsOn: WeekStartsOn,
+): Date[][] {
+  const gridStart = startOfWeek(startOfMonth(visibleMonth), { weekStartsOn });
+  const gridEnd = endOfWeek(endOfMonth(visibleMonth), { weekStartsOn });
+  const days = eachDayOfInterval({ start: gridStart, end: gridEnd });
+
+  const weeks: Date[][] = [];
+  for (let index = 0; index < days.length; index += DAYS_PER_WEEK) {
+    weeks.push(days.slice(index, index + DAYS_PER_WEEK));
+  }
+
+  return weeks;
+}
+
+/**
+ * Clips every task overlapping the week to that week's seven columns, then
+ * greedily packs the clipped segments into lanes so overlapping tasks stack
+ * instead of colliding. Segments past `maxLanes` are reported per day so the
+ * cell can render an overflow hint.
+ */
+export function packWeekLanes<TTask extends PackableTask>(
+  week: Date[],
+  tasks: TTask[],
+  maxLanes: number,
+): WeekLayout<TTask> {
+  const hiddenCountByDay = new Array<number>(DAYS_PER_WEEK).fill(0);
+  const tasksByDay: TTask[][] = Array.from({ length: DAYS_PER_WEEK }, () => []);
+  const weekStart = week[0];
+
+  if (!weekStart) {
+    return { segments: [], hiddenCountByDay, tasksByDay };
+  }
+
+  const lastDayIndex = DAYS_PER_WEEK - 1;
+
+  const candidates = tasks
+    .map((task) => {
+      const startOffset = differenceInCalendarDays(
+        task.scheduleStart,
+        weekStart,
+      );
+      const endOffset = differenceInCalendarDays(task.scheduleEnd, weekStart);
+
+      if (endOffset < 0 || startOffset > lastDayIndex) return null;
+
+      const clippedStart = Math.max(0, startOffset);
+      const clippedEnd = Math.min(lastDayIndex, endOffset);
+
+      return {
+        task,
+        clippedStart,
+        clippedEnd,
+        columnStart: clippedStart + 1,
+        columnEnd: clippedEnd + 2,
+        continuesBefore: startOffset < 0,
+        continuesAfter: endOffset > lastDayIndex,
+      };
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    // Longest bar first within a start column, then by id so the layout does
+    // not shuffle between renders of the same data.
+    .sort((left, right) => {
+      if (left.columnStart !== right.columnStart) {
+        return left.columnStart - right.columnStart;
+      }
+      const leftSpan = left.columnEnd - left.columnStart;
+      const rightSpan = right.columnEnd - right.columnStart;
+      if (leftSpan !== rightSpan) return rightSpan - leftSpan;
+      return left.task.id.localeCompare(right.task.id);
+    });
+
+  const segments: Array<WeekSegment<TTask>> = [];
+  const laneNextFreeColumn: number[] = [];
+
+  for (const candidate of candidates) {
+    for (
+      let dayIndex = candidate.clippedStart;
+      dayIndex <= candidate.clippedEnd;
+      dayIndex += 1
+    ) {
+      tasksByDay[dayIndex].push(candidate.task);
+    }
+
+    let lane = laneNextFreeColumn.findIndex(
+      (nextFree) => nextFree <= candidate.columnStart,
+    );
+
+    if (lane === -1) {
+      lane = laneNextFreeColumn.length;
+      laneNextFreeColumn.push(candidate.columnEnd);
+    } else {
+      laneNextFreeColumn[lane] = candidate.columnEnd;
+    }
+
+    if (lane < maxLanes) {
+      segments.push({
+        task: candidate.task,
+        lane,
+        columnStart: candidate.columnStart,
+        columnEnd: candidate.columnEnd,
+        continuesBefore: candidate.continuesBefore,
+        continuesAfter: candidate.continuesAfter,
+      });
+      continue;
+    }
+
+    for (
+      let dayIndex = candidate.clippedStart;
+      dayIndex <= candidate.clippedEnd;
+      dayIndex += 1
+    ) {
+      hiddenCountByDay[dayIndex] += 1;
+    }
+  }
+
+  return { segments, hiddenCountByDay, tasksByDay };
+}

--- a/apps/web/src/components/calendar/month-grid.tsx
+++ b/apps/web/src/components/calendar/month-grid.tsx
@@ -1,4 +1,5 @@
 import { format, isSameMonth, isToday, isWeekend } from "date-fns";
+import { type JSX, useMemo } from "react";
 import { cn } from "@/lib/cn";
 import { formatDate } from "@/lib/format";
 import CalendarTaskBar, { type CalendarTask } from "./calendar-task-bar";
@@ -21,8 +22,12 @@ export default function MonthGrid({
   maxLanes,
   projectSlug,
   onOpenTask,
-}: MonthGridProps) {
+}: MonthGridProps): JSX.Element {
   const weekdayTemplate = weeks[0] ?? [];
+  const layouts = useMemo(
+    () => weeks.map((week) => packWeekLanes(week, tasks, maxLanes)),
+    [weeks, tasks, maxLanes],
+  );
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-auto overscroll-x-contain">
@@ -38,12 +43,8 @@ export default function MonthGrid({
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col">
-        {weeks.map((week) => {
-          const { segments, hiddenCountByDay, tasksByDay } = packWeekLanes(
-            week,
-            tasks,
-            maxLanes,
-          );
+        {weeks.map((week, weekIndex) => {
+          const { segments, hiddenCountByDay, tasksByDay } = layouts[weekIndex];
 
           return (
             <div

--- a/apps/web/src/components/calendar/month-grid.tsx
+++ b/apps/web/src/components/calendar/month-grid.tsx
@@ -1,0 +1,120 @@
+import { format, isSameMonth, isToday, isWeekend } from "date-fns";
+import { cn } from "@/lib/cn";
+import { formatDate } from "@/lib/format";
+import CalendarTaskBar, { type CalendarTask } from "./calendar-task-bar";
+import DayOverflowPopover from "./day-overflow-popover";
+import { packWeekLanes } from "./month-grid-model";
+
+type MonthGridProps = {
+  weeks: Date[][];
+  tasks: CalendarTask[];
+  visibleMonth: Date;
+  maxLanes: number;
+  projectSlug?: string;
+  onOpenTask: (taskId: string) => void;
+};
+
+export default function MonthGrid({
+  weeks,
+  tasks,
+  visibleMonth,
+  maxLanes,
+  projectSlug,
+  onOpenTask,
+}: MonthGridProps) {
+  const weekdayTemplate = weeks[0] ?? [];
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-auto overscroll-x-contain">
+      <div className="sticky top-0 z-20 grid grid-cols-7 border-b border-border bg-background/95 backdrop-blur">
+        {weekdayTemplate.map((day) => (
+          <div
+            key={`weekday-${day.toISOString()}`}
+            className="border-r border-border/60 px-1 py-2 text-center text-[11px] font-medium uppercase tracking-wide text-muted-foreground"
+          >
+            {formatDate(day, { weekday: "short" })}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        {weeks.map((week) => {
+          const { segments, hiddenCountByDay, tasksByDay } = packWeekLanes(
+            week,
+            tasks,
+            maxLanes,
+          );
+
+          return (
+            <div
+              key={`week-${week[0].toISOString()}`}
+              className="relative grid min-h-24 flex-1 grid-cols-7 border-b border-border/70 sm:min-h-28"
+              style={{
+                // Row 1 carries the date numbers, then one row per lane, then a
+                // trailing row for the per-day overflow hint.
+                gridTemplateRows: `auto repeat(${maxLanes}, min-content) auto`,
+              }}
+            >
+              {week.map((day, dayIndex) => (
+                <div
+                  key={`cell-${day.toISOString()}`}
+                  style={{ gridColumn: dayIndex + 1, gridRow: "1 / -1" }}
+                  className={cn(
+                    "min-w-0 border-r border-border/60",
+                    isWeekend(day) && "bg-muted/25",
+                  )}
+                />
+              ))}
+
+              {week.map((day, dayIndex) => (
+                <div
+                  key={`number-${day.toISOString()}`}
+                  style={{ gridColumn: dayIndex + 1, gridRow: 1 }}
+                  className="z-10 flex justify-end px-1 py-1"
+                >
+                  <span
+                    className={cn(
+                      "flex size-5 items-center justify-center rounded-full text-[11px] font-medium",
+                      !isSameMonth(day, visibleMonth) &&
+                        "text-muted-foreground/60",
+                      isToday(day) && "bg-primary text-primary-foreground",
+                    )}
+                  >
+                    {format(day, "d")}
+                  </span>
+                </div>
+              ))}
+
+              {segments.map((segment) => (
+                <CalendarTaskBar
+                  key={`bar-${segment.task.id}`}
+                  segment={segment}
+                  projectSlug={projectSlug}
+                  onOpenTask={onOpenTask}
+                />
+              ))}
+
+              {week.map((day, dayIndex) =>
+                hiddenCountByDay[dayIndex] > 0 ? (
+                  <div
+                    key={`overflow-${day.toISOString()}`}
+                    style={{ gridColumn: dayIndex + 1, gridRow: maxLanes + 2 }}
+                    className="z-10 min-w-0"
+                  >
+                    <DayOverflowPopover
+                      day={day}
+                      tasks={tasksByDay[dayIndex]}
+                      hiddenCount={hiddenCountByDay[dayIndex]}
+                      projectSlug={projectSlug}
+                      onOpenTask={onOpenTask}
+                    />
+                  </div>
+                ) : null,
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/common/header/mobile-project-nav.tsx
+++ b/apps/web/src/components/common/header/mobile-project-nav.tsx
@@ -6,6 +6,7 @@ import {
   Plus,
   SquareKanban,
 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -39,6 +40,7 @@ export default function MobileProjectNav({
   onSelectProject,
   onAddProject,
 }: MobileProjectNavProps) {
+  const { t } = useTranslation();
   const { data: projects = [] } = useGetProjects({ workspaceId });
 
   return (
@@ -97,7 +99,7 @@ export default function MobileProjectNav({
                 )}
               >
                 <CalendarRange className="size-3.5" />
-                Calendar
+                {t("tasks:calendar.title")}
               </button>
               <button
                 type="button"

--- a/apps/web/src/components/common/header/mobile-project-nav.tsx
+++ b/apps/web/src/components/common/header/mobile-project-nav.tsx
@@ -1,4 +1,11 @@
-import { CalendarDays, Check, Menu, Plus, SquareKanban } from "lucide-react";
+import {
+  CalendarDays,
+  CalendarRange,
+  Check,
+  Menu,
+  Plus,
+  SquareKanban,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -12,9 +19,10 @@ import { cn } from "@/lib/cn";
 type MobileProjectNavProps = {
   workspaceId: string;
   projectId: string;
-  activeView: "backlog" | "board" | "gantt";
+  activeView: "backlog" | "board" | "calendar" | "gantt";
   onSelectBoard: () => void;
   onSelectBacklog: () => void;
+  onSelectCalendar: () => void;
   onSelectGantt: () => void;
   onSelectProject: (projectId: string) => void;
   onAddProject: () => void;
@@ -26,6 +34,7 @@ export default function MobileProjectNav({
   activeView,
   onSelectBoard,
   onSelectBacklog,
+  onSelectCalendar,
   onSelectGantt,
   onSelectProject,
   onAddProject,
@@ -51,7 +60,7 @@ export default function MobileProjectNav({
             <p className="px-1 text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
               View
             </p>
-            <div className="grid grid-cols-3 gap-1">
+            <div className="grid grid-cols-4 gap-1">
               <button
                 type="button"
                 onClick={onSelectBacklog}
@@ -76,6 +85,19 @@ export default function MobileProjectNav({
               >
                 <SquareKanban className="size-3.5" />
                 Board
+              </button>
+              <button
+                type="button"
+                onClick={onSelectCalendar}
+                className={cn(
+                  "flex w-full items-center justify-center gap-1 whitespace-nowrap rounded-md border px-2 py-1.5 text-xs font-medium transition-colors",
+                  activeView === "calendar"
+                    ? "border-border bg-secondary text-foreground"
+                    : "border-transparent text-muted-foreground hover:bg-accent",
+                )}
+              >
+                <CalendarRange className="size-3.5" />
+                Calendar
               </button>
               <button
                 type="button"

--- a/apps/web/src/components/common/project-layout.tsx
+++ b/apps/web/src/components/common/project-layout.tsx
@@ -6,6 +6,7 @@ import {
   SquircleDashed,
 } from "lucide-react";
 import { type ReactNode, useState } from "react";
+import { useTranslation } from "react-i18next";
 import MobileProjectNav from "@/components/common/header/mobile-project-nav";
 import ProjectCrumbSelect from "@/components/common/header/project-crumb-select";
 import WorkspaceCrumbSelect from "@/components/common/header/workspace-crumb-select";
@@ -42,6 +43,7 @@ export default function ProjectLayout({
   showViewSwitcher = true,
   activeView,
 }: ProjectLayoutProps) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const { data: project } = useGetProject({ id: projectId, workspaceId });
@@ -193,7 +195,7 @@ export default function ProjectLayout({
                   )}
                 >
                   <CalendarRange className="size-3.5" />
-                  Calendar
+                  {t("tasks:calendar.title")}
                 </Button>
                 <Button
                   variant={resolvedView === "gantt" ? "secondary" : "ghost"}

--- a/apps/web/src/components/common/project-layout.tsx
+++ b/apps/web/src/components/common/project-layout.tsx
@@ -1,5 +1,10 @@
 import { useLocation, useNavigate } from "@tanstack/react-router";
-import { CalendarDays, SquareKanban, SquircleDashed } from "lucide-react";
+import {
+  CalendarDays,
+  CalendarRange,
+  SquareKanban,
+  SquircleDashed,
+} from "lucide-react";
 import { type ReactNode, useState } from "react";
 import MobileProjectNav from "@/components/common/header/mobile-project-nav";
 import ProjectCrumbSelect from "@/components/common/header/project-crumb-select";
@@ -26,7 +31,7 @@ type ProjectLayoutProps = {
   headerActions?: ReactNode;
   children: ReactNode;
   showViewSwitcher?: boolean;
-  activeView?: "backlog" | "board" | "gantt";
+  activeView?: "backlog" | "board" | "calendar" | "gantt";
 };
 
 export default function ProjectLayout({
@@ -49,9 +54,11 @@ export default function ProjectLayout({
     activeView ??
     (location.pathname.includes("/backlog")
       ? "backlog"
-      : location.pathname.includes("/gantt")
-        ? "gantt"
-        : "board");
+      : location.pathname.includes("/calendar")
+        ? "calendar"
+        : location.pathname.includes("/gantt")
+          ? "gantt"
+          : "board");
 
   const handleNavigateToBacklog = () => {
     navigate({
@@ -63,6 +70,13 @@ export default function ProjectLayout({
   const handleNavigateToBoard = () => {
     navigate({
       to: "/dashboard/workspace/$workspaceId/project/$projectId/board",
+      params: { workspaceId, projectId },
+    });
+  };
+
+  const handleNavigateToCalendar = () => {
+    navigate({
+      to: "/dashboard/workspace/$workspaceId/project/$projectId/calendar",
       params: { workspaceId, projectId },
     });
   };
@@ -79,9 +93,11 @@ export default function ProjectLayout({
       to:
         resolvedView === "backlog"
           ? "/dashboard/workspace/$workspaceId/project/$projectId/backlog"
-          : resolvedView === "gantt"
-            ? "/dashboard/workspace/$workspaceId/project/$projectId/gantt"
-            : "/dashboard/workspace/$workspaceId/project/$projectId/board",
+          : resolvedView === "calendar"
+            ? "/dashboard/workspace/$workspaceId/project/$projectId/calendar"
+            : resolvedView === "gantt"
+              ? "/dashboard/workspace/$workspaceId/project/$projectId/gantt"
+              : "/dashboard/workspace/$workspaceId/project/$projectId/board",
       params: {
         workspaceId,
         projectId: nextProjectId,
@@ -134,6 +150,7 @@ export default function ProjectLayout({
                 activeView={resolvedView}
                 onSelectBacklog={handleNavigateToBacklog}
                 onSelectBoard={handleNavigateToBoard}
+                onSelectCalendar={handleNavigateToCalendar}
                 onSelectGantt={handleNavigateToGantt}
                 onSelectProject={handleProjectSwitch}
                 onAddProject={() => setIsCreateProjectModalOpen(true)}
@@ -165,6 +182,18 @@ export default function ProjectLayout({
                 >
                   <SquareKanban className="size-3.5" />
                   Tasks
+                </Button>
+                <Button
+                  variant={resolvedView === "calendar" ? "secondary" : "ghost"}
+                  size="xs"
+                  onClick={handleNavigateToCalendar}
+                  className={cn(
+                    "h-6 gap-1.5 rounded-md px-2 text-xs",
+                    resolvedView !== "calendar" && "text-muted-foreground",
+                  )}
+                >
+                  <CalendarRange className="size-3.5" />
+                  Calendar
                 </Button>
                 <Button
                   variant={resolvedView === "gantt" ? "secondary" : "ghost"}

--- a/apps/web/src/components/keyboard-shortcuts-help.tsx
+++ b/apps/web/src/components/keyboard-shortcuts-help.tsx
@@ -88,6 +88,10 @@ function useShortcutCategories(): ShortcutCategory[] {
             keys: [shortcuts.view.prefix, shortcuts.view.backlog],
             description: t("navigation:keyboardShortcuts.items.backlogView"),
           },
+          {
+            keys: [shortcuts.view.prefix, shortcuts.view.calendar],
+            description: t("navigation:keyboardShortcuts.items.calendarView"),
+          },
         ],
       },
       {

--- a/apps/web/src/constants/shortcuts.ts
+++ b/apps/web/src/constants/shortcuts.ts
@@ -33,6 +33,7 @@ export const shortcuts = {
   view: {
     prefix: "v",
     board: "b",
+    calendar: "c",
     gantt: "g",
     list: "l",
     backlog: "k",

--- a/apps/web/src/lib/task-schedule.test.ts
+++ b/apps/web/src/lib/task-schedule.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseTaskDate,
+  toScheduledTask,
+  toScheduledTasks,
+} from "./task-schedule";
+
+function task(id: string, startDate: string | null, dueDate: string | null) {
+  return { id, startDate, dueDate };
+}
+
+describe("parseTaskDate", () => {
+  it("returns null for empty and unparseable values", () => {
+    expect(parseTaskDate(null)).toBeNull();
+    expect(parseTaskDate(undefined)).toBeNull();
+    expect(parseTaskDate("")).toBeNull();
+    expect(parseTaskDate("not-a-date")).toBeNull();
+  });
+
+  it("parses an ISO string", () => {
+    expect(parseTaskDate("2026-08-13T00:00:00.000Z")?.toISOString()).toBe(
+      "2026-08-13T00:00:00.000Z",
+    );
+  });
+});
+
+describe("toScheduledTask", () => {
+  it("falls back to the due date when only a due date exists", () => {
+    const scheduled = toScheduledTask(
+      task("a", null, "2026-08-13T00:00:00.000Z"),
+    );
+
+    expect(scheduled?.scheduleStart.toISOString()).toBe(
+      "2026-08-13T00:00:00.000Z",
+    );
+    expect(scheduled?.scheduleEnd.toISOString()).toBe(
+      "2026-08-13T00:00:00.000Z",
+    );
+  });
+
+  it("falls back to the start date when only a start date exists", () => {
+    const scheduled = toScheduledTask(
+      task("a", "2026-08-10T00:00:00.000Z", null),
+    );
+
+    expect(scheduled?.scheduleStart.toISOString()).toBe(
+      "2026-08-10T00:00:00.000Z",
+    );
+    expect(scheduled?.scheduleEnd.toISOString()).toBe(
+      "2026-08-10T00:00:00.000Z",
+    );
+  });
+
+  it("drops a task with neither date", () => {
+    expect(toScheduledTask(task("a", null, null))).toBeNull();
+  });
+
+  it("drops a task whose only date is unparseable", () => {
+    expect(toScheduledTask(task("a", "nonsense", null))).toBeNull();
+  });
+
+  it("swaps a reversed range instead of dropping it", () => {
+    const scheduled = toScheduledTask(
+      task("a", "2026-08-20T00:00:00.000Z", "2026-08-10T00:00:00.000Z"),
+    );
+
+    expect(scheduled?.scheduleStart.toISOString()).toBe(
+      "2026-08-10T00:00:00.000Z",
+    );
+    expect(scheduled?.scheduleEnd.toISOString()).toBe(
+      "2026-08-20T00:00:00.000Z",
+    );
+  });
+
+  it("preserves the other task fields", () => {
+    const scheduled = toScheduledTask({
+      id: "a",
+      startDate: "2026-08-10T00:00:00.000Z",
+      dueDate: null,
+      title: "Ship it",
+    });
+
+    expect(scheduled?.id).toBe("a");
+    expect(scheduled?.title).toBe("Ship it");
+  });
+});
+
+describe("toScheduledTasks", () => {
+  const source = {
+    columns: [
+      {
+        tasks: [
+          task("late", "2026-08-20T00:00:00.000Z", "2026-08-22T00:00:00.000Z"),
+          task("undated", null, null),
+        ],
+      },
+      {
+        tasks: [
+          task("early", "2026-08-01T00:00:00.000Z", "2026-08-03T00:00:00.000Z"),
+        ],
+      },
+    ],
+    plannedTasks: [
+      task("planned", "2026-08-10T00:00:00.000Z", "2026-08-11T00:00:00.000Z"),
+    ],
+  };
+
+  it("flattens columns and planned tasks, sorted by start date", () => {
+    expect(toScheduledTasks(source).map((entry) => entry.id)).toEqual([
+      "early",
+      "planned",
+      "late",
+    ]);
+  });
+
+  it("returns an empty list for missing data", () => {
+    expect(toScheduledTasks(undefined)).toEqual([]);
+    expect(toScheduledTasks(null)).toEqual([]);
+    expect(toScheduledTasks({ columns: [], plannedTasks: [] })).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/task-schedule.ts
+++ b/apps/web/src/lib/task-schedule.ts
@@ -1,0 +1,69 @@
+import { parseISO } from "date-fns";
+
+/**
+ * Minimal shape a task needs to be placed on a date-based view. Kept structural
+ * rather than tied to `Task` so both the typed API response and the local
+ * `Task` type satisfy it.
+ */
+export type SchedulableTask = {
+  startDate: string | null;
+  dueDate: string | null;
+};
+
+export type Scheduled<TTask> = TTask & {
+  scheduleStart: Date;
+  scheduleEnd: Date;
+};
+
+export type ScheduleSource<TTask> = {
+  columns: Array<{ tasks: TTask[] }>;
+  plannedTasks: TTask[];
+};
+
+export function parseTaskDate(value: string | null | undefined) {
+  if (!value) return null;
+  const parsed = parseISO(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/**
+ * A task only needs one of the two dates to be schedulable: each side falls
+ * back to the other, so a task with just a due date renders as a single day.
+ * Reversed ranges are swapped rather than dropped.
+ */
+export function toScheduledTask<TTask extends SchedulableTask>(
+  task: TTask,
+): Scheduled<TTask> | null {
+  const parsedStart =
+    parseTaskDate(task.startDate) ?? parseTaskDate(task.dueDate);
+  const parsedEnd =
+    parseTaskDate(task.dueDate) ?? parseTaskDate(task.startDate);
+
+  if (!parsedStart || !parsedEnd) return null;
+
+  const scheduleStart = parsedStart <= parsedEnd ? parsedStart : parsedEnd;
+  const scheduleEnd = parsedEnd >= parsedStart ? parsedEnd : parsedStart;
+
+  return { ...task, scheduleStart, scheduleEnd };
+}
+
+/**
+ * Flattens the board columns plus planned tasks into a date-sorted list.
+ * Archived tasks are intentionally excluded from schedule views.
+ */
+export function toScheduledTasks<TTask extends SchedulableTask>(
+  source: ScheduleSource<TTask> | undefined | null,
+): Array<Scheduled<TTask>> {
+  const tasks = [
+    ...(source?.columns.flatMap((column) => column.tasks) ?? []),
+    ...(source?.plannedTasks ?? []),
+  ];
+
+  return tasks
+    .map(toScheduledTask)
+    .filter((task): task is Scheduled<TTask> => task !== null)
+    .sort(
+      (left, right) =>
+        left.scheduleStart.getTime() - right.scheduleStart.getTime(),
+    );
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -54,6 +54,7 @@ import { Route as LayoutAuthenticatedDashboardSettingsProjectsProjectIdWorkflowR
 import { Route as LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdIndexRouteImport } from './routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/index'
 import { Route as LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBacklogRouteImport } from './routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog'
 import { Route as LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRouteImport } from './routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board'
+import { Route as LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRouteImport } from './routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar'
 import { Route as LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRouteImport } from './routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/gantt'
 import { Route as LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdTaskTaskIdRouteImport } from './routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId_'
 
@@ -328,6 +329,15 @@ const LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute
         LayoutAuthenticatedDashboardWorkspaceWorkspaceIdRoute,
     } as any,
   )
+const LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute =
+  LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRouteImport.update(
+    {
+      id: '/project/$projectId/calendar',
+      path: '/project/$projectId/calendar',
+      getParentRoute: () =>
+        LayoutAuthenticatedDashboardWorkspaceWorkspaceIdRoute,
+    } as any,
+  )
 const LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute =
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRouteImport.update(
     {
@@ -390,6 +400,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/settings/projects/$projectId/workflow': typeof LayoutAuthenticatedDashboardSettingsProjectsProjectIdWorkflowRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/backlog': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBacklogRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/board': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute
+  '/dashboard/workspace/$workspaceId/project/$projectId/calendar': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/gantt': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdIndexRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdTaskTaskIdRoute
@@ -434,6 +445,7 @@ export interface FileRoutesByTo {
   '/dashboard/settings/projects/$projectId/workflow': typeof LayoutAuthenticatedDashboardSettingsProjectsProjectIdWorkflowRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/backlog': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBacklogRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/board': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute
+  '/dashboard/workspace/$workspaceId/project/$projectId/calendar': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/gantt': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute
   '/dashboard/workspace/$workspaceId/project/$projectId': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdIndexRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdTaskTaskIdRoute
@@ -484,6 +496,7 @@ export interface FileRoutesById {
   '/_layout/_authenticated/dashboard/settings/projects/$projectId/workflow': typeof LayoutAuthenticatedDashboardSettingsProjectsProjectIdWorkflowRoute
   '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBacklogRoute
   '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute
+  '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute
   '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/gantt': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute
   '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdIndexRoute
   '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId_': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdTaskTaskIdRoute
@@ -533,6 +546,7 @@ export interface FileRouteTypes {
     | '/dashboard/settings/projects/$projectId/workflow'
     | '/dashboard/workspace/$workspaceId/project/$projectId/backlog'
     | '/dashboard/workspace/$workspaceId/project/$projectId/board'
+    | '/dashboard/workspace/$workspaceId/project/$projectId/calendar'
     | '/dashboard/workspace/$workspaceId/project/$projectId/gantt'
     | '/dashboard/workspace/$workspaceId/project/$projectId/'
     | '/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId'
@@ -577,6 +591,7 @@ export interface FileRouteTypes {
     | '/dashboard/settings/projects/$projectId/workflow'
     | '/dashboard/workspace/$workspaceId/project/$projectId/backlog'
     | '/dashboard/workspace/$workspaceId/project/$projectId/board'
+    | '/dashboard/workspace/$workspaceId/project/$projectId/calendar'
     | '/dashboard/workspace/$workspaceId/project/$projectId/gantt'
     | '/dashboard/workspace/$workspaceId/project/$projectId'
     | '/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId'
@@ -626,6 +641,7 @@ export interface FileRouteTypes {
     | '/_layout/_authenticated/dashboard/settings/projects/$projectId/workflow'
     | '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog'
     | '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board'
+    | '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar'
     | '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/gantt'
     | '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/'
     | '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId_'
@@ -959,6 +975,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRouteImport
       parentRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdRoute
     }
+    '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar': {
+      id: '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar'
+      path: '/project/$projectId/calendar'
+      fullPath: '/dashboard/workspace/$workspaceId/project/$projectId/calendar'
+      preLoaderRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRouteImport
+      parentRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdRoute
+    }
     '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/gantt': {
       id: '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/gantt'
       path: '/project/$projectId/gantt'
@@ -1075,6 +1098,7 @@ interface LayoutAuthenticatedDashboardWorkspaceWorkspaceIdRouteChildren {
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdIndexRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdIndexRoute
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBacklogRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBacklogRoute
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute
+  LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdIndexRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdIndexRoute
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdTaskTaskIdRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdTaskTaskIdRoute
@@ -1092,6 +1116,8 @@ const LayoutAuthenticatedDashboardWorkspaceWorkspaceIdRouteChildren: LayoutAuthe
       LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBacklogRoute,
     LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute:
       LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute,
+    LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute:
+      LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute,
     LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute:
       LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute,
     LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdIndexRoute:

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog.tsx
@@ -98,6 +98,12 @@ function RouteComponent() {
             params: { workspaceId, projectId },
           });
         },
+        [shortcuts.view.calendar]: () => {
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/calendar",
+            params: { workspaceId, projectId },
+          });
+        },
         [shortcuts.view.gantt]: () => {
           navigate({
             to: "/dashboard/workspace/$workspaceId/project/$projectId/gantt",

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board.tsx
@@ -106,6 +106,11 @@ function RouteComponent() {
       [shortcuts.view.prefix]: {
         [shortcuts.view.board]: () => setViewMode("board"),
         [shortcuts.view.list]: () => setViewMode("list"),
+        [shortcuts.view.calendar]: () =>
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/calendar",
+            params: { workspaceId, projectId },
+          }),
         [shortcuts.view.gantt]: () =>
           navigate({
             to: "/dashboard/workspace/$workspaceId/project/$projectId/gantt",

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar.tsx
@@ -1,0 +1,160 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { addMonths, startOfMonth, subMonths } from "date-fns";
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import CalendarToolbar from "@/components/calendar/calendar-toolbar";
+import MonthGrid from "@/components/calendar/month-grid";
+import { buildMonthWeeks } from "@/components/calendar/month-grid-model";
+import ProjectLayout from "@/components/common/project-layout";
+import PageTitle from "@/components/page-title";
+import TaskDetailsSheet from "@/components/task/task-details-sheet";
+import { shortcuts } from "@/constants/shortcuts";
+import { useGetTasks } from "@/hooks/queries/task/use-get-tasks";
+import { useRegisterShortcuts } from "@/hooks/use-keyboard-shortcuts";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { toScheduledTasks } from "@/lib/task-schedule";
+import { useUserPreferencesStore } from "@/store/user-preferences";
+
+type CalendarSearchParams = {
+  taskId?: string;
+};
+
+export const Route = createFileRoute(
+  "/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar",
+)({
+  component: RouteComponent,
+  validateSearch: (search: Record<string, unknown>): CalendarSearchParams => ({
+    taskId: typeof search.taskId === "string" ? search.taskId : undefined,
+  }),
+});
+
+// Lanes are capped so a busy week cannot push a row taller than the viewport;
+// anything past the cap surfaces as a per-day overflow hint.
+const MAX_LANES_DESKTOP = 3;
+const MAX_LANES_MOBILE = 2;
+
+function RouteComponent() {
+  const { t } = useTranslation();
+  const { projectId, workspaceId } = Route.useParams();
+  const { taskId } = Route.useSearch();
+  const navigate = useNavigate();
+  const { data: project } = useGetTasks(projectId);
+  const weekStartsOn = useUserPreferencesStore((state) => state.weekStartsOn);
+  const setViewMode = useUserPreferencesStore((state) => state.setViewMode);
+  const isMobile = useIsMobile();
+  const [visibleMonth, setVisibleMonth] = useState(() =>
+    startOfMonth(new Date()),
+  );
+
+  const scheduledTasks = useMemo(() => toScheduledTasks(project), [project]);
+
+  const weeks = useMemo(
+    () => buildMonthWeeks(visibleMonth, weekStartsOn),
+    [visibleMonth, weekStartsOn],
+  );
+
+  const handlePreviousMonth = useCallback(() => {
+    setVisibleMonth((current) => subMonths(current, 1));
+  }, []);
+
+  const handleNextMonth = useCallback(() => {
+    setVisibleMonth((current) => addMonths(current, 1));
+  }, []);
+
+  const handleToday = useCallback(() => {
+    setVisibleMonth(startOfMonth(new Date()));
+  }, []);
+
+  const handleOpenTask = useCallback(
+    (nextTaskId: string) => {
+      navigate({ to: ".", search: { taskId: nextTaskId }, replace: true });
+    },
+    [navigate],
+  );
+
+  const handleCloseTaskSheet = useCallback(() => {
+    navigate({ to: ".", search: {}, replace: true });
+  }, [navigate]);
+
+  useRegisterShortcuts({
+    sequentialShortcuts: {
+      [shortcuts.view.prefix]: {
+        [shortcuts.view.board]: () => {
+          setViewMode("board");
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/board",
+            params: { workspaceId, projectId },
+          });
+        },
+        [shortcuts.view.list]: () => {
+          setViewMode("list");
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/board",
+            params: { workspaceId, projectId },
+          });
+        },
+        [shortcuts.view.backlog]: () => {
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/backlog",
+            params: { workspaceId, projectId },
+          });
+        },
+        [shortcuts.view.gantt]: () => {
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/gantt",
+            params: { workspaceId, projectId },
+          });
+        },
+        [shortcuts.view.calendar]: () => {},
+      },
+    },
+  });
+
+  return (
+    <ProjectLayout
+      projectId={projectId}
+      workspaceId={workspaceId}
+      activeView="calendar"
+    >
+      <PageTitle
+        title={t("tasks:calendar.pageTitle", { name: project?.name })}
+        hideAppName
+      />
+      <div className="flex h-full min-h-0 flex-col bg-background">
+        <CalendarToolbar
+          visibleMonth={visibleMonth}
+          onPreviousMonth={handlePreviousMonth}
+          onNextMonth={handleNextMonth}
+          onToday={handleToday}
+        />
+
+        {scheduledTasks.length === 0 ? (
+          <div className="border-b border-border/80 px-4 py-3 text-center">
+            <p className="text-sm font-semibold text-foreground">
+              {t("tasks:calendar.noTasks")}
+            </p>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              {t("tasks:calendar.noTasksSubtitle")}
+            </p>
+          </div>
+        ) : null}
+
+        <MonthGrid
+          weeks={weeks}
+          tasks={scheduledTasks}
+          visibleMonth={visibleMonth}
+          maxLanes={isMobile ? MAX_LANES_MOBILE : MAX_LANES_DESKTOP}
+          projectSlug={project?.slug}
+          onOpenTask={handleOpenTask}
+        />
+
+        <TaskDetailsSheet
+          taskId={taskId}
+          projectId={projectId}
+          workspaceId={workspaceId}
+          onClose={handleCloseTaskSheet}
+        />
+      </div>
+    </ProjectLayout>
+  );
+}

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar.tsx
@@ -38,7 +38,7 @@ function RouteComponent() {
   const { projectId, workspaceId } = Route.useParams();
   const { taskId } = Route.useSearch();
   const navigate = useNavigate();
-  const { data: project } = useGetTasks(projectId);
+  const { data: project, isLoading, isError } = useGetTasks(projectId);
   const weekStartsOn = useUserPreferencesStore((state) => state.weekStartsOn);
   const setViewMode = useUserPreferencesStore((state) => state.setViewMode);
   const isMobile = useIsMobile();
@@ -128,7 +128,19 @@ function RouteComponent() {
           onToday={handleToday}
         />
 
-        {scheduledTasks.length === 0 ? (
+        {isLoading ? (
+          <div className="border-b border-border/80 px-4 py-3 text-center">
+            <p className="text-sm text-muted-foreground">
+              {t("common:empty.loading")}
+            </p>
+          </div>
+        ) : isError ? (
+          <div className="border-b border-border/80 px-4 py-3 text-center">
+            <p className="text-sm font-semibold text-destructive">
+              {t("tasks:calendar.loadError")}
+            </p>
+          </div>
+        ) : scheduledTasks.length === 0 ? (
           <div className="border-b border-border/80 px-4 py-3 text-center">
             <p className="text-sm font-semibold text-foreground">
               {t("tasks:calendar.noTasks")}

--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -1952,7 +1952,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -1356,7 +1356,8 @@
 				"nextTask": "Nächste Aufgabe",
 				"prevTask": "Vorherige Aufgabe",
 				"openTask": "Ausgewählte Aufgabe öffnen",
-				"quickSelectNumber": "Option per Nummer auswählen"
+				"quickSelectNumber": "Option per Nummer auswählen",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1940,6 +1941,18 @@
 				"deleteRow": "Zeile löschen",
 				"deleteTable": "Tabelle löschen"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -1950,7 +1950,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/el-GR.json
+++ b/i18n/el-GR.json
@@ -1952,7 +1952,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/el-GR.json
+++ b/i18n/el-GR.json
@@ -1356,7 +1356,8 @@
 				"nextTask": "Επόμενη εργασία",
 				"prevTask": "Προηγούμενη εργασία",
 				"openTask": "Άνοιγμα επιλεγμένης εργασίας",
-				"quickSelectNumber": "Επιλογή επιλογής με αριθμό"
+				"quickSelectNumber": "Επιλογή επιλογής με αριθμό",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1940,6 +1941,18 @@
 				"deleteRow": "Διαγραφή γραμμής",
 				"deleteTable": "Διαγραφή πίνακα"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/el-GR.json
+++ b/i18n/el-GR.json
@@ -1950,7 +1950,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1837,6 +1837,7 @@
 			"noTasks": "No scheduled tasks",
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"moreTasks": "+{{count}} more",
+			"loadError": "Failed to load tasks.",
 			"dayTasksAriaLabel": "Show all tasks for {{date}}",
 			"taskAriaLabel": "{{title}}: open task"
 		},

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1839,7 +1839,7 @@
 			"moreTasks": "+{{count}} more",
 			"loadError": "Failed to load tasks.",
 			"dayTasksAriaLabel": "Show all tasks for {{date}}",
-			"taskAriaLabel": "{{title}}: open task"
+			"taskAriaLabel": "{{title}}, {{range}}: open task"
 		},
 		"gantt": {
 			"pageTitle": "{{name}} – Gantt",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1353,6 +1353,7 @@
 				"boardView": "Switch to board view",
 				"listView": "Switch to list view",
 				"backlogView": "Switch to backlog view",
+				"calendarView": "Switch to calendar view",
 				"nextTask": "Next task",
 				"prevTask": "Previous task",
 				"openTask": "Open selected task",
@@ -1826,6 +1827,18 @@
 				"isAnyOf": "is any of",
 				"includeAnyOf": "include any of"
 			}
+		},
+		"calendar": {
+			"pageTitle": "{{name}} – Calendar",
+			"title": "Calendar",
+			"previousMonth": "Previous month",
+			"nextMonth": "Next month",
+			"today": "Today",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"moreTasks": "+{{count}} more",
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"taskAriaLabel": "{{title}}: open task"
 		},
 		"gantt": {
 			"pageTitle": "{{name}} – Gantt",

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -1952,7 +1952,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -1356,7 +1356,8 @@
 				"nextTask": "Siguiente tarea",
 				"prevTask": "Tarea anterior",
 				"openTask": "Abrir tarea seleccionada",
-				"quickSelectNumber": "Seleccionar opción por número"
+				"quickSelectNumber": "Seleccionar opción por número",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1940,6 +1941,18 @@
 				"deleteRow": "Eliminar fila",
 				"deleteTable": "Eliminar tabla"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -1950,7 +1950,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -1952,7 +1952,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -1356,7 +1356,8 @@
 				"nextTask": "Tâche suivante",
 				"prevTask": "Tâche précédente",
 				"openTask": "Ouvrir la tâche sélectionnée",
-				"quickSelectNumber": "Sélectionner une option par numéro"
+				"quickSelectNumber": "Sélectionner une option par numéro",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1940,6 +1941,18 @@
 				"deleteRow": "Supprimer la ligne",
 				"deleteTable": "Supprimer le tableau"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -1950,7 +1950,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/hi-IN.json
+++ b/i18n/hi-IN.json
@@ -1952,7 +1952,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/hi-IN.json
+++ b/i18n/hi-IN.json
@@ -1356,7 +1356,8 @@
 				"nextTask": "अगला कार्य",
 				"prevTask": "पिछला कार्य",
 				"openTask": "चयनित कार्य खोलें",
-				"quickSelectNumber": "संख्या द्वारा विकल्प चुनें"
+				"quickSelectNumber": "संख्या द्वारा विकल्प चुनें",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1940,6 +1941,18 @@
 				"deleteRow": "पंक्ति हटाएँ",
 				"deleteTable": "तालिका हटाएँ"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/hi-IN.json
+++ b/i18n/hi-IN.json
@@ -1950,7 +1950,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/id-ID.json
+++ b/i18n/id-ID.json
@@ -1952,7 +1952,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/id-ID.json
+++ b/i18n/id-ID.json
@@ -1356,7 +1356,8 @@
 				"nextTask": "Tugas berikutnya",
 				"prevTask": "Tugas sebelumnya",
 				"openTask": "Buka tugas terpilih",
-				"quickSelectNumber": "Pilih opsi berdasarkan nomor"
+				"quickSelectNumber": "Pilih opsi berdasarkan nomor",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1940,6 +1941,18 @@
 				"deleteRow": "Hapus baris",
 				"deleteTable": "Hapus tabel"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/id-ID.json
+++ b/i18n/id-ID.json
@@ -1950,7 +1950,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/it-IT.json
+++ b/i18n/it-IT.json
@@ -1356,7 +1356,8 @@
 				"nextTask": "Attività successiva",
 				"prevTask": "Attività precedente",
 				"openTask": "Apri attività selezionata",
-				"quickSelectNumber": "Seleziona opzione per numero"
+				"quickSelectNumber": "Seleziona opzione per numero",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1940,6 +1941,18 @@
 				"deleteRow": "Elimina riga",
 				"deleteTable": "Elimina tabella"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/it-IT.json
+++ b/i18n/it-IT.json
@@ -1952,7 +1952,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/it-IT.json
+++ b/i18n/it-IT.json
@@ -1950,7 +1950,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/ko-KR.json
+++ b/i18n/ko-KR.json
@@ -1353,6 +1353,7 @@
 				"boardView": "보드 보기로 전환",
 				"listView": "목록 보기로 전환",
 				"backlogView": "백로그 보기로 전환",
+				"calendarView": "캘린더 보기로 전환",
 				"nextTask": "다음 작업",
 				"prevTask": "이전 작업",
 				"openTask": "선택한 작업 열기",
@@ -1826,6 +1827,19 @@
 				"isAnyOf": "다음 중 하나",
 				"includeAnyOf": "다음 중 하나 포함"
 			}
+		},
+		"calendar": {
+			"pageTitle": "{{name}} – 캘린더",
+			"title": "캘린더",
+			"previousMonth": "이전 달",
+			"nextMonth": "다음 달",
+			"today": "오늘",
+			"noTasks": "예약된 작업 없음",
+			"noTasksSubtitle": "캘린더에 작업을 배치하려면 시작일, 마감일 또는 둘 다 추가하세요.",
+			"moreTasks": "+{{count}}개",
+			"loadError": "작업을 불러오지 못했습니다.",
+			"dayTasksAriaLabel": "{{date}}의 모든 작업 보기",
+			"taskAriaLabel": "{{title}}: 작업 열기"
 		},
 		"gantt": {
 			"pageTitle": "{{name}} – 간트",

--- a/i18n/ko-KR.json
+++ b/i18n/ko-KR.json
@@ -1839,7 +1839,7 @@
 			"moreTasks": "+{{count}}개",
 			"loadError": "작업을 불러오지 못했습니다.",
 			"dayTasksAriaLabel": "{{date}}의 모든 작업 보기",
-			"taskAriaLabel": "{{title}}: 작업 열기"
+			"taskAriaLabel": "{{title}}, {{range}}: 작업 열기"
 		},
 		"gantt": {
 			"pageTitle": "{{name}} – 간트",

--- a/i18n/mk-MK.json
+++ b/i18n/mk-MK.json
@@ -1952,7 +1952,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/mk-MK.json
+++ b/i18n/mk-MK.json
@@ -1356,7 +1356,8 @@
 				"nextTask": "Следна задача",
 				"prevTask": "Претходна задача",
 				"openTask": "Отвори избрана задача",
-				"quickSelectNumber": "Избери опција по број"
+				"quickSelectNumber": "Избери опција по број",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1940,6 +1941,18 @@
 				"deleteRow": "Избриши ред",
 				"deleteTable": "Избриши табела"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/mk-MK.json
+++ b/i18n/mk-MK.json
@@ -1950,7 +1950,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/nl-NL.json
+++ b/i18n/nl-NL.json
@@ -1952,7 +1952,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/nl-NL.json
+++ b/i18n/nl-NL.json
@@ -1950,7 +1950,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/nl-NL.json
+++ b/i18n/nl-NL.json
@@ -1356,7 +1356,8 @@
 				"nextTask": "Volgende taak",
 				"prevTask": "Vorige taak",
 				"openTask": "Geselecteerde taak openen",
-				"quickSelectNumber": "Selecteer optie via nummer"
+				"quickSelectNumber": "Selecteer optie via nummer",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1940,6 +1941,18 @@
 				"deleteRow": "Rij verwijderen",
 				"deleteTable": "Tabel verwijderen"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -1952,7 +1952,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -1356,7 +1356,8 @@
 				"nextTask": "Próxima tarefa",
 				"prevTask": "Tarefa anterior",
 				"openTask": "Abrir tarefa selecionada",
-				"quickSelectNumber": "Selecionar opção por número"
+				"quickSelectNumber": "Selecionar opção por número",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1940,6 +1941,18 @@
 				"deleteRow": "Excluir linha",
 				"deleteTable": "Excluir tabela"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -1950,7 +1950,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/ru-RU.json
+++ b/i18n/ru-RU.json
@@ -1366,7 +1366,8 @@
 				"nextTask": "Следующая задача",
 				"prevTask": "Предыдущая задача",
 				"openTask": "Открыть выбранную задачу",
-				"quickSelectNumber": "Выбрать вариант по номеру"
+				"quickSelectNumber": "Выбрать вариант по номеру",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -2008,6 +2009,18 @@
 				"deleteRow": "Удалить строку",
 				"deleteTable": "Удалить таблицу"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/ru-RU.json
+++ b/i18n/ru-RU.json
@@ -2020,7 +2020,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/ru-RU.json
+++ b/i18n/ru-RU.json
@@ -2018,7 +2018,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -1318,6 +1318,98 @@
 								}
 							},
 							"required": ["nameRequired", "nameShort", "invalidEmail"]
+						},
+						"avatar": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"hint": {
+									"type": "string"
+								},
+								"remove": {
+									"type": "string"
+								},
+								"updateSuccess": {
+									"type": "string"
+								},
+								"updateError": {
+									"type": "string"
+								},
+								"removeSuccess": {
+									"type": "string"
+								},
+								"removeError": {
+									"type": "string"
+								},
+								"edit": {
+									"type": "string"
+								},
+								"change": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"hint",
+								"remove",
+								"updateSuccess",
+								"updateError",
+								"removeSuccess",
+								"removeError",
+								"edit",
+								"change"
+							]
+						},
+						"deleteAccount": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"sectionTitle": {
+									"type": "string"
+								},
+								"sectionSubtitle": {
+									"type": "string"
+								},
+								"title": {
+									"type": "string"
+								},
+								"description": {
+									"type": "string"
+								},
+								"modalTitle": {
+									"type": "string"
+								},
+								"modalDescription": {
+									"type": "string"
+								},
+								"confirmLabel": {
+									"type": "string"
+								},
+								"confirm": {
+									"type": "string"
+								},
+								"success": {
+									"type": "string"
+								},
+								"error": {
+									"type": "string"
+								},
+								"sessionTooOld": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"sectionTitle",
+								"sectionSubtitle",
+								"title",
+								"description",
+								"modalTitle",
+								"modalDescription",
+								"confirmLabel",
+								"confirm",
+								"success",
+								"error",
+								"sessionTooOld"
+							]
 						}
 					},
 					"required": [
@@ -1333,7 +1425,9 @@
 						"emailPlaceholder",
 						"updateSuccess",
 						"updateError",
-						"validation"
+						"validation",
+						"avatar",
+						"deleteAccount"
 					]
 				},
 				"notificationsPage": {
@@ -3639,6 +3733,12 @@
 								"repoNotFound": {
 									"type": "string"
 								},
+								"redirected": {
+									"type": "string"
+								},
+								"notGiteaInstance": {
+									"type": "string"
+								},
 								"verifyError": {
 									"type": "string"
 								},
@@ -3689,6 +3789,8 @@
 								"verifyOk",
 								"verifyWarning",
 								"repoNotFound",
+								"redirected",
+								"notGiteaInstance",
 								"verifyError",
 								"tokenRequired",
 								"tokenRequiredVerify",
@@ -5246,6 +5348,9 @@
 								"backlogView": {
 									"type": "string"
 								},
+								"calendarView": {
+									"type": "string"
+								},
 								"nextTask": {
 									"type": "string"
 								},
@@ -5271,6 +5376,7 @@
 								"boardView",
 								"listView",
 								"backlogView",
+								"calendarView",
 								"nextTask",
 								"prevTask",
 								"openTask",
@@ -7129,6 +7235,54 @@
 						"operators"
 					]
 				},
+				"calendar": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"pageTitle": {
+							"type": "string"
+						},
+						"title": {
+							"type": "string"
+						},
+						"previousMonth": {
+							"type": "string"
+						},
+						"nextMonth": {
+							"type": "string"
+						},
+						"today": {
+							"type": "string"
+						},
+						"noTasks": {
+							"type": "string"
+						},
+						"noTasksSubtitle": {
+							"type": "string"
+						},
+						"moreTasks": {
+							"type": "string"
+						},
+						"dayTasksAriaLabel": {
+							"type": "string"
+						},
+						"taskAriaLabel": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"pageTitle",
+						"title",
+						"previousMonth",
+						"nextMonth",
+						"today",
+						"noTasks",
+						"noTasksSubtitle",
+						"moreTasks",
+						"dayTasksAriaLabel",
+						"taskAriaLabel"
+					]
+				},
 				"gantt": {
 					"type": "object",
 					"additionalProperties": false,
@@ -7571,6 +7725,7 @@
 				"backlog",
 				"sort",
 				"boardFilters",
+				"calendar",
 				"gantt",
 				"delete",
 				"archive",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -7263,6 +7263,9 @@
 						"moreTasks": {
 							"type": "string"
 						},
+						"loadError": {
+							"type": "string"
+						},
 						"dayTasksAriaLabel": {
 							"type": "string"
 						},
@@ -7279,6 +7282,7 @@
 						"noTasks",
 						"noTasksSubtitle",
 						"moreTasks",
+						"loadError",
 						"dayTasksAriaLabel",
 						"taskAriaLabel"
 					]

--- a/i18n/tr-TR.json
+++ b/i18n/tr-TR.json
@@ -1952,7 +1952,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/tr-TR.json
+++ b/i18n/tr-TR.json
@@ -1356,7 +1356,8 @@
 				"nextTask": "Sonraki talep",
 				"prevTask": "Önceki talep",
 				"openTask": "Seçili talebi aç",
-				"quickSelectNumber": "Numarayla seçenek seç"
+				"quickSelectNumber": "Numarayla seçenek seç",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1940,6 +1941,18 @@
 				"deleteRow": "Satırı sil",
 				"deleteTable": "Tabloyu sil"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/tr-TR.json
+++ b/i18n/tr-TR.json
@@ -1950,7 +1950,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/uk-UA.json
+++ b/i18n/uk-UA.json
@@ -1962,7 +1962,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/uk-UA.json
+++ b/i18n/uk-UA.json
@@ -1964,7 +1964,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/uk-UA.json
+++ b/i18n/uk-UA.json
@@ -1358,7 +1358,8 @@
 				"nextTask": "Наступне завдання",
 				"prevTask": "Попереднє завдання",
 				"openTask": "Відкрити обране завдання",
-				"quickSelectNumber": "Обрати варіант за номером"
+				"quickSelectNumber": "Обрати варіант за номером",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1952,6 +1953,18 @@
 				"deleteRow": "Видалити рядок",
 				"deleteTable": "Видалити таблицю"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/vi-VN.json
+++ b/i18n/vi-VN.json
@@ -1952,7 +1952,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/vi-VN.json
+++ b/i18n/vi-VN.json
@@ -1950,7 +1950,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/vi-VN.json
+++ b/i18n/vi-VN.json
@@ -1356,7 +1356,8 @@
 				"nextTask": "Công việc tiếp theo",
 				"prevTask": "Công việc trước đó",
 				"openTask": "Mở công việc đã chọn",
-				"quickSelectNumber": "Chọn tùy chọn theo số"
+				"quickSelectNumber": "Chọn tùy chọn theo số",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1940,6 +1941,18 @@
 				"deleteRow": "Xóa hàng",
 				"deleteTable": "Xóa bảng"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -1952,7 +1952,8 @@
 			"previousMonth": "Previous month",
 			"taskAriaLabel": "{{title}}: open task",
 			"title": "Calendar",
-			"today": "Today"
+			"today": "Today",
+			"loadError": "Failed to load tasks."
 		}
 	},
 	"invitations": {

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -1950,7 +1950,7 @@
 			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
 			"pageTitle": "{{name}} – Calendar",
 			"previousMonth": "Previous month",
-			"taskAriaLabel": "{{title}}: open task",
+			"taskAriaLabel": "{{title}}, {{range}}: open task",
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -1356,7 +1356,8 @@
 				"nextTask": "下一任务",
 				"prevTask": "上一任务",
 				"openTask": "打开所选任务",
-				"quickSelectNumber": "按数字选择选项"
+				"quickSelectNumber": "按数字选择选项",
+				"calendarView": "Switch to calendar view"
 			}
 		}
 	},
@@ -1940,6 +1941,18 @@
 				"deleteRow": "删除行",
 				"deleteTable": "删除表格"
 			}
+		},
+		"calendar": {
+			"dayTasksAriaLabel": "Show all tasks for {{date}}",
+			"moreTasks": "+{{count}} more",
+			"nextMonth": "Next month",
+			"noTasks": "No scheduled tasks",
+			"noTasksSubtitle": "Add a start date, due date, or both to tasks to place them on the calendar.",
+			"pageTitle": "{{name}} – Calendar",
+			"previousMonth": "Previous month",
+			"taskAriaLabel": "{{title}}: open task",
+			"title": "Calendar",
+			"today": "Today"
 		}
 	},
 	"invitations": {


### PR DESCRIPTION
## Description

Adds a per-project monthly calendar view alongside board, backlog and gantt.

Tasks appear as bars spanning their start–due range, reusing the gantt view's
date normalization and the same `["tasks", projectId]` query — so it shares
the cache and needs no API change. Bars crossing a week boundary are clipped
per week row, overlapping tasks are packed into lanes, and overflow beyond the
lane cap is reachable through a per-day popover listing that day's full task
list. Weekday and month labels go through Intl (`lib/format`) so they follow
the user's locale without new translation keys.

The PR is three commits:
- `feat(web)`: the calendar view + view switcher wiring
- `chore(i18n)`: seed the new keys into non-English locales (ko-KR left out,
  being translated by hand separately)
- `chore(i18n)`: regenerate `schema.json` — note this also pulls in settings
  keys that `384eb005` left out, so that diff is larger than the calendar
  change alone would suggest

Left for follow-ups: drag-to-reschedule, and the `parseISO` timezone behavior
that this shares with the existing gantt view (a task at UTC midnight shifts a
day in timezones behind UTC — unchanged from gantt, out of scope here).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

Unit tests cover the non-obvious logic: date normalization (start-only /
due-only / neither / reversed ranges), the month-grid model, week-boundary
clipping with `continuesBefore/After`, lane packing, overflow counts, and
`weekStartsOn` 0/1/6. Manually verified in the browser: bar placement across
all date cases, week-boundary spans, the overflow popover, task click opening
the details sheet, the view switcher + `v c` shortcut, and week-start changes.

## Screenshots (if applicable)

Calendar view with a task detail popover open (weekStartsOn = Monday):

<img width="1901" height="1097" alt="image" src="https://github.com/user-attachments/assets/a0d897cb-9a81-44cc-86d9-7ab8221f424b" />


The view switcher now includes Calendar between Tasks and Gantt:

<img width="1901" height="1096" alt="image" src="https://github.com/user-attachments/assets/0ae416ec-4bdf-493f-8b18-34670a1bc50c" />

<img width="1900" height="1093" alt="image" src="https://github.com/user-attachments/assets/45c7d1ca-8522-4b78-8406-a76985d28737" />


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

`ko-KR` is intentionally excluded from the locale seed commit and will be
translated by hand. The `schema.json` regeneration is unrelated to the
calendar feature itself but is required because adding en-US keys drifts the
generated schema; it was already stale from `384eb005`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a monthly calendar view for project tasks with scheduled task bars, date ranges, continuation indicators, and responsive layouts.
  - Added month navigation, a Today button, current-day highlighting, task opening, and loading or empty states.
  - Added overflow popovers for viewing all tasks on busy days.
  - Added calendar access through project navigation and the `C` keyboard shortcut.
- **Localization**
  - Added calendar labels, navigation text, accessibility messages, and empty states across supported locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->