### PR TITLE
fix(api): attribute created activity to the authenticated user

### DIFF
--- a/apps/api/src/activity/index.ts
+++ b/apps/api/src/activity/index.ts
@@ -58,7 +58,6 @@ const activity = new Hono<{
       "json",
       v.object({
         taskId: v.string(),
-        userId: v.string(),
         message: v.nullable(v.string()),
         type: v.string(),
         eventData: v.optional(v.nullable(v.record(v.string(), v.unknown()))),
@@ -67,7 +66,8 @@ const activity = new Hono<{
     workspaceAccess.fromTaskId(),
     requireWorkspacePermission({ task: ["update"] }),
     async (c) => {
-      const { taskId, userId, message, type, eventData } = c.req.valid("json");
+      const { taskId, message, type, eventData } = c.req.valid("json");
+      const userId = c.get("userId");
       const activity = await createActivity(
         taskId,
         type,

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -3123,9 +3123,6 @@
                   "taskId": {
                     "type": "string"
                   },
-                  "userId": {
-                    "type": "string"
-                  },
                   "message": {
                     "type": "string",
                     "nullable": true
@@ -3141,7 +3138,6 @@
                 },
                 "required": [
                   "taskId",
-                  "userId",
                   "message",
                   "type"
                 ]

--- a/tests/api-integration/activity.test.ts
+++ b/tests/api-integration/activity.test.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import db, { schema } from "../../apps/api/src/database";
+import { createApp } from "../../apps/api/src/index";
+import { mockAuthenticatedSession } from "./helpers/auth";
+import { resetTestDatabase } from "./helpers/database";
+import {
+  createProjectFixture,
+  createWorkspaceMember,
+} from "./helpers/fixtures";
+
+async function addWorkspaceMember(workspaceId: string) {
+  const userId = `user-${randomUUID()}`;
+
+  const [user] = await db
+    .insert(schema.userTable)
+    .values({
+      id: userId,
+      email: `${userId}@example.com`,
+      emailVerified: true,
+      name: "Other Member",
+    })
+    .returning();
+
+  await db.insert(schema.workspaceUserTable).values({
+    workspaceId,
+    userId: user.id,
+    role: "member",
+    joinedAt: new Date(),
+  });
+
+  return user;
+}
+
+async function createTaskFixture() {
+  const member = await createWorkspaceMember();
+  const { project, columns } = await createProjectFixture({
+    workspaceId: member.workspace.id,
+  });
+  const [task] = await db
+    .insert(schema.taskTable)
+    .values({
+      projectId: project.id,
+      title: "Activity attribution",
+      status: "to-do",
+      columnId: columns.todo.id,
+      priority: "medium",
+      number: 1,
+      position: 1,
+    })
+    .returning();
+
+  return { member, task };
+}
+
+describe("API integration: activity authorship", () => {
+  beforeEach(async () => {
+    await resetTestDatabase();
+  });
+
+  it("attributes a created activity to the caller, not to a userId in the body", async () => {
+    const { member, task } = await createTaskFixture();
+    const colleague = await addWorkspaceMember(member.workspace.id);
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request("/api/activity/create", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        taskId: task.id,
+        userId: colleague.id,
+        message: "Attributed to a colleague",
+        type: "status_changed",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const activities = await db
+      .select()
+      .from(schema.activityTable)
+      .where(eq(schema.activityTable.taskId, task.id));
+
+    expect(activities).toHaveLength(1);
+    expect(activities[0]?.userId).toBe(member.user.id);
+  });
+
+  it("attributes a created activity to the caller", async () => {
+    const { member, task } = await createTaskFixture();
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request("/api/activity/create", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        taskId: task.id,
+        message: "Attributed to the caller",
+        type: "status_changed",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      taskId: task.id,
+      userId: member.user.id,
+      content: "Attributed to the caller",
+      type: "status_changed",
+    });
+  });
+});


### PR DESCRIPTION
## Description

`POST /api/activity/create` read the activity author's `userId` from the request body and passed it straight to `createActivity()`, which inserts it verbatim.

`workspaceAccess.fromTaskId()` and `requireWorkspacePermission({ task: ["update"] })` authorize the *caller*; neither validates the `userId` in the body. The result is an attribution / data-integrity bug: a workspace member who already has task-update permission can create activity rows attributed to a different member of the same workspace, and the misattributed row then renders in the task's activity feed. It is not a cross-tenant or privilege-escalation issue — the caller must already be an authorized member of that workspace, and no additional access is gained.

The sibling `POST /api/activity/comment` route, directly below it in the same file, already does this correctly:

```ts
const { taskId, comment } = c.req.valid("json");
const userId = c.get("userId");
```

This PR aligns the create route with that pattern: `userId` is dropped from the Valibot request schema and read from the session instead.

## Related Issue(s)

No filed issue — found while reading the activity routes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

I did not tick "Breaking change", reasoning below — say the word if you disagree and I will re-tick it.

- No request that previously succeeded now fails. `v.object()` ignores unknown keys, so a client that still sends `userId` gets a `200` and the field is simply ignored. The first new test does exactly this and asserts `200`.
- `userId` went from required to absent, which relaxes the request contract rather than tightening it.
- The one intentional behaviour change is the attribution itself, which is the fix.
- Type-level caveat: `packages/libs` re-exports `hc<AppType>`, so a TypeScript caller passing `userId` to `client.activity.create.$post` would now get an excess-property error. `@kaneo/libs` is a workspace-internal package (`version 0.0.0`, `main` pointing at `src/index.ts`) consumed only by `apps/web`, and nothing in the repo calls this route, so nothing breaks here. Flagging it in case you treat the inferred client as a public surface.

## How Has This Been Tested?

- [ ] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

New `tests/api-integration/activity.test.ts` with two cases:

1. Posting with another member's `userId` in the body persists a row attributed to the authenticated caller.
2. A normal create is attributed to the caller.

Both were confirmed to fail before the source change (case 1 stored the colleague's id; case 2 returned `400` because `userId` was required) and pass after it.

Full local run: `pnpm exec biome ci .` (exit 0, unchanged 78 warnings / 2 infos), `pnpm typecheck` (6/6), `pnpm test` (API 355/52 files, web 91/30), `pnpm build` (7/7), `pnpm test:integration` (183 tests / 30 files, against `postgres:16`).

## Screenshots (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

**Alternative worth considering.** Instead of removing the field, the route could keep accepting `userId` and reject a mismatch with the session user via a `403`. I implemented the removal because the comment route immediately below is the strongest precedent in this file, and because there is no caller to stay compatible with. If you would rather keep the field and reject mismatches, I am happy to switch.

**Callers.** Nothing in the repo calls `POST /api/activity/create`, so no frontend or MCP change was needed:

- `apps/web/src/fetchers/activity/create-activity.ts` is named `createActivity` but actually posts to `/activity/comment`.
- `packages/mcp` only reads the route's sibling, `GET /api/activity/{taskId}` (`list_task_activity`).

The endpoint is reachable by external API clients, which is why the request-shape change is still documented below.

**OpenAPI.** `apps/docs/openapi.json` is updated for this route only (4 deleted lines: the `userId` property and its `required` entry). I deliberately did not commit a full `pnpm -F @kaneo/api openapi:export`, because the checked-in spec has pre-existing drift — regenerating it on an unmodified `main` produces a **1,469 insertion / 166 deletion** diff, adding around nine routes that exist in the API but not in the spec (`/billing/{workspaceId}` plus its `checkout` and `portal`, `/mcp/authorize`, `/mcp/authorize/request/{requestId}`, `/mcp/register`, `/project/reorder`, `/user/avatar`, `/user/avatar/{id}`) along with some reordering. That churn would bury a four-line fix.

To be certain the hand edit is exactly what the generator produces, I regenerated the spec both before and after the source change and diffed the two: the only difference is the four lines in this PR, and the resulting `/activity/create` path object is identical to the regenerated one. Re-syncing the rest of the spec looks like a separate chore — glad to open a follow-up PR for it if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Activity records are now automatically attributed to the authenticated user.
  - Activity creation requests no longer require or accept a `userId` field; only task, message, and type are needed.

- **Bug Fixes**
  - Prevented request payloads from assigning activities to a different user.

- **Tests**
  - Added integration coverage for authenticated activity authorship and response details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->