### PR TITLE
refactor(web): drop unrelated optional chaining from code block copy guard

### DIFF
--- a/apps/web/src/components/task/task-description.tsx
+++ b/apps/web/src/components/task/task-description.tsx
@@ -1316,7 +1316,7 @@ export default function TaskDescription({ taskId }: TaskDescriptionProps) {
   const copyHoveredCodeBlock = useCallback(async () => {
     if (!editor || !hoveredCodeBlock) return;
     const node = editor.state.doc.nodeAt(hoveredCodeBlock.nodePos);
-    if (node?.type.name !== "codeBlock") return;
+    if (!node || node.type.name !== "codeBlock") return;
 
     const content = node.textContent || "";
     if (!content) return;


### PR DESCRIPTION
﻿Reverts the optional-chaining change that rode along in #1581. It was flagged as unrelated to the editor-lifecycle fix; restoring the explicit guard keeps the PR scoped.

Web typecheck passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code block copying behavior by safely handling cases where no valid code block is hovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->