### PR TITLE
fix(time-entry): compute duration and reject an inverted range on create

### DIFF
--- a/apps/api/src/time-entry/controllers/create-time-entry.ts
+++ b/apps/api/src/time-entry/controllers/create-time-entry.ts
@@ -11,15 +11,25 @@ async function createTimeEntry({
   description,
   startTime,
   endTime,
-  duration,
 }: {
   taskId: string;
   userId: string;
   description?: string;
   startTime: Date;
   endTime?: Date;
-  duration?: number;
 }) {
+  if (endTime && startTime.getTime() > endTime.getTime()) {
+    throw new HTTPException(400, {
+      message:
+        "Start time cannot be after end time. Please adjust the time range.",
+    });
+  }
+
+  let duration: number | null = null;
+  if (endTime) {
+    duration = Math.floor((endTime.getTime() - startTime.getTime()) / 1000); // duration in seconds
+  }
+
   const [createdTimeEntry] = await db
     .insert(timeEntryTable)
     .values({
@@ -29,7 +39,7 @@ async function createTimeEntry({
       description: description || "",
       startTime,
       endTime: endTime || null,
-      duration: duration || 0,
+      duration,
     })
     .returning();
 

--- a/tests/api/time-entry/create-time-entry.test.ts
+++ b/tests/api/time-entry/create-time-entry.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+const mockInsert = vi.fn();
+const mockSelect = vi.fn();
+const mockPublishEvent = vi.fn();
+
+vi.mock("../../../apps/api/src/database", () => ({
+  default: {
+    insert: (...args: unknown[]) => mockInsert(...args),
+    select: (...args: unknown[]) => mockSelect(...args),
+  },
+}));
+
+vi.mock("../../../apps/api/src/events", () => ({
+  publishEvent: (...args: unknown[]) => mockPublishEvent(...args),
+}));
+
+import createTimeEntry from "../../../apps/api/src/time-entry/controllers/create-time-entry";
+
+function makeInsertMock(createdRow: unknown) {
+  const returning = vi.fn(() => Promise.resolve([createdRow]));
+  const values = vi.fn(() => ({ returning }));
+  return { values, returning };
+}
+
+function makeSelectMock(rows: unknown[]) {
+  const chain: Record<string, Mock> = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => Promise.resolve(rows)),
+  };
+  return chain;
+}
+
+describe("createTimeEntry", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("stores the duration in seconds when an endTime is supplied", async () => {
+    const startTime = new Date("2026-08-10T10:00:00.000Z");
+    const endTime = new Date("2026-08-10T11:00:00.000Z");
+    const insertChain = makeInsertMock({
+      id: "time-entry-1",
+      taskId: "task-1",
+      startTime,
+      endTime,
+      duration: 3600,
+    });
+
+    mockInsert.mockReturnValue(insertChain);
+    mockSelect.mockReturnValue(
+      makeSelectMock([{ userId: "task-owner", title: "Ship the thing" }]),
+    );
+
+    await createTimeEntry({
+      taskId: "task-1",
+      userId: "user-1",
+      startTime,
+      endTime,
+    });
+
+    expect(insertChain.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startTime,
+        endTime,
+        duration: 3600,
+      }),
+    );
+  });
+
+  it("leaves the duration null for an entry that is still running", async () => {
+    const startTime = new Date("2026-08-10T10:00:00.000Z");
+    const insertChain = makeInsertMock({
+      id: "time-entry-1",
+      taskId: "task-1",
+      startTime,
+      endTime: null,
+      duration: null,
+    });
+
+    mockInsert.mockReturnValue(insertChain);
+    mockSelect.mockReturnValue(
+      makeSelectMock([{ userId: "task-owner", title: "Ship the thing" }]),
+    );
+
+    await createTimeEntry({
+      taskId: "task-1",
+      userId: "user-1",
+      startTime,
+    });
+
+    expect(insertChain.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startTime,
+        endTime: null,
+        duration: null,
+      }),
+    );
+  });
+
+  it("rejects a startTime later than the endTime", async () => {
+    const insertChain = makeInsertMock({});
+
+    mockInsert.mockReturnValue(insertChain);
+
+    await expect(
+      createTimeEntry({
+        taskId: "task-1",
+        userId: "user-1",
+        startTime: new Date("2026-08-10T12:00:00.000Z"),
+        endTime: new Date("2026-08-10T11:00:00.000Z"),
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message:
+        "Start time cannot be after end time. Please adjust the time range.",
+    });
+
+    expect(insertChain.values).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

`createTimeEntry` always stored `duration: 0`, even for an entry created complete with an explicit `endTime`.

The controller accepted a `duration` parameter, but nothing ever passed one — the `POST /time-entry` route does not forward it, and the route's Valibot validator does not accept the field at all. `duration` was therefore always `undefined`, so `duration: duration || 0` stored `0` unconditionally. The controller also never checked that `endTime` is after `startTime`, so an inverted range was silently accepted.

Repro: `POST /api/time-entry` with `startTime` `2026-08-10T10:00:00Z` and `endTime` `2026-08-10T11:00:00Z` stores `duration: 0` instead of `3600`. The MCP `create_time_entry` tool goes through the same route, so an entry logged through it reports `0` too, despite the tool documenting "Omit endTime to leave the entry running".

This removes the vestigial parameter, derives the duration from the two timestamps, and adds the inverted-range guard — mirroring `updateTimeEntry`, which was hardened the same way in #1554. The guard reuses that controller's exact 400 message, so both paths respond identically.

### Behaviour change for running entries

An entry created without an `endTime` now stores `duration: null` rather than `0`. That matches `updateTimeEntry`, the nullable column (`integer("duration").default(0)` — no `.notNull()`), and `timeEntrySchema` (`v.nullable(v.number())`). `null` is also the more accurate value: `0` asserts that no time elapsed, `null` says the duration is not known yet.

I checked every consumer of the field before making this change:

- **`apps/web`** — the only reference is the `TimeEntry` type, which is already `duration: number | null`. No component reads the field: the time-entry fetchers and hooks are not imported by any UI yet, and nothing sums or formats the value. (`apps/web/src/lib/format-duration.ts` takes a `number`, but it is not imported anywhere.)
- **`packages/mcp`** — `create_time_entry` sends only `taskId`/`startTime`/`endTime`/`description` and returns the API response verbatim.
- **`apps/api`** — `get-time-entries.ts` selects the column as-is.
- **`tests/api-integration/account-deletion.test.ts`** — inserts a duration straight through the DB, so it does not exercise this path.

No consumer needs a null-safe read, so nothing outside the controller changed.

## Related Issue(s)

No filed issue — found while reading the time-entry controllers alongside #1554.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

New `tests/api/time-entry/create-time-entry.test.ts`, following the mocking conventions in the sibling `update-time-entry.test.ts`:

1. stores `3600` for a 10:00 → 11:00 entry
2. leaves `duration` as `null` for an entry with no `endTime`
3. rejects a `startTime` later than the `endTime` with a 400 and the shared message, without inserting

All three fail against the current code and pass with the fix.

Full local run on the branch:

- `pnpm exec biome ci .` — exit 0 (78 warnings, 2 infos, unchanged from `main`)
- `pnpm typecheck` — 6/6 tasks
- `pnpm test` — API 358 tests / 53 files, web 91 tests / 30 files
- `pnpm build` — 7/7 tasks
- `pnpm test:integration` — 181 tests / 29 files, against Postgres 16

## Screenshots (if applicable)

N/A — API-only change.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

`apps/docs/openapi.json` does not need regenerating. The request shape is unchanged — the removed `duration` parameter was internal and never part of the validator — and the documented response already describes `duration` as `{"type": "number", "nullable": true}`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Time entries now calculate duration automatically from their start and end times.
  * Ongoing entries retain an unset duration until they are completed.
  * Invalid entries with an end time before the start time are rejected.
  * Duration values are preserved correctly when creating time entries.

* **Tests**
  * Added coverage for duration calculation, ongoing entries, and invalid time ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->