### PR TITLE
fix(web): save a description to the task it was typed in

### DIFF
--- a/apps/web/src/components/task/task-description-save.test.tsx
+++ b/apps/web/src/components/task/task-description-save.test.tsx
@@ -1,0 +1,157 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { Extension } from "@tiptap/core";
+import TaskItem from "@tiptap/extension-task-item";
+import type { Editor } from "@tiptap/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TaskDescription from "./task-description";
+
+const mocks = vi.hoisted(() => ({
+  t: (key: string) => key,
+  tasks: new Map<
+    string,
+    { id: string; projectId: string; description: string }
+  >(),
+  mutateAsync: vi.fn(),
+  editors: [] as unknown[],
+}));
+
+vi.mock("@tiptap/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tiptap/react")>();
+  return {
+    ...actual,
+    useEditor: (...args: Parameters<typeof actual.useEditor>) => {
+      const editor = actual.useEditor(...args);
+      if (editor && !mocks.editors.includes(editor)) mocks.editors.push(editor);
+      return editor;
+    },
+  };
+});
+
+function inert(name: string) {
+  return Extension.create({ name });
+}
+
+vi.mock("./extensions/shiki-code-block", () => ({
+  ShikiCodeBlock: inert("shikiCodeBlockStub"),
+}));
+vi.mock("./extensions/mermaid-block", () => ({
+  MermaidBlock: inert("mermaidBlockStub"),
+}));
+vi.mock("./extensions/embed-block", () => ({
+  EmbedBlock: inert("embedBlockStub"),
+}));
+vi.mock("./extensions/attachment-card", () => ({
+  AttachmentCard: inert("attachmentCardStub"),
+}));
+vi.mock("./extensions/kaneo-issue-link", () => ({
+  KaneoIssueLink: inert("kaneoIssueLinkStub"),
+}));
+vi.mock("./extensions/task-item-with-checkbox", () => ({
+  TaskItemWithCheckbox: TaskItem,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: mocks.t }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+vi.mock("@/hooks/queries/task/use-get-task", () => ({
+  default: (taskId: string) => ({ data: mocks.tasks.get(taskId) }),
+}));
+vi.mock("@/hooks/mutations/task/use-update-task-description", () => ({
+  useUpdateTaskDescription: () => ({ mutateAsync: mocks.mutateAsync }),
+}));
+vi.mock("@/hooks/use-workspace-permission", () => ({
+  useWorkspacePermission: () => ({ canUpdateTasks: () => true }),
+}));
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+vi.mock("@/lib/upload-task-image", () => ({ uploadTaskImage: vi.fn() }));
+vi.mock("@/lib/shiki-highlighter", () => ({
+  getSharedShikiHighlighter: () => new Promise(() => {}),
+}));
+
+const DEBOUNCE_MS = 700;
+
+function latestEditor() {
+  return mocks.editors[mocks.editors.length - 1] as Editor;
+}
+
+// Hydration parks the editor behind a flag cleared on a later animation
+// frame. An edit dispatched before that is swallowed, not saved.
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
+}
+
+function savedTaskIds() {
+  return mocks.mutateAsync.mock.calls.map((call) => call[0].id);
+}
+
+beforeEach(() => {
+  mocks.mutateAsync.mockReset();
+  mocks.mutateAsync.mockResolvedValue({});
+  mocks.editors.length = 0;
+  mocks.tasks.set("task-a", {
+    id: "task-a",
+    projectId: "project-1",
+    description: "alpha",
+  });
+  mocks.tasks.set("task-b", {
+    id: "task-b",
+    projectId: "project-1",
+    description: "bravo",
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("TaskDescription pending saves", () => {
+  it("saves an edit to the task it was typed in, not the one navigated to", async () => {
+    const { container, rerender } = render(<TaskDescription taskId="task-a" />);
+    await waitFor(() => expect(container.textContent).toContain("alpha"));
+
+    await settle();
+    latestEditor().commands.insertContent(" edited in a");
+    expect(mocks.mutateAsync).not.toHaveBeenCalled();
+
+    rerender(<TaskDescription taskId="task-b" />);
+    await waitFor(() => expect(container.textContent).toContain("bravo"));
+
+    await vi.waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(1), {
+      timeout: DEBOUNCE_MS * 4,
+    });
+
+    const [saved] = mocks.mutateAsync.mock.calls[0];
+    expect(saved.id).toBe("task-a");
+    expect(saved.description).toContain("edited in a");
+  });
+
+  it("does not let an edit in one task cancel another task's pending save", async () => {
+    const { container, rerender } = render(<TaskDescription taskId="task-a" />);
+    await waitFor(() => expect(container.textContent).toContain("alpha"));
+
+    await settle();
+    latestEditor().commands.insertContent(" edited in a");
+
+    rerender(<TaskDescription taskId="task-b" />);
+    await waitFor(() => expect(container.textContent).toContain("bravo"));
+
+    await settle();
+    latestEditor().commands.insertContent(" edited in b");
+
+    await vi.waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(2), {
+      timeout: DEBOUNCE_MS * 4,
+    });
+
+    expect(savedTaskIds().sort()).toEqual(["task-a", "task-b"]);
+  });
+});

--- a/apps/web/src/components/task/task-description-save.test.tsx
+++ b/apps/web/src/components/task/task-description-save.test.tsx
@@ -83,10 +83,14 @@ function latestEditor() {
 }
 
 // Hydration parks the editor behind a flag cleared on a later animation
-// frame. An edit dispatched before that is swallowed, not saved.
+// frame. An edit dispatched before that is swallowed, not saved. Waiting on a
+// frame rather than a delay is what makes it deterministic: hydration's
+// callback is already queued, so one queued after it cannot run first.
 async function settle() {
   await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => resolve(undefined));
+    });
   });
 }
 

--- a/apps/web/src/components/task/task-description.tsx
+++ b/apps/web/src/components/task/task-description.tsx
@@ -65,7 +65,6 @@ import { useUpdateTaskDescription } from "@/hooks/mutations/task/use-update-task
 import useGetTask from "@/hooks/queries/task/use-get-task";
 import { useWorkspacePermission } from "@/hooks/use-workspace-permission";
 import { cn } from "@/lib/cn";
-import debounce from "@/lib/debounce";
 import { parseTaskListMarkdownToNodes } from "@/lib/editor-task-list-paste";
 import {
   extractIssueKeyFromUrl,
@@ -118,6 +117,8 @@ type SlashMenuState = {
   left: number;
   selectedIndex: number;
 };
+
+const DESCRIPTION_SAVE_DEBOUNCE_MS = 700;
 
 function formatMarkdown(markdown: string) {
   return markdown
@@ -575,25 +576,42 @@ export default function TaskDescription({ taskId }: TaskDescriptionProps) {
     };
   }, []);
 
-  const debouncedUpdate = useCallback(
-    debounce(async (markdown: string) => {
-      if (!canEditRef.current) return;
-
-      const currentTask = taskRef.current;
-      const updateTaskFn = updateTaskRef.current;
-      if (!currentTask || !updateTaskFn) return;
-
-      try {
-        await updateTaskFn({
-          ...currentTask,
-          description: markdown,
-        });
-      } catch (error) {
-        console.error("Failed to update description:", error);
-      }
-    }, 700),
-    [],
+  const pendingDescriptionSavesRef = useRef(
+    new Map<string, ReturnType<typeof setTimeout>>(),
   );
+
+  const scheduleDescriptionSave = useCallback((markdown: string) => {
+    if (!canEditRef.current) return;
+
+    const editedTask = taskRef.current;
+    if (!editedTask) return;
+
+    const timers = pendingDescriptionSavesRef.current;
+    const pending = timers.get(editedTask.id);
+    if (pending) clearTimeout(pending);
+
+    timers.set(
+      editedTask.id,
+      setTimeout(async () => {
+        timers.delete(editedTask.id);
+
+        const updateTaskFn = updateTaskRef.current;
+        if (!updateTaskFn) return;
+
+        const latestTask = taskRef.current;
+        const base = latestTask?.id === editedTask.id ? latestTask : editedTask;
+
+        try {
+          await updateTaskFn({
+            ...base,
+            description: markdown,
+          });
+        } catch (error) {
+          console.error("Failed to update description:", error);
+        }
+      }, DESCRIPTION_SAVE_DEBOUNCE_MS),
+    );
+  }, []);
 
   const editor = useEditor(
     {
@@ -806,7 +824,7 @@ export default function TaskDescription({ taskId }: TaskDescriptionProps) {
         const markdown = formatMarkdown(activeEditor.getMarkdown());
         if (markdown === latestSyncedMarkdownRef.current) return;
         latestSyncedMarkdownRef.current = markdown;
-        debouncedUpdate(markdown);
+        scheduleDescriptionSave(markdown);
       },
     },
     [getOverlayPosition, handleAssetFileUpload, t, toShikiLanguage],


### PR DESCRIPTION
Fixes #1599. Shipped broken in v2.19.0.

## The bug

Description saves are debounced by 700ms. `debouncedUpdate` reads `taskRef.current` when the timer fires rather than when the text was typed, and `updateTaskDescription(task.id, task)` uses the id to pick the endpoint. Leave a task inside that window and its markdown is written over whichever task is open when the timer expires. Both tasks are damaged: the one navigated to loses its description, the one edited never receives the text.

Separately, `lib/debounce` keeps a single `timeout` in its closure, and `useCallback(..., [])` gives one instance for the life of the component. Since #1581 the editor survives a task switch, so typing in the newly opened task clears the timer still owed to the previous one and that edit is dropped with nothing shown.

Before #1581 the editor was torn down on every task change, which made this harder to reach. It is not caused by that change.

## The fix

Pending saves are keyed by task id in a `Map`, and the task is captured when the text is typed rather than looked up when the timer fires. When the timer fires and that task is still the open one, its freshest copy is used, so a status or due date changed inside the window is not carried back stale.

The `debounce` import is dropped from this file only. `task-title.tsx` and `mermaid-block.ts` still use the helper and are untouched.

## Tests

`task-description-save.test.tsx` is new, and mounts the component with a real Tiptap editor, using the harness added in #1595. Both cases were written against v2.19.0 first and fail there:

```
× saves an edit to the task it was typed in, not the one navigated to
  AssertionError: expected 'task-b' to be 'task-a'

× does not let an edit in one task cancel another task's pending save
  AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times
```

The first failure is the misdirected write. The second is the cancelled save.

One detail worth knowing if you touch these: hydration parks the editor behind `isSyncingExternalContentRef`, which a later animation frame clears, so an edit dispatched immediately after mount is swallowed rather than saved. The tests settle before typing.

## Verification

- Web suite: 35 files, 109 tests pass.
- `tsc --noEmit` clean, `biome ci .` exits 0.
- The #1595 regression tests still pass alongside these.

## Provenance

#1587 covered the same ground and was closed with its author. I did not reuse it. This was written from the code, the issue was filed first, and each test was checked against the released build before the fix went in. The shape of a small fix like this converges, so the approaches resemble each other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task description saving when switching between tasks.
  * Prevented pending edits from being canceled or saved to the wrong task.
  * Ensured edits to multiple tasks are saved independently, even when made close together.

* **Tests**
  * Added coverage for pending saves during navigation and simultaneous edits across tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->