### PR TITLE
fix(github): ignore non-branch refs on push webhooks

### DIFF
--- a/apps/api/src/plugins/github/webhooks/push.ts
+++ b/apps/api/src/plugins/github/webhooks/push.ts
@@ -36,7 +36,12 @@ const PROTECTED_BRANCHES = [
 export async function handlePush(payload: PushPayload) {
   const { ref, repository, head_commit } = payload;
 
-  const branchName = ref.replace("refs/heads/", "");
+  if (!ref.startsWith("refs/heads/")) {
+    console.log(`[Push] Skipping non-branch ref: ${ref}`);
+    return;
+  }
+
+  const branchName = ref.slice("refs/heads/".length);
   console.log(`[Push] Processing branch: ${branchName}`);
 
   if (PROTECTED_BRANCHES.includes(branchName)) {

--- a/tests/api/plugins/github/webhooks/push.test.ts
+++ b/tests/api/plugins/github/webhooks/push.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFindAllIntegrationsByRepo = vi.fn();
+const mockFindTaskByNumber = vi.fn();
+const mockIsTaskInFinalState = vi.fn();
+const mockUpdateTaskStatus = vi.fn();
+const mockCreateOrUpdateExternalLink = vi.fn();
+const mockResolveTargetStatus = vi.fn();
+const mockPublishEvent = vi.fn();
+
+vi.mock(
+  "../../../../../apps/api/src/plugins/github/services/task-service",
+  () => ({
+    findAllIntegrationsByRepo: (...args: unknown[]) =>
+      mockFindAllIntegrationsByRepo(...args),
+    findTaskByNumber: (...args: unknown[]) => mockFindTaskByNumber(...args),
+    isTaskInFinalState: (...args: unknown[]) => mockIsTaskInFinalState(...args),
+    updateTaskStatus: (...args: unknown[]) => mockUpdateTaskStatus(...args),
+  }),
+);
+
+vi.mock(
+  "../../../../../apps/api/src/plugins/github/services/link-manager",
+  () => ({
+    createOrUpdateExternalLink: (...args: unknown[]) =>
+      mockCreateOrUpdateExternalLink(...args),
+  }),
+);
+
+vi.mock(
+  "../../../../../apps/api/src/plugins/github/utils/resolve-column",
+  () => ({
+    resolveTargetStatus: (...args: unknown[]) =>
+      mockResolveTargetStatus(...args),
+  }),
+);
+
+vi.mock("../../../../../apps/api/src/events", () => ({
+  publishEvent: (...args: unknown[]) => mockPublishEvent(...args),
+}));
+
+import { handlePush } from "../../../../../apps/api/src/plugins/github/webhooks/push";
+
+const repository = {
+  owner: { login: "usekaneo" },
+  name: "kaneo",
+  html_url: "https://github.com/usekaneo/kaneo",
+};
+
+const head_commit = {
+  id: "abc123",
+  message: "chore: release",
+  author: { name: "Jane" },
+  timestamp: "2024-01-01T00:00:00Z",
+};
+
+function makeIntegration(config: Record<string, unknown> = {}) {
+  return {
+    id: "integration-1",
+    projectId: "project-1",
+    project: { slug: "KAN" },
+    config: JSON.stringify({
+      repositoryOwner: "usekaneo",
+      repositoryName: "kaneo",
+      installationId: 1,
+      branchPattern: "{slug}-{number}",
+      ...config,
+    }),
+  };
+}
+
+const task = {
+  id: "task-1",
+  projectId: "project-1",
+  number: 42,
+  status: "to-do",
+  columnId: null,
+  title: "Ship it",
+  userId: "user-1",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "log").mockImplementation(() => {});
+
+  mockFindAllIntegrationsByRepo.mockResolvedValue([makeIntegration()]);
+  mockFindTaskByNumber.mockResolvedValue(task);
+  mockIsTaskInFinalState.mockResolvedValue(false);
+  mockResolveTargetStatus.mockResolvedValue("in-progress");
+  mockUpdateTaskStatus.mockResolvedValue({
+    applied: true,
+    before: task,
+    after: { ...task, status: "in-progress" },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("handlePush ref filtering", () => {
+  const nonBranchRefs = [
+    "refs/tags/v1.0",
+    "refs/tags/v2.3.4",
+    "refs/pull/12/merge",
+    "refs/notes/commits",
+  ];
+
+  for (const ref of nonBranchRefs) {
+    it(`returns early for the non-branch ref ${ref}`, async () => {
+      await handlePush({ ref, repository, head_commit });
+
+      expect(mockFindAllIntegrationsByRepo).not.toHaveBeenCalled();
+      expect(mockFindTaskByNumber).not.toHaveBeenCalled();
+      expect(mockCreateOrUpdateExternalLink).not.toHaveBeenCalled();
+      expect(mockUpdateTaskStatus).not.toHaveBeenCalled();
+    });
+  }
+
+  it("leaves a task untouched when a tag matches an unanchored custom regex", async () => {
+    mockFindAllIntegrationsByRepo.mockResolvedValue([
+      makeIntegration({ customBranchRegex: "kan-(\\d+)" }),
+    ]);
+
+    await handlePush({ ref: "refs/tags/kan-42", repository, head_commit });
+
+    expect(mockUpdateTaskStatus).not.toHaveBeenCalled();
+    expect(mockPublishEvent).not.toHaveBeenCalled();
+    expect(mockFindAllIntegrationsByRepo).not.toHaveBeenCalled();
+  });
+});
+
+describe("handlePush branch handling", () => {
+  it("looks up integrations for a branch push", async () => {
+    await handlePush({
+      ref: "refs/heads/feature-x",
+      repository,
+      head_commit,
+    });
+
+    expect(mockFindAllIntegrationsByRepo).toHaveBeenCalledWith(
+      "usekaneo",
+      "kaneo",
+    );
+  });
+
+  it("strips the ref prefix before matching and linking a task", async () => {
+    await handlePush({ ref: "refs/heads/kan-42", repository, head_commit });
+
+    expect(mockFindTaskByNumber).toHaveBeenCalledWith("project-1", 42);
+    expect(mockCreateOrUpdateExternalLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: "task-1",
+        externalId: "kan-42",
+        title: "kan-42",
+        url: "https://github.com/usekaneo/kaneo/tree/kan-42",
+      }),
+    );
+    expect(mockUpdateTaskStatus).toHaveBeenCalledWith("task-1", "in-progress");
+  });
+
+  it("skips a protected branch", async () => {
+    await handlePush({ ref: "refs/heads/main", repository, head_commit });
+
+    expect(mockFindAllIntegrationsByRepo).not.toHaveBeenCalled();
+    expect(mockUpdateTaskStatus).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

`handlePush` derived the branch name with `ref.replace("refs/heads/", "")`. `String.replace` is a no-op when the needle is absent, so a non-branch ref fell through with `branchName` set to the entire ref.

The handler is registered for the `push` event, and GitHub delivers `push` for tag creation and deletion as well. Nothing upstream (`handleGithubWebhookRoute` → `handleGitHubWebhook` → `verifyAndReceive` → the registered `push` handler) filters the ref, so tag pushes reached the same code path as branch pushes.

Repro: push a tag `v1.0` to a repository with a Kaneo GitHub integration. The webhook arrives with `ref: "refs/tags/v1.0"`; `branchName` becomes the literal string `refs/tags/v1.0`, it is not in `PROTECTED_BRANCHES`, and Kaneo runs the integration lookup and branch matching against that string on every tag push.

Usually this only wastes an integration query, because the default pattern compiles to an anchored regex that `refs/tags/...` cannot match. With a `customBranchRegex`, which is applied unanchored, it is a real state change: a tag `refs/tags/kan-42` matches `kan-(\d+)`, and the task is linked and moved to `in-progress` by a release tag.

This adds the `refs/heads/` guard before stripping and switches `replace` to `slice`, which is exactly what the Gitea push handler already does (`apps/api/src/plugins/gitea/webhooks/push.ts`), so the two providers now read identically. It is the same shape of fix as #1522.

Scope note: GitHub was the only affected handler. Gitea already guards. The pull request handlers read `pull_request.head.ref`, which is a bare branch name with no prefix to strip, and there are no other inbound source-control providers (`generic-webhook` is outbound only).

## Related Issue(s)
<!-- Link to the related issue(s) this PR addresses -->
No filed issue; found while reading the two push handlers side by side.

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

Adds `tests/api/plugins/github/webhooks/push.test.ts` (8 cases), mocking the task service, link manager, column resolver and event bus, and exercising the real branch matcher:

- returns early for `refs/tags/v1.0`, `refs/tags/v2.3.4`, `refs/pull/12/merge` and `refs/notes/commits`, asserting the integration lookup is never reached
- leaves the task untouched when a tag matches an unanchored `customBranchRegex`
- still looks up integrations for `refs/heads/feature-x`
- still strips the prefix so `refs/heads/kan-42` links `kan-42` and updates the task status
- still skips a protected branch

Reverting the source change fails 5 of the 8 cases; the custom-regex case fails with `updateTaskStatus` called as `("task-1", "in-progress")`, which is the task-mutating behaviour described above. The remaining 3 pass either way and are there to guard the branch path against regression.

Full suite on this branch: `biome ci .` clean (78 warnings, 2 infos, 0 errors, unchanged from `main`), `pnpm typecheck` 6/6, `pnpm test` API 363 tests across 53 files and web 91 across 30, `pnpm build` 7/7.

## Screenshots (if applicable)

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The log prefix uses this file's existing `[Push]` style rather than Gitea's `[Gitea Push]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub push webhook handling by ignoring tags and other non-branch references.
  * Correctly extracts branch names from valid branch references.
  * Prevents updates for protected branches.

* **Tests**
  * Added comprehensive coverage for branch pushes, tags, pull references, notes, custom tag patterns, task lookups, links, and status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->