### PR TITLE
test(web): cover the crash #1580 actually reported

### DIFF
--- a/apps/web/src/components/task/task-description.test.tsx
+++ b/apps/web/src/components/task/task-description.test.tsx
@@ -1,43 +1,48 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { Extension } from "@tiptap/core";
+import TaskItem from "@tiptap/extension-task-item";
 import { describe, expect, it, vi } from "vitest";
 import TaskDescription from "./task-description";
 
 const mocks = vi.hoisted(() => ({
-  useEditor: vi.fn(),
   t: (key: string) => key,
+  tasks: new Map<string, { id: string; description: string }>(),
 }));
 
-vi.mock("@tiptap/react", () => ({
-  useEditor: mocks.useEditor,
-  EditorContent: () => null,
-  NodeViewWrapper: ({ children }: { children: unknown }) => children,
-  ReactNodeViewRenderer: () => () => null,
-}));
-vi.mock("@tiptap/react/menus", () => ({ BubbleMenu: () => null }));
-vi.mock("./extensions/attachment-card", () => ({
-  AttachmentCard: { configure: () => ({}) },
-}));
-vi.mock("./extensions/embed-block", () => ({
-  EmbedBlock: { configure: () => ({}) },
-}));
-vi.mock("./extensions/kaneo-issue-link", () => ({
-  KaneoIssueLink: { configure: () => ({}) },
+// Only the extensions that pull in browser-only machinery are replaced, and
+// they are replaced with real (inert) Tiptap extensions rather than plain
+// objects, so `useEditor` builds a genuine editor. The editor lifecycle is the
+// thing under test here; stubbing it out is what let the previous version of
+// this file pass while #1580 was still broken.
+function inert(name: string) {
+  return Extension.create({ name });
+}
+
+vi.mock("./extensions/shiki-code-block", () => ({
+  ShikiCodeBlock: inert("shikiCodeBlockStub"),
 }));
 vi.mock("./extensions/mermaid-block", () => ({
-  MermaidBlock: { configure: () => ({}) },
+  MermaidBlock: inert("mermaidBlockStub"),
 }));
-vi.mock("./extensions/shiki-code-block", () => ({
-  ShikiCodeBlock: { configure: () => ({}) },
+vi.mock("./extensions/embed-block", () => ({
+  EmbedBlock: inert("embedBlockStub"),
+}));
+vi.mock("./extensions/attachment-card", () => ({
+  AttachmentCard: inert("attachmentCardStub"),
+}));
+vi.mock("./extensions/kaneo-issue-link", () => ({
+  KaneoIssueLink: inert("kaneoIssueLinkStub"),
 }));
 vi.mock("./extensions/task-item-with-checkbox", () => ({
-  TaskItemWithCheckbox: { configure: () => ({}) },
+  TaskItemWithCheckbox: TaskItem,
 }));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: mocks.t }),
   initReactI18next: { type: "3rdParty", init: () => {} },
 }));
 vi.mock("@/hooks/queries/task/use-get-task", () => ({
-  default: () => ({ data: undefined }),
+  default: (taskId: string) => ({ data: mocks.tasks.get(taskId) }),
 }));
 vi.mock("@/hooks/mutations/task/use-update-task-description", () => ({
   useUpdateTaskDescription: () => ({ mutateAsync: vi.fn() }),
@@ -55,29 +60,76 @@ vi.mock("@/lib/toast", () => ({
 }));
 vi.mock("@/lib/upload-task-image", () => ({ uploadTaskImage: vi.fn() }));
 vi.mock("@/lib/shiki-highlighter", () => ({
-  getSharedShikiHighlighter: () => Promise.resolve({}),
+  getSharedShikiHighlighter: () => new Promise(() => {}),
 }));
 
 describe("TaskDescription", () => {
-  it("keeps the useEditor deps stable when the task id changes", () => {
-    const depsPerRender: unknown[][] = [];
-    mocks.useEditor.mockImplementation((_options: unknown, deps: unknown[]) => {
-      depsPerRender.push(deps);
-      return null;
+  it("renders the parent description when navigating from a subtask (#1580)", async () => {
+    mocks.tasks.set("child-task", {
+      id: "child-task",
+      description: "child body",
+    });
+    mocks.tasks.set("parent-task", {
+      id: "parent-task",
+      description: "parent body",
     });
 
-    const { rerender } = render(<TaskDescription taskId="task-a" />);
-    rerender(<TaskDescription taskId="task-b" />);
-    rerender(<TaskDescription taskId="task-c" />);
+    const { container, rerender } = render(
+      <TaskDescription taskId="child-task" />,
+    );
 
-    expect(depsPerRender.length).toBeGreaterThanOrEqual(3);
+    await waitFor(() => {
+      expect(container.textContent).toContain("child body");
+    });
 
-    const [first, ...rest] = depsPerRender;
-    for (const deps of rest) {
-      expect(deps).toHaveLength(first.length);
-      deps.forEach((dep, index) => {
-        expect(dep).toBe(first[index]);
-      });
-    }
+    // The "Subtask of X" backlink: the same component instance is handed a
+    // different task id. Before #1580 was fixed this destroyed the editor and
+    // the hydration effect then read `commands` off the destroyed instance.
+    rerender(<TaskDescription taskId="parent-task" />);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("parent body");
+    });
+    expect(container.textContent).not.toContain("child body");
+  });
+
+  it("does not let undo pull the previous task's description back (#1580)", async () => {
+    mocks.tasks.set("child-task", {
+      id: "child-task",
+      description: "child body",
+    });
+    mocks.tasks.set("parent-task", {
+      id: "parent-task",
+      description: "parent body",
+    });
+
+    const { container, rerender } = render(
+      <TaskDescription taskId="child-task" />,
+    );
+    await waitFor(() => {
+      expect(container.textContent).toContain("child body");
+    });
+
+    rerender(<TaskDescription taskId="parent-task" />);
+    await waitFor(() => {
+      expect(container.textContent).toContain("parent body");
+    });
+
+    // The editor now survives the task switch, so its undo stack would still
+    // hold the previous task's document unless hydration is kept out of the
+    // history. Undoing into it would also schedule a save of the child's
+    // markdown against the parent's id.
+    const editable = container.querySelector<HTMLElement>(
+      '[contenteditable="true"]',
+    );
+    expect(editable).not.toBeNull();
+    fireEvent.keyDown(editable as HTMLElement, {
+      key: "z",
+      code: "KeyZ",
+      ctrlKey: true,
+    });
+
+    expect(container.textContent).toContain("parent body");
+    expect(container.textContent).not.toContain("child body");
   });
 });


### PR DESCRIPTION
Picks up @tinsever's review on #1581, which was right and which I merged past.

## The problem with the test that shipped

`task-description.test.tsx` mocked `useEditor` to return `null` and asserted its dependency array stayed referentially stable. There is no state of the code where that test fails and #1580 is broken: it never builds an editor, so it cannot observe an editor being destroyed, and it never reads a description, so it cannot observe the wrong one being rendered. It had the shape of a regression test without the substance, and the bots passed it because it passes.

## What replaces it

Two tests that build a **real** Tiptap editor. Only the extensions that need a browser are stubbed, and they are stubbed as real inert Tiptap extensions rather than `{ configure: () => ({}) }`, so `useEditor` constructs a genuine editor.

**`renders the parent description when navigating from a subtask`** drives the exact path from the issue: render `child-task`, hand the same component `parent-task`, assert the parent's body is on screen and the child's is not.

**`does not let undo pull the previous task's description back`** covers what #1581 introduced rather than fixed. Keeping one editor alive across the switch means its undo stack outlives the task, so hydration has to stay out of the history.

## Both were checked against code where they should fail

Against the component as of `9b2a3fa0^` (before #1581):

```
TypeError: Cannot read properties of null (reading 'commands')
 ❯ Editor.get commands  @tiptap/core/src/Editor.ts:238:31
    980|       editor.commands.setContent(incomingMarkdown, {
```

That is the message from #1580, verbatim.

With the undo guards removed but the lifecycle fix left in place, the second fails with `expected '' to contain 'parent body'`, which is the blanking @luantaraschi measured by hand during review, now caught automatically.

## Two things I did not do

The dependency-stability test is **dropped rather than kept alongside**, which is not quite what the review asked for. `vi.mock` is file-scoped, so a test that needs `useEditor` mocked and tests that need it real cannot share a file. It also asserted the mechanism where these assert the behaviour, so it is now redundant. Happy to restore it in its own file if you would rather have it.

**Stale uploads are still uncovered.** The drop path runs through ProseMirror's `editorProps.handleDrop`, and the file-picker path needs `openImagePicker` to have run first, so reaching either from jsdom means driving the slash menu. That coverage belongs with #1588, which is where the upload-discard behaviour is being finalised, and it is worth asking for there.

## Verification

- Web suite: 34 files, 107 tests pass.
- `tsc --noEmit` clean, `biome ci .` exits 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded task description coverage using realistic editor behavior.
  * Added tests for navigating between tasks and preventing undo from restoring a previous task’s description.
  * Improved test reliability by using browser-independent editor extensions and reusable task fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->