### PR TITLE
fix: GitHub-imported tasks without priority label get priority=null and can never be edited

### DIFF
--- a/apps/api/src/github-integration/controllers/import-issues.ts
+++ b/apps/api/src/github-integration/controllers/import-issues.ts
@@ -244,7 +244,7 @@ async function importSingleIssue(
     title: issue.title,
     description: formatTaskDescriptionFromIssue(issue.body),
     status: status || "to-do",
-    priority: priority || null,
+    priority: priority ?? "low",
     number: nextTaskNumber,
   };
 

--- a/apps/api/src/plugins/github/webhooks/issue-opened.ts
+++ b/apps/api/src/plugins/github/webhooks/issue-opened.ts
@@ -99,11 +99,9 @@ export async function handleIssueOpened(payload: IssueOpenedPayload) {
       description: formatTaskDescriptionFromIssue(issue.body),
       status: targetStatus,
       columnId: targetColumn?.id ?? null,
-      priority: null,
+      priority: priority ?? "low",
       number: nextTaskNumber,
     };
-
-    if (priority) taskValues.priority = priority;
 
     const [createdTask] = await db
       .insert(taskTable)

--- a/tests/api/plugins/github/webhooks/issue-opened.test.ts
+++ b/tests/api/plugins/github/webhooks/issue-opened.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleIssueOpened } from "../../../../../apps/api/src/plugins/github/webhooks/issue-opened";
+
+const mocks = vi.hoisted(() => {
+  const mockGetGithubApp = vi.fn();
+  const mockFindAllIntegrationsByRepo = vi.fn();
+  const mockFindExternalLink = vi.fn();
+  const mockCreateExternalLink = vi.fn();
+  const mockClaimTaskNumber = vi.fn();
+  const mockResolveTargetStatus = vi.fn();
+  const mockAddLabelsToIssue = vi.fn();
+  const mockCreateComment = vi.fn();
+  const mockGetInstallationOctokit = vi.fn();
+  const mockColumnFindFirst = vi.fn();
+  const mockProjectFindFirst = vi.fn();
+
+  const insertedValues: Array<Record<string, unknown>> = [];
+
+  const mockDb = {
+    insert: () => ({
+      values: (values: Record<string, unknown>) => {
+        insertedValues.push(values);
+        return {
+          returning: async () => [{ id: "task-1" }],
+        };
+      },
+    }),
+    query: {
+      columnTable: { findFirst: mockColumnFindFirst },
+      projectTable: { findFirst: mockProjectFindFirst },
+    },
+  };
+
+  const mockOctokit = {
+    rest: {
+      issues: {
+        createComment: mockCreateComment,
+      },
+    },
+  };
+
+  const mockGithubApp = {
+    getInstallationOctokit: mockGetInstallationOctokit,
+  };
+
+  return {
+    mockGetGithubApp,
+    mockFindAllIntegrationsByRepo,
+    mockFindExternalLink,
+    mockCreateExternalLink,
+    mockClaimTaskNumber,
+    mockResolveTargetStatus,
+    mockAddLabelsToIssue,
+    mockCreateComment,
+    mockGetInstallationOctokit,
+    mockColumnFindFirst,
+    mockProjectFindFirst,
+    mockDb,
+    insertedValues,
+    mockOctokit,
+    mockGithubApp,
+  };
+});
+
+vi.mock("../../../../../apps/api/src/database", () => ({
+  default: mocks.mockDb,
+}));
+
+vi.mock("../../../../../apps/api/src/plugins/github/utils/github-app", () => ({
+  getGithubApp: () => mocks.mockGetGithubApp(),
+}));
+
+vi.mock(
+  "../../../../../apps/api/src/plugins/github/services/task-service",
+  () => ({
+    findAllIntegrationsByRepo: (...args: unknown[]) =>
+      mocks.mockFindAllIntegrationsByRepo(...args),
+  }),
+);
+
+vi.mock(
+  "../../../../../apps/api/src/plugins/github/services/link-manager",
+  () => ({
+    createExternalLink: (...args: unknown[]) =>
+      mocks.mockCreateExternalLink(...args),
+    findExternalLink: (...args: unknown[]) =>
+      mocks.mockFindExternalLink(...args),
+  }),
+);
+
+vi.mock(
+  "../../../../../apps/api/src/task/controllers/claim-task-numbers",
+  () => ({
+    claimTaskNumber: (...args: unknown[]) => mocks.mockClaimTaskNumber(...args),
+  }),
+);
+
+vi.mock(
+  "../../../../../apps/api/src/plugins/github/utils/resolve-column",
+  () => ({
+    resolveTargetStatus: (...args: unknown[]) =>
+      mocks.mockResolveTargetStatus(...args),
+  }),
+);
+
+vi.mock("../../../../../apps/api/src/plugins/github/utils/labels", () => ({
+  addLabelsToIssue: (...args: unknown[]) => mocks.mockAddLabelsToIssue(...args),
+}));
+
+const integration = {
+  id: "integration-1",
+  projectId: "project-1",
+  isActive: true,
+  type: "github",
+  config: JSON.stringify({
+    repositoryOwner: "usekaneo",
+    repositoryName: "kaneo",
+    installationId: 123,
+    commentTaskLinkOnGitHubIssue: true,
+    branchPattern: "{slug}-{number}",
+    statusTransitions: {
+      onBranchPush: "in-progress",
+      onPROpen: "in-review",
+      onPRMerge: "done",
+    },
+  }),
+  project: null,
+};
+
+function issueOpenedPayload(labels: Array<string | { name?: string }>) {
+  return {
+    action: "opened",
+    issue: {
+      number: 42,
+      title: "Fix the login bug",
+      body: "Steps to reproduce",
+      html_url: "https://github.com/usekaneo/kaneo/issues/42",
+      labels,
+      user: { login: "octocat" },
+    },
+    repository: {
+      owner: { login: "usekaneo" },
+      name: "kaneo",
+      full_name: "usekaneo/kaneo",
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.insertedValues.length = 0;
+  delete process.env.GITHUB_APP_NAME;
+  mocks.mockGetGithubApp.mockReturnValue(mocks.mockGithubApp);
+  mocks.mockFindAllIntegrationsByRepo.mockResolvedValue([integration]);
+  mocks.mockFindExternalLink.mockResolvedValue(null);
+  mocks.mockClaimTaskNumber.mockResolvedValue(7);
+  mocks.mockResolveTargetStatus.mockResolvedValue("to-do");
+  mocks.mockColumnFindFirst.mockResolvedValue(null);
+  mocks.mockProjectFindFirst.mockResolvedValue({
+    id: "project-1",
+    workspaceId: "workspace-1",
+    slug: "kaneo",
+  });
+  mocks.mockGetInstallationOctokit.mockResolvedValue(mocks.mockOctokit);
+  mocks.mockCreateExternalLink.mockResolvedValue({ id: "link-1" });
+  mocks.mockAddLabelsToIssue.mockResolvedValue(undefined);
+  mocks.mockCreateComment.mockResolvedValue({});
+});
+
+describe("handleIssueOpened", () => {
+  it("persists a valid default priority when the issue has no priority: label", async () => {
+    await handleIssueOpened(issueOpenedPayload(["type:bug"]));
+
+    expect(mocks.insertedValues).toHaveLength(1);
+    const priority = mocks.insertedValues[0].priority;
+    expect(priority).not.toBeNull();
+    expect(priority).toBe("low");
+  });
+
+  it("persists the extracted priority label when present", async () => {
+    await handleIssueOpened(issueOpenedPayload(["type:bug", "priority:high"]));
+
+    expect(mocks.insertedValues).toHaveLength(1);
+    expect(mocks.insertedValues[0].priority).toBe("high");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1582 — tasks imported from GitHub issues **without** a `priority:` label are created with `priority = null` in the database (overriding the schema default `"low"`). The task update endpoint validates priority against a picklist (`no-priority | low | medium | high | urgent`), so any edit of such a task fails with HTTP 400 (Valibot `picklist` issue) — GitHub-imported tasks without a priority label can never be edited.

## Root cause

- `apps/api/src/plugins/github/webhooks/issue-opened.ts`: `extractIssuePriority(issue.labels)` returns `null` when no `priority:*` label exists; the handler explicitly wrote `priority: null` and only overrode it when a label was present.
- `apps/api/src/github-integration/controllers/import-issues.ts`: same pattern (`priority: priority || null`) when bulk-importing existing GitHub issues.
- The update endpoint (`apps/api/src/task/index.ts`, `PUT /task/:id`) requires `priority` to be a picklist value, and the web frontend sends the entire task object on every edit (`use-update-task.ts`), so the `null` priority blocks any field edit.

## Changes

1. **`apps/api/src/plugins/github/webhooks/issue-opened.ts`** — default the created task's priority to `"low"` when the issue has no priority label (`priority: priority ?? "low"`), dropping the now-redundant conditional override.
2. **`apps/api/src/github-integration/controllers/import-issues.ts`** — same fix for the GitHub issue import flow (`priority: priority ?? "low"`).
3. **`tests/api/plugins/github/webhooks/issue-opened.test.ts`** — new unit test driving the `issues.opened` webhook handler; asserts the created task's priority is `"low"` (not `null`) when the issue has no `priority:` label, and that an explicit `priority:high` label is preserved.

## Verification

- Repo test (`test: add repro...`) fails on the old code with `AssertionError: expected null not to be null`.
- After the fix, the full API unit suite passes: 53 files / 357 tests.
- `pnpm run build` and `pnpm --filter @kaneo/api typecheck` pass.

## Out of scope

The Gitea plugin (`apps/api/src/plugins/gitea/webhooks/issue-opened.ts`, `apps/api/src/gitea-integration/controllers/import-gitea-issues.ts`) has the same `priority: null` pattern; it is intentionally not touched here to keep this PR focused on the GitHub integration (can follow up separately).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub-imported issues now receive a default **Low** priority when no priority label is provided.
  * Newly created tasks apply the extracted priority immediately, including explicitly selected priorities.

* **Tests**
  * Added coverage for default and explicitly assigned issue priorities during GitHub issue creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->