### PR TITLE
fix(web): make pending task description updates reliable across task switches

### DIFF
--- a/apps/web/src/components/task/task-description.tsx
+++ b/apps/web/src/components/task/task-description.tsx
@@ -77,6 +77,7 @@ import { isInCodeBlockLanguagePicker } from "@/lib/is-in-codeblock-language-pick
 import { getSharedShikiHighlighter } from "@/lib/shiki-highlighter";
 import { toast } from "@/lib/toast";
 import { uploadTaskImage } from "@/lib/upload-task-image";
+import type Task from "@/types/task";
 import { AttachmentCard } from "./extensions/attachment-card";
 import { EmbedBlock } from "./extensions/embed-block";
 import { KaneoIssueLink } from "./extensions/kaneo-issue-link";
@@ -576,22 +577,26 @@ export default function TaskDescription({ taskId }: TaskDescriptionProps) {
   }, []);
 
   const debouncedUpdate = useCallback(
-    debounce(async (markdown: string) => {
-      if (!canEditRef.current) return;
+    debounce(
+      async (
+        markdown: string,
+        taskId: string | undefined,
+        currentTask: Task | undefined,
+      ) => {
+        const updateTaskFn = updateTaskRef.current;
+        if (!taskId || !currentTask || !updateTaskFn) return;
 
-      const currentTask = taskRef.current;
-      const updateTaskFn = updateTaskRef.current;
-      if (!currentTask || !updateTaskFn) return;
-
-      try {
-        await updateTaskFn({
-          ...currentTask,
-          description: markdown,
-        });
-      } catch (error) {
-        console.error("Failed to update description:", error);
-      }
-    }, 700),
+        try {
+          await updateTaskFn({
+            ...currentTask,
+            description: markdown,
+          });
+        } catch (error) {
+          console.error("Failed to update description:", error);
+        }
+      },
+      700,
+    ),
     [],
   );
 
@@ -806,7 +811,7 @@ export default function TaskDescription({ taskId }: TaskDescriptionProps) {
         const markdown = formatMarkdown(activeEditor.getMarkdown());
         if (markdown === latestSyncedMarkdownRef.current) return;
         latestSyncedMarkdownRef.current = markdown;
-        debouncedUpdate(markdown);
+        debouncedUpdate(markdown, taskIdRef.current, taskRef.current);
       },
     },
     [getOverlayPosition, handleAssetFileUpload, t, toShikiLanguage],

--- a/apps/web/src/components/task/task-description.tsx
+++ b/apps/web/src/components/task/task-description.tsx
@@ -595,9 +595,11 @@ export default function TaskDescription({ taskId }: TaskDescriptionProps) {
         void (async () => {
           const updateTaskFn = updateTaskRef.current;
           if (!updateTaskFn) return;
+          const latest = taskRef.current;
+          const base = latest?.id === taskId ? latest : currentTask;
           try {
             await updateTaskFn({
-              ...currentTask,
+              ...base,
               description: markdown,
             });
           } catch (error) {

--- a/apps/web/src/components/task/task-description.tsx
+++ b/apps/web/src/components/task/task-description.tsx
@@ -65,7 +65,6 @@ import { useUpdateTaskDescription } from "@/hooks/mutations/task/use-update-task
 import useGetTask from "@/hooks/queries/task/use-get-task";
 import { useWorkspacePermission } from "@/hooks/use-workspace-permission";
 import { cn } from "@/lib/cn";
-import debounce from "@/lib/debounce";
 import { parseTaskListMarkdownToNodes } from "@/lib/editor-task-list-paste";
 import {
   extractIssueKeyFromUrl,
@@ -321,6 +320,7 @@ export default function TaskDescription({ taskId }: TaskDescriptionProps) {
   const hasHydratedRef = useRef(false);
   const isSyncingExternalContentRef = useRef(false);
   const latestSyncedMarkdownRef = useRef("");
+  const descriptionUpdateTimersRef = useRef<Map<string, number>>(new Map());
   const hoveredCodeBlockElementRef = useRef<HTMLElement | null>(null);
   const [hoveredCodeBlock, setHoveredCodeBlock] =
     useState<HoveredCodeBlock | null>(null);
@@ -577,26 +577,36 @@ export default function TaskDescription({ taskId }: TaskDescriptionProps) {
   }, []);
 
   const debouncedUpdate = useCallback(
-    debounce(
-      async (
-        markdown: string,
-        taskId: string | undefined,
-        currentTask: Task | undefined,
-      ) => {
-        const updateTaskFn = updateTaskRef.current;
-        if (!taskId || !currentTask || !updateTaskFn) return;
+    (
+      markdown: string,
+      taskId: string | undefined,
+      currentTask: Task | undefined,
+    ) => {
+      if (!taskId || !currentTask) return;
 
-        try {
-          await updateTaskFn({
-            ...currentTask,
-            description: markdown,
-          });
-        } catch (error) {
-          console.error("Failed to update description:", error);
-        }
-      },
-      700,
-    ),
+      const timers = descriptionUpdateTimersRef.current;
+      const existingTimer = timers.get(taskId);
+      if (existingTimer !== undefined) {
+        window.clearTimeout(existingTimer);
+      }
+
+      const timer = window.setTimeout(() => {
+        timers.delete(taskId);
+        void (async () => {
+          const updateTaskFn = updateTaskRef.current;
+          if (!updateTaskFn) return;
+          try {
+            await updateTaskFn({
+              ...currentTask,
+              description: markdown,
+            });
+          } catch (error) {
+            console.error("Failed to update description:", error);
+          }
+        })();
+      }, 700);
+      timers.set(taskId, timer);
+    },
     [],
   );
 

--- a/apps/web/src/components/task/task-description.tsx
+++ b/apps/web/src/components/task/task-description.tsx
@@ -320,7 +320,9 @@ export default function TaskDescription({ taskId }: TaskDescriptionProps) {
   const hasHydratedRef = useRef(false);
   const isSyncingExternalContentRef = useRef(false);
   const latestSyncedMarkdownRef = useRef("");
-  const descriptionUpdateTimersRef = useRef<Map<string, number>>(new Map());
+  const descriptionUpdateTimersRef = useRef<
+    Map<string, { timer: number; markdown: string; task: Task | undefined }>
+  >(new Map());
   const hoveredCodeBlockElementRef = useRef<HTMLElement | null>(null);
   const [hoveredCodeBlock, setHoveredCodeBlock] =
     useState<HoveredCodeBlock | null>(null);
@@ -576,41 +578,57 @@ export default function TaskDescription({ taskId }: TaskDescriptionProps) {
     };
   }, []);
 
+  const saveDescriptionUpdate = useCallback(
+    (taskId: string, markdown: string, task: Task | undefined) => {
+      const updateTaskFn = updateTaskRef.current;
+      if (!updateTaskFn) return;
+      const latest = taskRef.current;
+      const resolved = latest?.id === taskId ? latest : task;
+      if (!resolved) return;
+      void updateTaskFn({ ...resolved, description: markdown }).catch(
+        (error) => {
+          console.error("Failed to update description:", error);
+        },
+      );
+    },
+    [],
+  );
+
   const debouncedUpdate = useCallback(
     (
       markdown: string,
       taskId: string | undefined,
       currentTask: Task | undefined,
     ) => {
-      if (!taskId || !currentTask) return;
+      if (!taskId) return;
 
       const timers = descriptionUpdateTimersRef.current;
-      const existingTimer = timers.get(taskId);
-      if (existingTimer !== undefined) {
-        window.clearTimeout(existingTimer);
+      const existingEntry = timers.get(taskId);
+      if (existingEntry !== undefined) {
+        window.clearTimeout(existingEntry.timer);
       }
 
       const timer = window.setTimeout(() => {
+        const entry = timers.get(taskId);
+        if (!entry) return;
         timers.delete(taskId);
-        void (async () => {
-          const updateTaskFn = updateTaskRef.current;
-          if (!updateTaskFn) return;
-          const latest = taskRef.current;
-          const base = latest?.id === taskId ? latest : currentTask;
-          try {
-            await updateTaskFn({
-              ...base,
-              description: markdown,
-            });
-          } catch (error) {
-            console.error("Failed to update description:", error);
-          }
-        })();
+        saveDescriptionUpdate(taskId, entry.markdown, entry.task);
       }, 700);
-      timers.set(taskId, timer);
+      timers.set(taskId, { timer, markdown, task: currentTask });
     },
-    [],
+    [saveDescriptionUpdate],
   );
+
+  useEffect(() => {
+    const timers = descriptionUpdateTimersRef.current;
+    return () => {
+      timers.forEach(({ timer, markdown, task }, taskId) => {
+        window.clearTimeout(timer);
+        saveDescriptionUpdate(taskId, markdown, task);
+      });
+      timers.clear();
+    };
+  }, [saveDescriptionUpdate]);
 
   const editor = useEditor(
     {


### PR DESCRIPTION
## What

Hardening for the task description save pipeline, split out of #1581 per review feedback. This PR makes pending description updates reliable when the user switches tasks or closes the page mid-edit.

## Changes

1. **Bind pending description updates to their source task** — the 700 ms debounced update captures the task id + snapshot at edit time, so navigating away mid-debounce can never send one task's markdown to another task's endpoint.
2. **Keep per-task pending updates independent** — each task gets its own debounce timer, so editing task B within the interval no longer cancels task A's pending save.
3. **Persist fresh task state at save time** — when the timer fires, the update uses the freshest task snapshot for that task, so field changes made during the 700 ms window (status, assignee, due date) aren't overwritten by the older copy.
4. **Flush pending updates on unmount** — instead of just cancelling timers, the cleanup now runs any pending save immediately, so an edit typed right before closing the view isn't silently lost (addresses review feedback to replace clear with flush).
5. **Resolve the task at save time** — the debounce no longer requires the task to be loaded at keystroke time; the update resolves the task (id-matched fresh snapshot, else the captured one) when the timer fires, so a character typed during the initial task fetch is no longer dropped.

## Verification

- `pnpm --filter @kaneo/web typecheck` — pass
- `pnpm --filter @kaneo/web test` — task description test passes (pre-existing suite failures in `env.test.ts`/`use-board-sort`/`use-task-filters` are jsdom-env issues unrelated to this change)

Depends on #1581 (the core editor-lifecycle fix).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task description updates to reliably save the latest changes.
  * Prevented updates from being applied to the wrong task.
  * Ensured pending description edits are saved when leaving the editor.
  * Added clearer error logging when a description update fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->