### PR TITLE
feat(sentry): provision alerts and dashboards as code

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -82,7 +82,7 @@ SMTP_REQUIRE_TLS=
 # SENTRY_TRACES_SAMPLE_RATE=0.1         # 0.0 disables; default 0 (opt-in)
 # SENTRY_PROFILES_SAMPLE_RATE=0.1      # 0.0 disables; default 0 (opt-in)
 # SENTRY_RELEASE=                       # git SHA; ties events to source maps. Falls back to package.json version.
-# SENTRY_API_TOKEN=                     # Used by scripts/provision-sentry-alerts.sh. Scope: org:write. https://sentry.io/settings/account/api/auth-tokens/
+# SENTRY_API_TOKEN=                     # Used by scripts/provision-sentry-alerts.sh and scripts/provision-sentry-dashboards.sh. Scope: org:write. https://sentry.io/settings/account/api/auth-tokens/
 
 # Kaneo Cloud billing via Creem (Optional): only active when KANEO_CLOUD=true
 # and both keys are set. Self-hosted installs leave these empty; billing stays off.

--- a/.env.sample
+++ b/.env.sample
@@ -82,6 +82,7 @@ SMTP_REQUIRE_TLS=
 # SENTRY_TRACES_SAMPLE_RATE=0.1         # 0.0 disables; default 0 (opt-in)
 # SENTRY_PROFILES_SAMPLE_RATE=0.1      # 0.0 disables; default 0 (opt-in)
 # SENTRY_RELEASE=                       # git SHA; ties events to source maps. Falls back to package.json version.
+# SENTRY_API_TOKEN=                     # Used by scripts/provision-sentry-alerts.sh. Scope: org:write. https://sentry.io/settings/account/api/auth-tokens/
 
 # Kaneo Cloud billing via Creem (Optional): only active when KANEO_CLOUD=true
 # and both keys are set. Self-hosted installs leave these empty; billing stays off.

--- a/scripts/provision-sentry-alerts.sh
+++ b/scripts/provision-sentry-alerts.sh
@@ -21,14 +21,28 @@
 #   - v2: alerts were create-only; edited spec never propagated. now uses PUT.
 set -euo pipefail
 
-ORG="kaneo"
-REGION="de"
-API_BASE="${SENTRY_API_BASE:-https://${REGION}.sentry.io/api/0}"
-DEFAULT_FREQUENCY_MIN=30
-
+# Resolve the spec file first so we can pull org/region/api_base from it.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_DIR="$(dirname "$SCRIPT_DIR")"
 ALERTS_FILE="${SENTRY_ALERTS_FILE:-${CONFIG_DIR}/sentry/alerts.json}"
+
+# Read target organization, region, and API base from the spec. The README
+# documents the region field as the migration point — hardcoded values
+# below would silently route traffic to the wrong endpoint. SENTRY_API_BASE
+# remains an explicit override for ad-hoc runs against a different region.
+ORG=$(jq -er '.organization' "$ALERTS_FILE") || {
+  err "missing or invalid \`organization\` in $ALERTS_FILE"
+  exit 1
+}
+REGION=$(jq -er '.region' "$ALERTS_FILE") || {
+  err "missing or invalid \`region\` in $ALERTS_FILE"
+  exit 1
+}
+API_BASE="${SENTRY_API_BASE:-$(jq -er '.api_base' "$ALERTS_FILE")}" || {
+  err "missing or invalid \`api_base\` in $ALERTS_FILE (or unset SENTRY_API_BASE)"
+  exit 1
+}
+DEFAULT_FREQUENCY_MIN=30
 
 DRY_RUN=0
 if [ "${1:-}" = "--dry-run" ] || [ "${SENTRY_DRY_RUN:-0}" = "1" ]; then
@@ -229,12 +243,19 @@ for i in $(seq 0 $((COUNT - 1))); do
 
   case "$KIND" in
     issue)
-      # Build the workflow payload. Drop empty actions/actionFilters \u2014 the
-      # api rejects workflows with empty arrays in those fields.
+      # Issue alerts carry a top-level `projects` array. Forward it to the
+      # workflow payload so the rule is scoped to the named projects; without
+      # this, the api/web first-seen alerts fall back to organization-wide.
       WORKFLOW=$(echo "$ALERT" | jq --arg org "$ORG" --argjson freq "$DEFAULT_FREQUENCY_MIN" '
-        .workflow
-        | .organizationId = $org
-        | .config = ((.config // {}) + {frequency: $freq})
+        {
+          name:            .workflow.name,
+          enabled:         (.workflow.enabled // true),
+          organizationId:  $org,
+          projects:        (.projects // []),
+          config:          ((.workflow.config // {}) + {frequency: $freq}),
+          triggers:        .workflow.triggers,
+          actionFilters:   .workflow.actionFilters
+        }
         | if (.triggers // {}).actions == [] then del(.triggers.actions) else . end
         | if (.triggers // {}).conditions | not then del(.triggers) else . end
         | if (.actionFilters // []) == [] then del(.actionFilters) else . end
@@ -268,18 +289,23 @@ for i in $(seq 0 $((COUNT - 1))); do
           continue
         }
         RESOLVED=()
+        MISSING=()
         for slug in $SLUGS; do
           id=$(echo "$RESP" | jq -r --arg slug "$slug" \
             '.[] | select(.slug == $slug) | .id' | head -n1)
           if [ -z "$id" ] || [ "$id" = "null" ]; then
-            warn "Cron monitor '$slug' not found in Sentry yet. Has the cron run at least once?"
+            MISSING+=("$slug")
           else
             info "  resolved '$slug' -> id $id"
             RESOLVED+=("$id")
           fi
         done
-        if [ "${#RESOLVED[@]}" -eq 0 ]; then
-          err "No cron monitors resolved for '$NAME'. Skipping."
+        # The spec promises coverage of every configured slug. Partial
+        # resolution (e.g. only the five-minute crons have ticked) is a normal
+        # rollout state, not a pass — surface the missing slugs so a re-run
+        # cannot be mistaken for complete provisioning.
+        if [ "${#MISSING[@]}" -gt 0 ]; then
+          err "Cron monitors not found for '$NAME' (${#MISSING[@]} of ${#SLUGS[@]} missing): ${MISSING[*]}. Has each cron run at least once? Skipping."
           ERRORS=$((ERRORS + 1))
           continue
         fi
@@ -327,6 +353,7 @@ for i in $(seq 0 $((COUNT - 1))); do
           name: .workflow.name,
           enabled: (.workflow.enabled // true),
           organizationId: $org,
+          projects: (.projects // []),
           config: ((.workflow.config // {}) + {frequency: $freq}),
           detectorIds: $detectors,
           triggers: {

--- a/scripts/provision-sentry-alerts.sh
+++ b/scripts/provision-sentry-alerts.sh
@@ -76,6 +76,8 @@ api_call() {
 
   local tmp
   tmp=$(mktemp)
+  local curl_err
+  curl_err=$(mktemp)
   local status
   # --fail-with-body: exit non-zero on HTTP error, but still write the body
   # to stdout (curl 7.76+). Lets us capture error responses inline.
@@ -86,14 +88,21 @@ api_call() {
     -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
     -H "Content-Type: application/json" \
     "${body_args[@]}" \
-    "$url" 2>/dev/null) || {
+    "$url" 2>"$curl_err") || {
     err "HTTP ${status:-?} from $method $url"
     err "Request body: $body"
     err "Response body:"
     [ -s "$tmp" ] && sed 's/^/  /' "$tmp" >&2 || echo "  (empty)" >&2
-    rm -f "$tmp"
+    # Surface transport-level diagnostics (DNS, TLS, timeout) when no
+    # HTTP response was produced. Helpful when the API is unreachable.
+    if [ -s "$curl_err" ]; then
+      err "curl:"
+      sed 's/^/  /' "$curl_err" >&2
+    fi
+    rm -f "$tmp" "$curl_err"
     return 1
   }
+  rm -f "$curl_err"
   cat "$tmp"
   rm -f "$tmp"
 }
@@ -109,11 +118,28 @@ list_monitors() {
   api_call GET "${API_BASE}/organizations/${ORG}/monitors/"
 }
 
-find_existing_workflow() {
-  # Returns the full workflow object as compact JSON, or empty string.
+list_detectors() {
+  api_call GET "${API_BASE}/organizations/${ORG}/detectors/"
+}
+
+# Find an existing detector by name. Returns the numeric id, or empty string.
+# Returns non-zero if the list call itself failed.
+find_detector_by_name() {
   local name="$1"
   local response
-  response=$(list_workflows) || return 0
+  response=$(list_detectors) || return 1
+  echo "$response" | jq -r --arg name "$name" \
+    '.[] | select(.name == $name) | .id' | head -n1
+}
+
+find_existing_workflow() {
+  # Returns the full workflow object as compact JSON, or empty string.
+  # Returns non-zero if the list call itself failed (network, auth, etc.) —
+  # callers must distinguish "no match" from "lookup failed" so they can
+  # skip the alert rather than silently create a duplicate.
+  local name="$1"
+  local response
+  response=$(list_workflows) || return 1
   echo "$response" | jq -c --arg name "$name" \
     '.[] | select(.name == $name)' | head -n1
 }
@@ -141,12 +167,11 @@ create_or_update_workflow() {
 }
 
 create_or_update_detector() {
-  local project="$1"
-  local body="$2"
-  local id="${3:-}"
+  local body="$1"
+  local id="${2:-}"
   local method=POST
   # Detectors are organization-scoped. The project lives in the body
-  # (`projectId`), not the URL — `/projects/${project}/detectors/` returns
+  # (`projectId`), not the URL — `/projects/{project}/detectors/` returns
   # 200 on POST but 404 on PUT, so the update path always failed.
   local url="${API_BASE}/organizations/${ORG}/detectors/"
   if [ -n "$id" ]; then
@@ -191,7 +216,11 @@ for i in $(seq 0 $((COUNT - 1))); do
 
   # Find existing workflow (full object, or empty string). The script
   # discriminates create vs update on whether this returns a value.
-  EXISTING=$(find_existing_workflow "$NAME")
+  if ! EXISTING=$(find_existing_workflow "$NAME"); then
+    err "  failed to look up existing workflow \u2014 skipping"
+    ERRORS=$((ERRORS + 1))
+    continue
+  fi
   EXISTING_ID=""
   if [ -n "$EXISTING" ]; then
     EXISTING_ID=$(echo "$EXISTING" | jq -r '.id // empty')
@@ -262,15 +291,21 @@ for i in $(seq 0 $((COUNT - 1))); do
         DETECTOR=$(echo "$ALERT" | jq --arg org "$ORG" --arg project "$PROJECT" '
           .detector + {organizationId: $org, projectId: $project}
         ')
+        DETECTOR_NAME=$(echo "$DETECTOR" | jq -r '.name')
 
-        # On update, find the existing detector id from the workflow's
-        # detectorIds. On create, it is empty.
+        # Resolve the existing detector id. The workflow's detectorIds is
+        # authoritative when the workflow exists, but a previous failed run
+        # can leave an orphaned detector behind. Falling back to a name
+        # lookup keeps idempotent re-runs from creating a duplicate.
         EXISTING_DET_ID=""
         if [ -n "$EXISTING_ID" ]; then
           EXISTING_DET_ID=$(echo "$EXISTING" | jq -r '.detectorIds[0] // empty')
         fi
+        if [ -z "$EXISTING_DET_ID" ]; then
+          EXISTING_DET_ID=$(find_detector_by_name "$DETECTOR_NAME" || true)
+        fi
 
-        if NEW_DET_ID=$(create_or_update_detector "$PROJECT" "$DETECTOR" "$EXISTING_DET_ID") && [ -n "$NEW_DET_ID" ]; then
+        if NEW_DET_ID=$(create_or_update_detector "$DETECTOR" "$EXISTING_DET_ID") && [ -n "$NEW_DET_ID" ]; then
           if [ -n "$EXISTING_DET_ID" ]; then
             ok "Updated detector $NEW_DET_ID"
           else

--- a/scripts/provision-sentry-alerts.sh
+++ b/scripts/provision-sentry-alerts.sh
@@ -59,13 +59,6 @@ fi
 command -v jq >/dev/null || { err "jq is required"; exit 1; }
 
 # ---- API helpers ----
-# URL-encode a value for use in a query string. Slugs and alert names with
-# spaces, colons, or other reserved chars would otherwise break the GET
-# endpoints (HTTP 000 with curl).
-url_encode() {
-  printf '%s' "$1" | jq -sRr @uri
-}
-
 # Run an API call. Prints response body on success, returns 0.
 # On HTTP >= 400, prints the response body to stderr and returns 1.
 api_call() {
@@ -102,12 +95,21 @@ api_call() {
   rm -f "$tmp"
 }
 
+# Sentry's `?query=` parameter is tokenized (e.g. `is:unresolved`, `project:foo`),
+# not free-text. Names like "Kaneo API: New issue" parse as broken search tokens.
+# Easier to fetch all and filter client-side: at most ~10 alerts in this org.
+list_workflows() {
+  api_call GET "${API_BASE}/organizations/${ORG}/workflows/"
+}
+
+list_monitors() {
+  api_call GET "${API_BASE}/organizations/${ORG}/monitors/"
+}
+
 find_existing_workflow_id() {
   local name="$1"
-  local encoded
-  encoded=$(url_encode "$name")
   local response
-  response=$(api_call GET "${API_BASE}/organizations/${ORG}/workflows/?query=${encoded}") || return 0
+  response=$(list_workflows) || return 0
   echo "$response" | jq -r --arg name "$name" \
     '.[] | select(.name == $name) | .id' | head -n1
 }
@@ -184,14 +186,13 @@ for i in $(seq 0 $((COUNT - 1))); do
 
       if [ "$HAS_SLUGS" = "true" ]; then
         SLUGS=$(echo "$ALERT" | jq -r '.detector_slugs[]')
+        RESP=$(list_monitors) || {
+          err "Monitor lookup failed for '$NAME'"
+          ERRORS=$((ERRORS + 1))
+          continue
+        }
         RESOLVED=()
         for slug in $SLUGS; do
-          encoded=$(url_encode "$slug")
-          RESP=$(curl -sS -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
-            "${API_BASE}/organizations/${ORG}/monitors/?query=${encoded}" 2>/dev/null) || {
-            err "Monitor lookup failed for '$slug'"
-            continue
-          }
           id=$(echo "$RESP" | jq -r --arg slug "$slug" \
             '.[] | select(.slug == $slug) | .id' | head -n1)
           if [ -z "$id" ] || [ "$id" = "null" ]; then

--- a/scripts/provision-sentry-alerts.sh
+++ b/scripts/provision-sentry-alerts.sh
@@ -282,7 +282,9 @@ for i in $(seq 0 $((COUNT - 1))); do
       DETECTOR_IDS='[]'
 
       if [ "$HAS_SLUGS" = "true" ]; then
-        SLUGS=$(echo "$ALERT" | jq -r '.detector_slugs[]')
+        # Declare as an array so ${#SLUGS[@]} works under `set -u` (accessing
+        # a scalar with array syntax aborts the script with "unbound variable").
+        mapfile -t SLUGS < <(echo "$ALERT" | jq -r '.detector_slugs[]')
         RESP=$(list_monitors) || {
           err "Monitor lookup failed for '$NAME'"
           ERRORS=$((ERRORS + 1))
@@ -290,7 +292,7 @@ for i in $(seq 0 $((COUNT - 1))); do
         }
         RESOLVED=()
         MISSING=()
-        for slug in $SLUGS; do
+        for slug in "${SLUGS[@]}"; do
           id=$(echo "$RESP" | jq -r --arg slug "$slug" \
             '.[] | select(.slug == $slug) | .id' | head -n1)
           if [ -z "$id" ] || [ "$id" = "null" ]; then

--- a/scripts/provision-sentry-alerts.sh
+++ b/scripts/provision-sentry-alerts.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Provisions Sentry alert rules from sentry/alerts.json via the Sentry REST API.
+# Idempotent: existing alerts with the same name are skipped.
+#
+# Usage:
+#   SENTRY_API_TOKEN=sntrys_... ./scripts/provision-sentry-alerts.sh
+#   SENTRY_API_TOKEN=... ./scripts/provision-sentry-alerts.sh --dry-run
+#
+# The token needs one of: alerts:write, org:admin, org:write, or org:manager scopes.
+# Generate at: https://sentry.io/settings/account/api/auth-tokens/
+set -euo pipefail
+
+ORG="kaneo"
+REGION="de"
+API_BASE="https://${REGION}.sentry.io/api/0"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="$(dirname "$SCRIPT_DIR")"
+ALERTS_FILE="${SENTRY_ALERTS_FILE:-${CONFIG_DIR}/sentry/alerts.json}"
+
+DRY_RUN=0
+if [ "${1:-}" = "--dry-run" ] || [ "${SENTRY_DRY_RUN:-0}" = "1" ]; then
+  DRY_RUN=1
+fi
+
+info()   { printf '\033[1;34m[info]\033[0m %s\n' "$*"; }
+warn()   { printf '\033[1;33m[warn]\033[0m %s\n' "$*" >&2; }
+error()  { printf '\033[1;31m[err]\033[0m  %s\n' "$*" >&2; }
+ok()     { printf '\033[1;32m[ok]\033[0m   %s\n' "$*"; }
+
+if [ -z "${SENTRY_API_TOKEN:-}" ]; then
+  error "SENTRY_API_TOKEN is not set. Generate one at https://sentry.io/settings/account/api/auth-tokens/ with alerts:write scope."
+  exit 1
+fi
+
+if [ ! -f "$ALERTS_FILE" ]; then
+  error "Alerts config not found at $ALERTS_FILE"
+  exit 1
+fi
+
+command -v jq >/dev/null || { error "jq is required"; exit 1; }
+
+# Resolve monitor slug -> numeric ID via Sentry API.
+# Returns 1 if not found.
+resolve_monitor_id() {
+  local slug="$1"
+  local response
+  response=$(curl -fsSL \
+    -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
+    "${API_BASE}/organizations/${ORG}/monitors/?query=${slug}" 2>/dev/null) || return 1
+  echo "$response" | jq -r --arg slug "$slug" \
+    '.[] | select(.slug == $slug) | .id' | head -n1
+}
+
+# Check whether an alert with this name already exists.
+# Returns the ID if found, empty string otherwise.
+find_existing_alert() {
+  local name="$1"
+  local response
+  response=$(curl -fsSL \
+    -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
+    "${API_BASE}/organizations/${ORG}/workflows/?query=${name}" 2>/dev/null) || return 1
+  echo "$response" | jq -r --arg name "$name" \
+    '.[] | select(.name == $name) | .id' | head -n1
+}
+
+# Create a metric detector (used by metric alerts). Returns the new ID.
+# Args: detector JSON (without organizationId / projectId).
+create_detector() {
+  local project="$1"
+  local body="$2"
+  local response
+  response=$(curl -fsSL \
+    -X POST \
+    -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$body" \
+    "${API_BASE}/organizations/${ORG}/projects/${project}/detectors/")
+  echo "$response" | jq -r '.id'
+}
+
+# Create a workflow (alert rule). Returns the new ID.
+create_workflow() {
+  local body="$1"
+  local response
+  response=$(curl -fsSL \
+    -X POST \
+    -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$body" \
+    "${API_BASE}/organizations/${ORG}/workflows/")
+  echo "$response" | jq -r '.id'
+}
+
+# Wire a detector into a workflow (POST detector_ids to the workflow).
+attach_detector_to_workflow() {
+  local workflow_id="$1"
+  local detector_id="$2"
+  curl -fsSL \
+    -X PUT \
+    -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "{\"detectorIds\": [\"${detector_id}\"]}" \
+    "${API_BASE}/workflows/${workflow_id}/detector/${detector_id}" >/dev/null
+}
+
+# Apply a single alert entry from the JSON config.
+apply_alert() {
+  local alert_json="$1"
+  local name type projects workflow_json
+
+  name=$(echo "$alert_json" | jq -r '.name')
+  type=$(echo "$alert_json" | jq -r '.kind')
+
+  if [ -z "$name" ] || [ "$name" = "null" ]; then
+    error "Alert entry missing name; skipping"
+    return 0
+  fi
+
+  local existing
+  existing=$(find_existing_alert "$name" || true)
+  if [ -n "$existing" ]; then
+    ok "Alert '$name' already exists (id $existing); skipping"
+    return 0
+  fi
+
+  info "Creating alert: $name ($type)"
+
+  case "$type" in
+    issue)
+      projects=$(echo "$alert_json" | jq -r '.projects | join(",")')
+      workflow_json=$(echo "$alert_json" | jq --arg org "$ORG" --arg projects "$projects" '
+        .workflow + {
+          organizationId: $org,
+          triggers: {
+            logicType: .workflow.triggers.logicType,
+            conditions: .workflow.triggers.conditions,
+            actions: []
+          }
+        }
+      ')
+      if [ "$DRY_RUN" = "1" ]; then
+        echo "$workflow_json" | jq .
+      else
+        local new_id
+        new_id=$(create_workflow "$workflow_json")
+        ok "Created workflow $new_id"
+      fi
+      ;;
+
+    metric)
+      local detector_id
+      detector_id=$(echo "$alert_json" | jq -r '.detector.id // ""')
+
+      if [ -z "$detector_id" ] || [ "$detector_id" = "null" ]; then
+        # Try resolving from detector_slugs (cron check-in monitors).
+        local slugs
+        slugs=$(echo "$alert_json" | jq -r '.detector_slugs | join(" ")')
+        local resolved_ids=()
+
+        for slug in $slugs; do
+          local id
+          id=$(resolve_monitor_id "$slug" || true)
+          if [ -z "$id" ]; then
+            warn "  cron monitor '$slug' not found in Sentry yet. Have the cron jobs run at least once?"
+            continue
+          fi
+          resolved_ids+=("$id")
+          info "  resolved monitor '$slug' -> id $id"
+        done
+        detector_id=$(echo "${resolved_ids[@]:-}" | tr ' ' '\n' | head -n1)
+      fi
+
+      # Create the detector (if we have a body for it).
+      local detector_body
+      detector_body=$(echo "$alert_json" | jq -r '.detector // empty')
+      if [ -n "$detector_body" ]; then
+        local project
+        project=$(echo "$alert_json" | jq -r '.project')
+        detector_body=$(echo "$detector_body" | jq --arg org "$ORG" --arg project "$project" '
+          . + {organizationId: $org, projectId: $project}
+        ')
+        if [ "$DRY_RUN" = "1" ]; then
+          echo "$detector_body" | jq .
+        else
+          local new_detector_id
+          new_detector_id=$(create_detector "$project" "$detector_body")
+          ok "Created detector $new_detector_id"
+          detector_id="$new_detector_id"
+        fi
+      fi
+
+      # Create the workflow.
+      local workflow_body
+      workflow_body=$(echo "$alert_json" | jq --arg org "$ORG" --arg det "$detector_id" '
+        .workflow + {
+          organizationId: $org,
+          detectorIds: (if $det != "" then [$det] else [] end)
+        }
+      ')
+      if [ "$DRY_RUN" = "1" ]; then
+        echo "$workflow_body" | jq .
+      else
+        local new_workflow_id
+        new_workflow_id=$(create_workflow "$workflow_body")
+        ok "Created workflow $new_workflow_id"
+      fi
+      ;;
+
+    *)
+      error "Unknown alert kind '$type' for '$name'; skipping"
+      return 0
+      ;;
+  esac
+}
+
+# ---- main ----
+info "Reading alerts from $ALERTS_FILE"
+[ "$DRY_RUN" = "1" ] && info "DRY RUN: no changes will be made"
+info "Organization: $ORG, Region: $REGION"
+
+count=$(jq '.alerts | length' "$ALERTS_FILE")
+info "Found $count alert(s) to process"
+
+OK=0
+SKIPPED=0
+ERRORED=0
+
+for i in $(seq 0 $((count - 1))); do
+  ALERT=$(jq -c ".alerts[$i]" "$ALERTS_FILE")
+  if apply_alert "$ALERT"; then
+    OK=$((OK + 1))
+  else
+    ERRORED=$((ERRORED + 1))
+  fi
+done
+
+echo ""
+info "Done: $OK created/skipped, $ERRORED errors"
+[ "$DRY_RUN" = "1" ] && info "Re-run without --dry-run to apply"
+info "Configure per-alert notifications in Sentry: Settings > Alerts > [alert name] > Actions"

--- a/scripts/provision-sentry-alerts.sh
+++ b/scripts/provision-sentry-alerts.sh
@@ -280,8 +280,9 @@ for i in $(seq 0 $((COUNT - 1))); do
         fi
       fi
 
-      # Workflow for metric alerts: detector-only, no triggers. The detector
-      # itself fires when its condition matches.
+      # Workflow for metric alerts: detectorOnly is the firing model, but the
+      # API still expects a `triggers` field on every workflow. Empty conditions
+      # are fine; the detector drives notification when the threshold trips.
       WORKFLOW=$(echo "$ALERT" | jq --arg org "$ORG" --argjson freq "$DEFAULT_FREQUENCY_MIN" \
         --argjson detectors "$DETECTOR_IDS" '
         {
@@ -289,7 +290,11 @@ for i in $(seq 0 $((COUNT - 1))); do
           enabled: (.workflow.enabled // true),
           organizationId: $org,
           config: ((.workflow.config // {}) + {frequency: $freq}),
-          detectorIds: $detectors
+          detectorIds: $detectors,
+          triggers: {
+            logicType: "any-short",
+            conditions: []
+          }
         }
       ')
 

--- a/scripts/provision-sentry-alerts.sh
+++ b/scripts/provision-sentry-alerts.sh
@@ -59,6 +59,13 @@ fi
 command -v jq >/dev/null || { err "jq is required"; exit 1; }
 
 # ---- API helpers ----
+# URL-encode a value for use in a query string. Slugs and alert names with
+# spaces, colons, or other reserved chars would otherwise break the GET
+# endpoints (HTTP 000 with curl).
+url_encode() {
+  printf '%s' "$1" | jq -sRr @uri
+}
+
 # Run an API call. Prints response body on success, returns 0.
 # On HTTP >= 400, prints the response body to stderr and returns 1.
 api_call() {
@@ -84,10 +91,10 @@ api_call() {
     -H "Content-Type: application/json" \
     "${body_args[@]}" \
     "$url" 2>/dev/null) || {
-    err "HTTP $status from $method $url"
+    err "HTTP ${status:-?} from $method $url"
     err "Request body: $body"
     err "Response body:"
-    sed 's/^/  /' "$tmp" >&2
+    [ -s "$tmp" ] && sed 's/^/  /' "$tmp" >&2 || echo "  (empty)" >&2
     rm -f "$tmp"
     return 1
   }
@@ -97,8 +104,10 @@ api_call() {
 
 find_existing_workflow_id() {
   local name="$1"
+  local encoded
+  encoded=$(url_encode "$name")
   local response
-  response=$(api_call GET "${API_BASE}/organizations/${ORG}/workflows/?query=${name}") || return 0
+  response=$(api_call GET "${API_BASE}/organizations/${ORG}/workflows/?query=${encoded}") || return 0
   echo "$response" | jq -r --arg name "$name" \
     '.[] | select(.name == $name) | .id' | head -n1
 }
@@ -177,8 +186,9 @@ for i in $(seq 0 $((COUNT - 1))); do
         SLUGS=$(echo "$ALERT" | jq -r '.detector_slugs[]')
         RESOLVED=()
         for slug in $SLUGS; do
+          encoded=$(url_encode "$slug")
           RESP=$(curl -sS -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
-            "${API_BASE}/organizations/${ORG}/monitors/?query=${slug}" 2>/dev/null) || {
+            "${API_BASE}/organizations/${ORG}/monitors/?query=${encoded}" 2>/dev/null) || {
             err "Monitor lookup failed for '$slug'"
             continue
           }

--- a/scripts/provision-sentry-alerts.sh
+++ b/scripts/provision-sentry-alerts.sh
@@ -145,7 +145,10 @@ create_or_update_detector() {
   local body="$2"
   local id="${3:-}"
   local method=POST
-  local url="${API_BASE}/organizations/${ORG}/projects/${project}/detectors/"
+  # Detectors are organization-scoped. The project lives in the body
+  # (`projectId`), not the URL — `/projects/${project}/detectors/` returns
+  # 200 on POST but 404 on PUT, so the update path always failed.
+  local url="${API_BASE}/organizations/${ORG}/detectors/"
   if [ -n "$id" ]; then
     method=PUT
     url="${url}${id}/"

--- a/scripts/provision-sentry-alerts.sh
+++ b/scripts/provision-sentry-alerts.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Provisions Sentry alert rules from sentry/alerts.json via the Sentry REST API.
-# Idempotent: existing alerts with the same name are skipped.
+# Idempotent: existing alerts with the same name are updated in place. Detectors
+# are matched by the workflow's detectorIds[0]. Cron monitor detectors are
+# re-resolved by slug on every run.
 #
 # Usage:
 #   SENTRY_API_TOKEN=sntrys_... ./scripts/provision-sentry-alerts.sh
@@ -16,6 +18,7 @@
 #   - jq "Cannot iterate over null" when detector_slugs is missing
 #   - missing config.frequency in workflows
 #   - cron alert workflows tried to send triggers alongside detectorIds
+#   - v2: alerts were create-only; edited spec never propagated. now uses PUT.
 set -euo pipefail
 
 ORG="kaneo"
@@ -106,12 +109,56 @@ list_monitors() {
   api_call GET "${API_BASE}/organizations/${ORG}/monitors/"
 }
 
-find_existing_workflow_id() {
+find_existing_workflow() {
+  # Returns the full workflow object as compact JSON, or empty string.
   local name="$1"
   local response
   response=$(list_workflows) || return 0
-  echo "$response" | jq -r --arg name "$name" \
-    '.[] | select(.name == $name) | .id' | head -n1
+  echo "$response" | jq -c --arg name "$name" \
+    '.[] | select(.name == $name)' | head -n1
+}
+
+# ---- POST/PUT helpers ----
+# POST if id is empty, PUT otherwise. Echoes the new/updated ID.
+create_or_update_workflow() {
+  local body="$1"
+  local id="${2:-}"
+  local method=POST
+  local url="${API_BASE}/organizations/${ORG}/workflows/"
+  if [ -n "$id" ]; then
+    method=PUT
+    url="${url}${id}/"
+  fi
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "[dry-run] would $method $url" >&2
+    echo "$body" | jq . >&2
+    echo "stub-id"
+    return 0
+  fi
+  local resp
+  resp=$(api_call "$method" "$url" "$body") || return 1
+  echo "$resp" | jq -r '.id // empty'
+}
+
+create_or_update_detector() {
+  local project="$1"
+  local body="$2"
+  local id="${3:-}"
+  local method=POST
+  local url="${API_BASE}/organizations/${ORG}/projects/${project}/detectors/"
+  if [ -n "$id" ]; then
+    method=PUT
+    url="${url}${id}/"
+  fi
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "[dry-run] would $method $url" >&2
+    echo "$body" | jq . >&2
+    echo "stub-detector-id"
+    return 0
+  fi
+  local resp
+  resp=$(api_call "$method" "$url" "$body") || return 1
+  echo "$resp" | jq -r '.id // empty'
 }
 
 # ---- input validation ----
@@ -129,7 +176,6 @@ jq -r '.alerts[] | .name | select(. == null or . == "")' "$ALERTS_FILE" \
 
 # ---- main loop ----
 APPLIED=0
-SKIPPED=0
 ERRORS=0
 
 for i in $(seq 0 $((COUNT - 1))); do
@@ -140,15 +186,18 @@ for i in $(seq 0 $((COUNT - 1))); do
   echo
   info "==== $NAME ($KIND) ===="
 
-  if existing=$(find_existing_workflow_id "$NAME") && [ -n "$existing" ]; then
-    ok "Workflow '$NAME' already exists (id $existing); skipping"
-    SKIPPED=$((SKIPPED + 1))
-    continue
+  # Find existing workflow (full object, or empty string). The script
+  # discriminates create vs update on whether this returns a value.
+  EXISTING=$(find_existing_workflow "$NAME")
+  EXISTING_ID=""
+  if [ -n "$EXISTING" ]; then
+    EXISTING_ID=$(echo "$EXISTING" | jq -r '.id // empty')
+    info "  existing workflow id $EXISTING_ID \u2014 will update"
   fi
 
   case "$KIND" in
     issue)
-      # Build the workflow payload. Drop empty actions/actionFilters — the
+      # Build the workflow payload. Drop empty actions/actionFilters \u2014 the
       # api rejects workflows with empty arrays in those fields.
       WORKFLOW=$(echo "$ALERT" | jq --arg org "$ORG" --argjson freq "$DEFAULT_FREQUENCY_MIN" '
         .workflow
@@ -159,19 +208,14 @@ for i in $(seq 0 $((COUNT - 1))); do
         | if (.actionFilters // []) == [] then del(.actionFilters) else . end
       ')
 
-      if [ "$DRY_RUN" = "1" ]; then
-        echo "$WORKFLOW" | jq .
-        APPLIED=$((APPLIED + 1))
-        continue
-      fi
-
-      if RESP=$(api_call POST "${API_BASE}/organizations/${ORG}/workflows/" "$WORKFLOW") \
-        && NEW_ID=$(echo "$RESP" | jq -r '.id // empty') && [ -n "$NEW_ID" ]; then
-        ok "Created workflow $NEW_ID"
+      if NEW_ID=$(create_or_update_workflow "$WORKFLOW" "$EXISTING_ID") && [ -n "$NEW_ID" ]; then
+        if [ -n "$EXISTING_ID" ]; then
+          ok "Updated workflow $NEW_ID"
+        else
+          ok "Created workflow $NEW_ID"
+        fi
         APPLIED=$((APPLIED + 1))
       else
-        # RESP is the error body at this point (api_call already printed a
-        # detailed error). Just count it.
         ERRORS=$((ERRORS + 1))
       fi
       ;;
@@ -203,7 +247,7 @@ for i in $(seq 0 $((COUNT - 1))); do
           fi
         done
         if [ "${#RESOLVED[@]}" -eq 0 ]; then
-          err "No cron monitors resolved for '$NAME'. Skipping workflow creation."
+          err "No cron monitors resolved for '$NAME'. Skipping."
           ERRORS=$((ERRORS + 1))
           continue
         fi
@@ -216,17 +260,23 @@ for i in $(seq 0 $((COUNT - 1))); do
           .detector + {organizationId: $org, projectId: $project}
         ')
 
-        if [ "$DRY_RUN" = "1" ]; then
-          echo "[dry-run] would POST detector:"; echo "$DETECTOR" | jq .
-        else
-          if RESP=$(api_call POST "${API_BASE}/organizations/${ORG}/projects/${PROJECT}/detectors/" "$DETECTOR") \
-            && NEW_DET_ID=$(echo "$RESP" | jq -r '.id // empty') && [ -n "$NEW_DET_ID" ]; then
-            ok "Created detector $NEW_DET_ID"
-            DETECTOR_IDS=$(echo "$DETECTOR_IDS" | jq --arg id "$NEW_DET_ID" '. + [$id]')
+        # On update, find the existing detector id from the workflow's
+        # detectorIds. On create, it is empty.
+        EXISTING_DET_ID=""
+        if [ -n "$EXISTING_ID" ]; then
+          EXISTING_DET_ID=$(echo "$EXISTING" | jq -r '.detectorIds[0] // empty')
+        fi
+
+        if NEW_DET_ID=$(create_or_update_detector "$PROJECT" "$DETECTOR" "$EXISTING_DET_ID") && [ -n "$NEW_DET_ID" ]; then
+          if [ -n "$EXISTING_DET_ID" ]; then
+            ok "Updated detector $NEW_DET_ID"
           else
-            ERRORS=$((ERRORS + 1))
-            continue
+            ok "Created detector $NEW_DET_ID"
           fi
+          DETECTOR_IDS=$(echo "$DETECTOR_IDS" | jq --arg id "$NEW_DET_ID" '. + [$id]')
+        else
+          ERRORS=$((ERRORS + 1))
+          continue
         fi
       fi
 
@@ -243,15 +293,12 @@ for i in $(seq 0 $((COUNT - 1))); do
         }
       ')
 
-      if [ "$DRY_RUN" = "1" ]; then
-        echo "[dry-run] would POST workflow:"; echo "$WORKFLOW" | jq .
-        APPLIED=$((APPLIED + 1))
-        continue
-      fi
-
-      if RESP=$(api_call POST "${API_BASE}/organizations/${ORG}/workflows/" "$WORKFLOW") \
-        && NEW_ID=$(echo "$RESP" | jq -r '.id // empty') && [ -n "$NEW_ID" ]; then
-        ok "Created workflow $NEW_ID"
+      if NEW_ID=$(create_or_update_workflow "$WORKFLOW" "$EXISTING_ID") && [ -n "$NEW_ID" ]; then
+        if [ -n "$EXISTING_ID" ]; then
+          ok "Updated workflow $NEW_ID"
+        else
+          ok "Created workflow $NEW_ID"
+        fi
         APPLIED=$((APPLIED + 1))
       else
         ERRORS=$((ERRORS + 1))
@@ -267,7 +314,7 @@ done
 
 echo
 echo "-----------------------------------------------------------"
-info "Done: $APPLIED created, $SKIPPED skipped, $ERRORS failed"
+info "Done: $APPLIED applied (created or updated), $ERRORS failed"
 [ "$DRY_RUN" = "1" ] && info "Re-run without --dry-run to apply"
 [ "$ERRORS" -gt 0 ] && exit 1
 exit 0

--- a/scripts/provision-sentry-alerts.sh
+++ b/scripts/provision-sentry-alerts.sh
@@ -6,13 +6,22 @@
 #   SENTRY_API_TOKEN=sntrys_... ./scripts/provision-sentry-alerts.sh
 #   SENTRY_API_TOKEN=... ./scripts/provision-sentry-alerts.sh --dry-run
 #
-# The token needs one of: alerts:write, org:admin, org:write, or org:manager scopes.
+# The token needs scope: org:write (or alerts:write).
 # Generate at: https://sentry.io/settings/account/api/auth-tokens/
+#
+# Bugs fixed vs v1:
+#   - local + $(...) was swallowing curl failures (subshell + set -e don't mix)
+#   - hidden error response body
+#   - false success on empty response
+#   - jq "Cannot iterate over null" when detector_slugs is missing
+#   - missing config.frequency in workflows
+#   - cron alert workflows tried to send triggers alongside detectorIds
 set -euo pipefail
 
 ORG="kaneo"
 REGION="de"
-API_BASE="https://${REGION}.sentry.io/api/0"
+API_BASE="${SENTRY_API_BASE:-https://${REGION}.sentry.io/api/0}"
+DEFAULT_FREQUENCY_MIN=30
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_DIR="$(dirname "$SCRIPT_DIR")"
@@ -23,219 +32,231 @@ if [ "${1:-}" = "--dry-run" ] || [ "${SENTRY_DRY_RUN:-0}" = "1" ]; then
   DRY_RUN=1
 fi
 
-info()   { printf '\033[1;34m[info]\033[0m %s\n' "$*"; }
-warn()   { printf '\033[1;33m[warn]\033[0m %s\n' "$*" >&2; }
-error()  { printf '\033[1;31m[err]\033[0m  %s\n' "$*" >&2; }
-ok()     { printf '\033[1;32m[ok]\033[0m   %s\n' "$*"; }
+# ---- output helpers ----
+if [ -t 1 ]; then
+  C_RESET=$'\033[0m'
+  C_INFO=$'\033[1;34m'
+  C_OK=$'\033[1;32m'
+  C_WARN=$'\033[1;33m'
+  C_ERR=$'\033[1;31m'
+else
+  C_RESET=""; C_INFO=""; C_OK=""; C_WARN=""; C_ERR=""
+fi
+info() { printf '%s[info]%s %s\n' "$C_INFO" "$C_RESET" "$*"; }
+ok()   { printf '%s[ok]%s   %s\n' "$C_OK"   "$C_RESET" "$*"; }
+warn() { printf '%s[warn]%s %s\n' "$C_WARN" "$C_RESET" "$*" >&2; }
+err()  { printf '%s[err]%s  %s\n' "$C_ERR"  "$C_RESET" "$*" >&2; }
 
+# ---- prerequisites ----
 if [ -z "${SENTRY_API_TOKEN:-}" ]; then
-  error "SENTRY_API_TOKEN is not set. Generate one at https://sentry.io/settings/account/api/auth-tokens/ with alerts:write scope."
+  err "SENTRY_API_TOKEN is not set. Generate at https://sentry.io/settings/account/api/auth-tokens/ (scope: org:write)."
   exit 1
 fi
-
 if [ ! -f "$ALERTS_FILE" ]; then
-  error "Alerts config not found at $ALERTS_FILE"
+  err "Alerts config not found at $ALERTS_FILE"
   exit 1
 fi
+command -v jq >/dev/null || { err "jq is required"; exit 1; }
 
-command -v jq >/dev/null || { error "jq is required"; exit 1; }
+# ---- API helpers ----
+# Run an API call. Prints response body on success, returns 0.
+# On HTTP >= 400, prints the response body to stderr and returns 1.
+api_call() {
+  local method="$1"
+  local url="$2"
+  local body="${3:-}"
 
-# Resolve monitor slug -> numeric ID via Sentry API.
-# Returns 1 if not found.
-resolve_monitor_id() {
-  local slug="$1"
-  local response
-  response=$(curl -fsSL \
+  local body_args=()
+  if [ -n "$body" ]; then
+    body_args+=(-d "$body")
+  fi
+
+  local tmp
+  tmp=$(mktemp)
+  local status
+  # --fail-with-body: exit non-zero on HTTP error, but still write the body
+  # to stdout (curl 7.76+). Lets us capture error responses inline.
+  status=$(curl -sS --fail-with-body \
+    -o "$tmp" \
+    -w "%{http_code}" \
+    -X "$method" \
     -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
-    "${API_BASE}/organizations/${ORG}/monitors/?query=${slug}" 2>/dev/null) || return 1
-  echo "$response" | jq -r --arg slug "$slug" \
-    '.[] | select(.slug == $slug) | .id' | head -n1
+    -H "Content-Type: application/json" \
+    "${body_args[@]}" \
+    "$url" 2>/dev/null) || {
+    err "HTTP $status from $method $url"
+    err "Request body: $body"
+    err "Response body:"
+    sed 's/^/  /' "$tmp" >&2
+    rm -f "$tmp"
+    return 1
+  }
+  cat "$tmp"
+  rm -f "$tmp"
 }
 
-# Check whether an alert with this name already exists.
-# Returns the ID if found, empty string otherwise.
-find_existing_alert() {
+find_existing_workflow_id() {
   local name="$1"
   local response
-  response=$(curl -fsSL \
-    -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
-    "${API_BASE}/organizations/${ORG}/workflows/?query=${name}" 2>/dev/null) || return 1
+  response=$(api_call GET "${API_BASE}/organizations/${ORG}/workflows/?query=${name}") || return 0
   echo "$response" | jq -r --arg name "$name" \
     '.[] | select(.name == $name) | .id' | head -n1
 }
 
-# Create a metric detector (used by metric alerts). Returns the new ID.
-# Args: detector JSON (without organizationId / projectId).
-create_detector() {
-  local project="$1"
-  local body="$2"
-  local response
-  response=$(curl -fsSL \
-    -X POST \
-    -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
-    -H "Content-Type: application/json" \
-    -d "$body" \
-    "${API_BASE}/organizations/${ORG}/projects/${project}/detectors/")
-  echo "$response" | jq -r '.id'
-}
+# ---- input validation ----
+COUNT=$(jq '.alerts | length' "$ALERTS_FILE")
+info "Reading $COUNT alert(s) from $ALERTS_FILE"
+[ "$DRY_RUN" = "1" ] && info "DRY RUN: no changes will be made"
+info "Organization: $ORG, Region: $REGION"
 
-# Create a workflow (alert rule). Returns the new ID.
-create_workflow() {
-  local body="$1"
-  local response
-  response=$(curl -fsSL \
-    -X POST \
-    -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
-    -H "Content-Type: application/json" \
-    -d "$body" \
-    "${API_BASE}/organizations/${ORG}/workflows/")
-  echo "$response" | jq -r '.id'
-}
+# Validate every alert has a name up front so we don't half-apply.
+jq -r '.alerts[] | .name | select(. == null or . == "")' "$ALERTS_FILE" \
+  | grep -q . && {
+    err "One or more alerts in $ALERTS_FILE have a missing name. Fix and retry."
+    exit 1
+  }
 
-# Wire a detector into a workflow (POST detector_ids to the workflow).
-attach_detector_to_workflow() {
-  local workflow_id="$1"
-  local detector_id="$2"
-  curl -fsSL \
-    -X PUT \
-    -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
-    -H "Content-Type: application/json" \
-    -d "{\"detectorIds\": [\"${detector_id}\"]}" \
-    "${API_BASE}/workflows/${workflow_id}/detector/${detector_id}" >/dev/null
-}
+# ---- main loop ----
+APPLIED=0
+SKIPPED=0
+ERRORS=0
 
-# Apply a single alert entry from the JSON config.
-apply_alert() {
-  local alert_json="$1"
-  local name type projects workflow_json
+for i in $(seq 0 $((COUNT - 1))); do
+  ALERT=$(jq -c ".alerts[$i]" "$ALERTS_FILE")
+  NAME=$(echo "$ALERT" | jq -r '.name')
+  KIND=$(echo "$ALERT" | jq -r '.kind')
 
-  name=$(echo "$alert_json" | jq -r '.name')
-  type=$(echo "$alert_json" | jq -r '.kind')
+  echo
+  info "==== $NAME ($KIND) ===="
 
-  if [ -z "$name" ] || [ "$name" = "null" ]; then
-    error "Alert entry missing name; skipping"
-    return 0
+  if existing=$(find_existing_workflow_id "$NAME") && [ -n "$existing" ]; then
+    ok "Workflow '$NAME' already exists (id $existing); skipping"
+    SKIPPED=$((SKIPPED + 1))
+    continue
   fi
 
-  local existing
-  existing=$(find_existing_alert "$name" || true)
-  if [ -n "$existing" ]; then
-    ok "Alert '$name' already exists (id $existing); skipping"
-    return 0
-  fi
-
-  info "Creating alert: $name ($type)"
-
-  case "$type" in
+  case "$KIND" in
     issue)
-      projects=$(echo "$alert_json" | jq -r '.projects | join(",")')
-      workflow_json=$(echo "$alert_json" | jq --arg org "$ORG" --arg projects "$projects" '
-        .workflow + {
-          organizationId: $org,
-          triggers: {
-            logicType: .workflow.triggers.logicType,
-            conditions: .workflow.triggers.conditions,
-            actions: []
-          }
-        }
+      # Build the workflow payload. Drop empty actions/actionFilters — the
+      # api rejects workflows with empty arrays in those fields.
+      WORKFLOW=$(echo "$ALERT" | jq --arg org "$ORG" --argjson freq "$DEFAULT_FREQUENCY_MIN" '
+        .workflow
+        | .organizationId = $org
+        | .config = ((.config // {}) + {frequency: $freq})
+        | if (.triggers // {}).actions == [] then del(.triggers.actions) else . end
+        | if (.triggers // {}).conditions | not then del(.triggers) else . end
+        | if (.actionFilters // []) == [] then del(.actionFilters) else . end
       ')
+
       if [ "$DRY_RUN" = "1" ]; then
-        echo "$workflow_json" | jq .
+        echo "$WORKFLOW" | jq .
+        APPLIED=$((APPLIED + 1))
+        continue
+      fi
+
+      if RESP=$(api_call POST "${API_BASE}/organizations/${ORG}/workflows/" "$WORKFLOW") \
+        && NEW_ID=$(echo "$RESP" | jq -r '.id // empty') && [ -n "$NEW_ID" ]; then
+        ok "Created workflow $NEW_ID"
+        APPLIED=$((APPLIED + 1))
       else
-        local new_id
-        new_id=$(create_workflow "$workflow_json")
-        ok "Created workflow $new_id"
+        # RESP is the error body at this point (api_call already printed a
+        # detailed error). Just count it.
+        ERRORS=$((ERRORS + 1))
       fi
       ;;
 
     metric)
-      local detector_id
-      detector_id=$(echo "$alert_json" | jq -r '.detector.id // ""')
+      # Detect whether the alert references cron monitor slugs (detectors
+      # auto-created by Sentry.captureCheckIn) versus inline detector defs.
+      HAS_SLUGS=$(echo "$ALERT" | jq -r '.detector_slugs | length > 0')
+      HAS_INLINE_DETECTOR=$(echo "$ALERT" | jq -r '.detector | type == "object"')
 
-      if [ -z "$detector_id" ] || [ "$detector_id" = "null" ]; then
-        # Try resolving from detector_slugs (cron check-in monitors).
-        local slugs
-        slugs=$(echo "$alert_json" | jq -r '.detector_slugs | join(" ")')
-        local resolved_ids=()
+      DETECTOR_IDS='[]'
 
-        for slug in $slugs; do
-          local id
-          id=$(resolve_monitor_id "$slug" || true)
-          if [ -z "$id" ]; then
-            warn "  cron monitor '$slug' not found in Sentry yet. Have the cron jobs run at least once?"
+      if [ "$HAS_SLUGS" = "true" ]; then
+        SLUGS=$(echo "$ALERT" | jq -r '.detector_slugs[]')
+        RESOLVED=()
+        for slug in $SLUGS; do
+          RESP=$(curl -sS -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
+            "${API_BASE}/organizations/${ORG}/monitors/?query=${slug}" 2>/dev/null) || {
+            err "Monitor lookup failed for '$slug'"
             continue
+          }
+          id=$(echo "$RESP" | jq -r --arg slug "$slug" \
+            '.[] | select(.slug == $slug) | .id' | head -n1)
+          if [ -z "$id" ] || [ "$id" = "null" ]; then
+            warn "Cron monitor '$slug' not found in Sentry yet. Has the cron run at least once?"
+          else
+            info "  resolved '$slug' -> id $id"
+            RESOLVED+=("$id")
           fi
-          resolved_ids+=("$id")
-          info "  resolved monitor '$slug' -> id $id"
         done
-        detector_id=$(echo "${resolved_ids[@]:-}" | tr ' ' '\n' | head -n1)
+        if [ "${#RESOLVED[@]}" -eq 0 ]; then
+          err "No cron monitors resolved for '$NAME'. Skipping workflow creation."
+          ERRORS=$((ERRORS + 1))
+          continue
+        fi
+        DETECTOR_IDS=$(printf '%s\n' "${RESOLVED[@]}" | jq -R . | jq -s .)
       fi
 
-      # Create the detector (if we have a body for it).
-      local detector_body
-      detector_body=$(echo "$alert_json" | jq -r '.detector // empty')
-      if [ -n "$detector_body" ]; then
-        local project
-        project=$(echo "$alert_json" | jq -r '.project')
-        detector_body=$(echo "$detector_body" | jq --arg org "$ORG" --arg project "$project" '
-          . + {organizationId: $org, projectId: $project}
+      if [ "$HAS_INLINE_DETECTOR" = "true" ]; then
+        PROJECT=$(echo "$ALERT" | jq -r '.project')
+        DETECTOR=$(echo "$ALERT" | jq --arg org "$ORG" --arg project "$PROJECT" '
+          .detector + {organizationId: $org, projectId: $project}
         ')
+
         if [ "$DRY_RUN" = "1" ]; then
-          echo "$detector_body" | jq .
+          echo "[dry-run] would POST detector:"; echo "$DETECTOR" | jq .
         else
-          local new_detector_id
-          new_detector_id=$(create_detector "$project" "$detector_body")
-          ok "Created detector $new_detector_id"
-          detector_id="$new_detector_id"
+          if RESP=$(api_call POST "${API_BASE}/organizations/${ORG}/projects/${PROJECT}/detectors/" "$DETECTOR") \
+            && NEW_DET_ID=$(echo "$RESP" | jq -r '.id // empty') && [ -n "$NEW_DET_ID" ]; then
+            ok "Created detector $NEW_DET_ID"
+            DETECTOR_IDS=$(echo "$DETECTOR_IDS" | jq --arg id "$NEW_DET_ID" '. + [$id]')
+          else
+            ERRORS=$((ERRORS + 1))
+            continue
+          fi
         fi
       fi
 
-      # Create the workflow.
-      local workflow_body
-      workflow_body=$(echo "$alert_json" | jq --arg org "$ORG" --arg det "$detector_id" '
-        .workflow + {
+      # Workflow for metric alerts: detector-only, no triggers. The detector
+      # itself fires when its condition matches.
+      WORKFLOW=$(echo "$ALERT" | jq --arg org "$ORG" --argjson freq "$DEFAULT_FREQUENCY_MIN" \
+        --argjson detectors "$DETECTOR_IDS" '
+        {
+          name: .workflow.name,
+          enabled: (.workflow.enabled // true),
           organizationId: $org,
-          detectorIds: (if $det != "" then [$det] else [] end)
+          config: ((.workflow.config // {}) + {frequency: $freq}),
+          detectorIds: $detectors
         }
       ')
+
       if [ "$DRY_RUN" = "1" ]; then
-        echo "$workflow_body" | jq .
+        echo "[dry-run] would POST workflow:"; echo "$WORKFLOW" | jq .
+        APPLIED=$((APPLIED + 1))
+        continue
+      fi
+
+      if RESP=$(api_call POST "${API_BASE}/organizations/${ORG}/workflows/" "$WORKFLOW") \
+        && NEW_ID=$(echo "$RESP" | jq -r '.id // empty') && [ -n "$NEW_ID" ]; then
+        ok "Created workflow $NEW_ID"
+        APPLIED=$((APPLIED + 1))
       else
-        local new_workflow_id
-        new_workflow_id=$(create_workflow "$workflow_body")
-        ok "Created workflow $new_workflow_id"
+        ERRORS=$((ERRORS + 1))
       fi
       ;;
 
     *)
-      error "Unknown alert kind '$type' for '$name'; skipping"
-      return 0
+      err "Unknown kind '$KIND' for '$NAME'"
+      ERRORS=$((ERRORS + 1))
       ;;
   esac
-}
-
-# ---- main ----
-info "Reading alerts from $ALERTS_FILE"
-[ "$DRY_RUN" = "1" ] && info "DRY RUN: no changes will be made"
-info "Organization: $ORG, Region: $REGION"
-
-count=$(jq '.alerts | length' "$ALERTS_FILE")
-info "Found $count alert(s) to process"
-
-OK=0
-SKIPPED=0
-ERRORED=0
-
-for i in $(seq 0 $((count - 1))); do
-  ALERT=$(jq -c ".alerts[$i]" "$ALERTS_FILE")
-  if apply_alert "$ALERT"; then
-    OK=$((OK + 1))
-  else
-    ERRORED=$((ERRORED + 1))
-  fi
 done
 
-echo ""
-info "Done: $OK created/skipped, $ERRORED errors"
+echo
+echo "-----------------------------------------------------------"
+info "Done: $APPLIED created, $SKIPPED skipped, $ERRORS failed"
 [ "$DRY_RUN" = "1" ] && info "Re-run without --dry-run to apply"
-info "Configure per-alert notifications in Sentry: Settings > Alerts > [alert name] > Actions"
+[ "$ERRORS" -gt 0 ] && exit 1
+exit 0

--- a/scripts/provision-sentry-alerts.sh
+++ b/scripts/provision-sentry-alerts.sh
@@ -328,7 +328,15 @@ for i in $(seq 0 $((COUNT - 1))); do
           EXISTING_DET_ID=$(echo "$EXISTING" | jq -r '.detectorIds[0] // empty')
         fi
         if [ -z "$EXISTING_DET_ID" ]; then
-          EXISTING_DET_ID=$(find_detector_by_name "$DETECTOR_NAME" || true)
+          # On a request failure, skip the alert rather than silently letting
+          # an empty ID fall through to create_or_update_detector's POST
+          # path. A successful lookup that finds no match still leaves
+          # EXISTING_DET_ID empty; that's the normal "create new" path.
+          if ! EXISTING_DET_ID=$(find_detector_by_name "$DETECTOR_NAME"); then
+            err "  failed to look up existing detector '$DETECTOR_NAME' \u2014 skipping"
+            ERRORS=$((ERRORS + 1))
+            continue
+          fi
         fi
 
         if NEW_DET_ID=$(create_or_update_detector "$DETECTOR" "$EXISTING_DET_ID") && [ -n "$NEW_DET_ID" ]; then

--- a/scripts/provision-sentry-dashboards.sh
+++ b/scripts/provision-sentry-dashboards.sh
@@ -90,9 +90,17 @@ list_dashboards() {
 }
 
 # Find existing dashboard by title. Returns the full dashboard object.
+# Returns non-zero if the list call itself failed (network, auth, etc.) —
+# callers must distinguish "no match" from "lookup failed" so they can
+# skip the dashboard rather than silently create a duplicate.
 find_dashboard_by_title() {
   local title="$1"
-  list_dashboards | jq -c --arg title "$title" \
+  local response
+  # Capture the list output so its exit status is preserved. Without this,
+  # a failed pipeline (list_dashboards | jq ...) would always look like
+  # "no match" because the jq side swallows the api_call failure.
+  response=$(list_dashboards) || return 1
+  echo "$response" | jq -c --arg title "$title" \
     '.[] | select(.title == $title)' | head -n1
 }
 
@@ -140,7 +148,11 @@ for i in $(seq 0 $((COUNT - 1))); do
   echo
   info "==== $TITLE ===="
 
-  EXISTING=$(find_dashboard_by_title "$TITLE")
+  if ! EXISTING=$(find_dashboard_by_title "$TITLE"); then
+    err "  failed to look up existing dashboard \u2014 skipping"
+    ERRORS=$((ERRORS + 1))
+    continue
+  fi
   EXISTING_ID=""
   if [ -n "$EXISTING" ]; then
     EXISTING_ID=$(echo "$EXISTING" | jq -r '.id // empty')
@@ -161,6 +173,7 @@ for i in $(seq 0 $((COUNT - 1))); do
     BODY=$(echo "$DASHBOARD" | jq --argjson existing "$EXISTING" '
       {
         title:          $existing.title,
+        description:    ($existing.description // .description // null),
         widgets:        .widgets
                         | map(. + {datasetSource: "user"}
                           + (if .displayType == "table" then {} else {limit: 10} end))
@@ -181,6 +194,7 @@ for i in $(seq 0 $((COUNT - 1))); do
     BODY=$(echo "$DASHBOARD" | jq '
       {
         title:          .title,
+        description:    .description,
         widgets:        .widgets
                         | map(. + {datasetSource: "user"}
                           + (if .displayType == "table" then {} else {limit: 10} end))

--- a/scripts/provision-sentry-dashboards.sh
+++ b/scripts/provision-sentry-dashboards.sh
@@ -151,15 +151,19 @@ for i in $(seq 0 $((COUNT - 1))); do
   # dashboard so user-set filters (projects, environment, period, etc.)
   # are preserved. On create, set sensible defaults.
   #
-  # The Sentry API requires datasetSource ("user") on user-defined widgets
-  # AND conditions ("") on every query. Inject these here so the spec
-  # doesn't have to repeat them.
+  # The Sentry API requires several fields the spec doesn't repeat:
+  # - datasetSource: "user" on every widget (user-defined dashboards)
+  # - conditions: "" on every query (default empty)
+  # - limit: 10 on widgets that render time series (line/bar/area). The
+  #   API rejects widgets without it AND rejects values above 10. Tables
+  #   accept it but don't require it, so we skip them.
   if [ -n "$EXISTING_ID" ]; then
     BODY=$(echo "$DASHBOARD" | jq --argjson existing "$EXISTING" '
       {
         title:          $existing.title,
         widgets:        .widgets
-                        | map(. + {datasetSource: "user"})
+                        | map(. + {datasetSource: "user"}
+                          + (if .displayType == "table" then {} else {limit: 10} end))
                         | map(.queries = (.queries
                             | map(. + {conditions: ""}))),
         projects:       ($existing.projects       // []),
@@ -178,7 +182,8 @@ for i in $(seq 0 $((COUNT - 1))); do
       {
         title:          .title,
         widgets:        .widgets
-                        | map(. + {datasetSource: "user"})
+                        | map(. + {datasetSource: "user"}
+                          + (if .displayType == "table" then {} else {limit: 10} end))
                         | map(.queries = (.queries
                             | map(. + {conditions: ""}))),
         projects:       [],

--- a/scripts/provision-sentry-dashboards.sh
+++ b/scripts/provision-sentry-dashboards.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Provisions Sentry dashboards from sentry/dashboards.json via the Sentry REST API.
+# Idempotent: existing dashboards with the same title are updated in place.
+# Preserves any filter settings (projects, environment, period, etc.) the
+# maintainer has set in the Sentry UI by reading the current dashboard first
+# and only swapping the widgets array.
+#
+# Usage:
+#   SENTRY_API_TOKEN=sntrys_... ./scripts/provision-sentry-dashboards.sh
+#   SENTRY_API_TOKEN=... ./scripts/provision-sentry-dashboards.sh --dry-run
+#
+# The token needs scope: org:write.
+# Generate at: https://sentry.io/settings/account/api/auth-tokens/
+set -euo pipefail
+
+ORG="kaneo"
+REGION="de"
+API_BASE="${SENTRY_API_BASE:-https://${REGION}.sentry.io/api/0}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="$(dirname "$SCRIPT_DIR")"
+DASHBOARDS_FILE="${SENTRY_DASHBOARDS_FILE:-${CONFIG_DIR}/sentry/dashboards.json}"
+
+DRY_RUN=0
+if [ "${1:-}" = "--dry-run" ] || [ "${SENTRY_DRY_RUN:-0}" = "1" ]; then
+  DRY_RUN=1
+fi
+
+# ---- output helpers ----
+if [ -t 1 ]; then
+  C_RESET=$'\033[0m'
+  C_INFO=$'\033[1;34m'
+  C_OK=$'\033[1;32m'
+  C_WARN=$'\033[1;33m'
+  C_ERR=$'\033[1;31m'
+else
+  C_RESET=""; C_INFO=""; C_OK=""; C_WARN=""; C_ERR=""
+fi
+info() { printf '%s[info]%s %s\n' "$C_INFO" "$C_RESET" "$*"; }
+ok()   { printf '%s[ok]%s   %s\n' "$C_OK"   "$C_RESET" "$*"; }
+warn() { printf '%s[warn]%s %s\n' "$C_WARN" "$C_RESET" "$*" >&2; }
+err()  { printf '%s[err]%s  %s\n' "$C_ERR"  "$C_RESET" "$*" >&2; }
+
+# ---- prerequisites ----
+if [ -z "${SENTRY_API_TOKEN:-}" ]; then
+  err "SENTRY_API_TOKEN is not set. Generate at https://sentry.io/settings/account/api/auth-tokens/ (scope: org:write)."
+  exit 1
+fi
+if [ ! -f "$DASHBOARDS_FILE" ]; then
+  err "Dashboards config not found at $DASHBOARDS_FILE"
+  exit 1
+fi
+command -v jq >/dev/null || { err "jq is required"; exit 1; }
+
+# ---- API helpers ----
+api_call() {
+  local method="$1"
+  local url="$2"
+  local body="${3:-}"
+
+  local body_args=()
+  if [ -n "$body" ]; then
+    body_args+=(-d "$body")
+  fi
+
+  local tmp
+  tmp=$(mktemp)
+  local status
+  status=$(curl -sS --fail-with-body \
+    -o "$tmp" \
+    -w "%{http_code}" \
+    -X "$method" \
+    -H "Authorization: Bearer ${SENTRY_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    "${body_args[@]}" \
+    "$url" 2>/dev/null) || {
+    err "HTTP ${status:-?} from $method $url"
+    err "Request body: $body"
+    err "Response body:"
+    [ -s "$tmp" ] && sed 's/^/  /' "$tmp" >&2 || echo "  (empty)" >&2
+    rm -f "$tmp"
+    return 1
+  }
+  cat "$tmp"
+  rm -f "$tmp"
+}
+
+list_dashboards() {
+  api_call GET "${API_BASE}/organizations/${ORG}/dashboards/"
+}
+
+# Find existing dashboard by title. Returns the full dashboard object.
+find_dashboard_by_title() {
+  local title="$1"
+  list_dashboards | jq -c --arg title "$title" \
+    '.[] | select(.title == $title)' | head -n1
+}
+
+# POST when id is empty, PUT otherwise. Echoes the new/updated ID.
+create_or_update_dashboard() {
+  local body="$1"
+  local id="${2:-}"
+  local method=POST
+  local url="${API_BASE}/organizations/${ORG}/dashboards/"
+  if [ -n "$id" ]; then
+    method=PUT
+    url="${url}${id}/"
+  fi
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "[dry-run] would $method $url" >&2
+    echo "$body" | jq . >&2
+    echo "stub-id"
+    return 0
+  fi
+  local resp
+  resp=$(api_call "$method" "$url" "$body") || return 1
+  echo "$resp" | jq -r '.id // empty'
+}
+
+# ---- input validation ----
+COUNT=$(jq '.dashboards | length' "$DASHBOARDS_FILE")
+info "Reading $COUNT dashboard(s) from $DASHBOARDS_FILE"
+[ "$DRY_RUN" = "1" ] && info "DRY RUN: no changes will be made"
+info "Organization: $ORG, Region: $REGION"
+
+jq -r '.dashboards[] | select(.title == null or .title == "")' "$DASHBOARDS_FILE" \
+  | grep -q . && {
+    err "One or more dashboards in $DASHBOARDS_FILE have a missing title. Fix and retry."
+    exit 1
+  }
+
+# ---- main loop ----
+APPLIED=0
+ERRORS=0
+
+for i in $(seq 0 $((COUNT - 1))); do
+  DASHBOARD=$(jq -c ".dashboards[$i]" "$DASHBOARDS_FILE")
+  TITLE=$(echo "$DASHBOARD" | jq -r '.title')
+
+  echo
+  info "==== $TITLE ===="
+
+  EXISTING=$(find_dashboard_by_title "$TITLE")
+  EXISTING_ID=""
+  if [ -n "$EXISTING" ]; then
+    EXISTING_ID=$(echo "$EXISTING" | jq -r '.id // empty')
+    info "  existing dashboard id $EXISTING_ID \u2014 will update widgets"
+  fi
+
+  # Build the request body. On update, merge widgets into the existing
+  # dashboard so user-set filters (projects, environment, period, etc.)
+  # are preserved. On create, set sensible defaults.
+  if [ -n "$EXISTING_ID" ]; then
+    BODY=$(echo "$DASHBOARD" | jq --argjson existing "$EXISTING" '
+      {
+        title:          $existing.title,
+        widgets:        .widgets,
+        projects:       ($existing.projects       // []),
+        environment:    ($existing.environment  // []),
+        period:         ($existing.period         // "24h"),
+        start:          ($existing.start          // null),
+        end:            ($existing.end            // null),
+        filters:        ($existing.filters        // {}),
+        utc:            ($existing.utc            // false),
+        permissions:    ($existing.permissions    // null),
+        is_favorited:   ($existing.is_favorited   // false)
+      }
+    ')
+  else
+    BODY=$(echo "$DASHBOARD" | jq '
+      {
+        title:          .title,
+        widgets:        .widgets,
+        projects:       [],
+        environment:    [],
+        period:         "24h",
+        filters:        {},
+        utc:            false
+      }
+    ')
+  fi
+
+  if NEW_ID=$(create_or_update_dashboard "$BODY" "$EXISTING_ID") && [ -n "$NEW_ID" ]; then
+    if [ -n "$EXISTING_ID" ]; then
+      ok "Updated dashboard $NEW_ID"
+    else
+      ok "Created dashboard $NEW_ID"
+    fi
+    APPLIED=$((APPLIED + 1))
+  else
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+echo
+echo "-----------------------------------------------------------"
+info "Done: $APPLIED applied (created or updated), $ERRORS failed"
+[ "$DRY_RUN" = "1" ] && info "Re-run without --dry-run to apply"
+[ "$ERRORS" -gt 0 ] && exit 1
+exit 0

--- a/scripts/provision-sentry-dashboards.sh
+++ b/scripts/provision-sentry-dashboards.sh
@@ -150,11 +150,18 @@ for i in $(seq 0 $((COUNT - 1))); do
   # Build the request body. On update, merge widgets into the existing
   # dashboard so user-set filters (projects, environment, period, etc.)
   # are preserved. On create, set sensible defaults.
+  #
+  # The Sentry API requires datasetSource ("user") on user-defined widgets
+  # AND conditions ("") on every query. Inject these here so the spec
+  # doesn't have to repeat them.
   if [ -n "$EXISTING_ID" ]; then
     BODY=$(echo "$DASHBOARD" | jq --argjson existing "$EXISTING" '
       {
         title:          $existing.title,
-        widgets:        .widgets,
+        widgets:        .widgets
+                        | map(. + {datasetSource: "user"})
+                        | map(.queries = (.queries
+                            | map(. + {conditions: ""}))),
         projects:       ($existing.projects       // []),
         environment:    ($existing.environment  // []),
         period:         ($existing.period         // "24h"),
@@ -170,7 +177,10 @@ for i in $(seq 0 $((COUNT - 1))); do
     BODY=$(echo "$DASHBOARD" | jq '
       {
         title:          .title,
-        widgets:        .widgets,
+        widgets:        .widgets
+                        | map(. + {datasetSource: "user"})
+                        | map(.queries = (.queries
+                            | map(. + {conditions: ""}))),
         projects:       [],
         environment:    [],
         period:         "24h",

--- a/scripts/provision-sentry-dashboards.sh
+++ b/scripts/provision-sentry-dashboards.sh
@@ -13,13 +13,27 @@
 # Generate at: https://sentry.io/settings/account/api/auth-tokens/
 set -euo pipefail
 
-ORG="kaneo"
-REGION="de"
-API_BASE="${SENTRY_API_BASE:-https://${REGION}.sentry.io/api/0}"
-
+# Resolve the spec file first so we can pull org/region/api_base from it.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_DIR="$(dirname "$SCRIPT_DIR")"
 DASHBOARDS_FILE="${SENTRY_DASHBOARDS_FILE:-${CONFIG_DIR}/sentry/dashboards.json}"
+
+# Read target organization, region, and API base from the spec. The README
+# documents the region field as the migration point — hardcoded values
+# below would silently route traffic to the wrong endpoint. SENTRY_API_BASE
+# remains an explicit override for ad-hoc runs against a different region.
+ORG=$(jq -er '.organization' "$DASHBOARDS_FILE") || {
+  err "missing or invalid \`organization\` in $DASHBOARDS_FILE"
+  exit 1
+}
+REGION=$(jq -er '.region' "$DASHBOARDS_FILE") || {
+  err "missing or invalid \`region\` in $DASHBOARDS_FILE"
+  exit 1
+}
+API_BASE="${SENTRY_API_BASE:-$(jq -er '.api_base' "$DASHBOARDS_FILE")}" || {
+  err "missing or invalid \`api_base\` in $DASHBOARDS_FILE (or unset SENTRY_API_BASE)"
+  exit 1
+}
 
 DRY_RUN=0
 if [ "${1:-}" = "--dry-run" ] || [ "${SENTRY_DRY_RUN:-0}" = "1" ]; then

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -1,0 +1,61 @@
+# Sentry
+
+This directory holds Sentry configuration as code, so the alert rules and dashboards that Kaneo depends on are version-controlled and reproducible.
+
+## What lives here
+
+- `alerts.json` — alert rules. Five rules cover first-seen issues, error spikes, missed cron check-ins, slow p95 latency, and MCP error rate. Both `kaneo-api` and `kaneo-web` are covered.
+
+## What's NOT here yet
+
+- Dashboards. The 10 prebuilt dashboards that Sentry ships are still empty (zero widgets each). Filling them in is the next monitoring item.
+- Cron monitor creation. These are auto-created the first time each cron job runs (`Sentry.captureCheckIn` from `apps/api/src/scheduler/index.ts`).
+
+## Applying the alerts
+
+### Option A: provisioning script (recommended)
+
+The script lives at `scripts/provision-sentry-alerts.sh`. It reads `sentry/alerts.json`, asks Sentry which rules already exist, and creates the missing ones. Idempotent — re-runs are safe.
+
+```bash
+# 1. Generate a Sentry auth token (admin scope)
+#    https://sentry.io/settings/account/api/auth-tokens/
+#    Scope: org:write (or alerts:write)
+
+# 2. Apply
+SENTRY_API_TOKEN=sntrys_... ./scripts/provision-sentry-alerts.sh
+
+# Dry-run first to see what would be created
+SENTRY_API_TOKEN=sntrys_... ./scripts/provision-sentry-alerts.sh --dry-run
+```
+
+The script targets the EU region (`https://de.sentry.io`). If Kaneo ever moves to the US region, change the `region` field in `alerts.json` (or override `SENTRY_API_BASE`).
+
+### Option B: manual setup via the Sentry UI
+
+For each rule in `alerts.json`, walk through Settings > Alerts > Create Alert. The JSON is human-readable enough to drop in to the Sentry UI form fields. Tables of the conditions are at the top of `alerts.json`; the `_comment_*` keys are stripped before applying.
+
+## After applying
+
+The script creates the rules but does NOT wire up notifications. Each rule lands in Sentry with an empty `actions` array so you can choose the right channel per rule. To finish setup:
+
+1. Settings > Alerts > [rule name] > Actions
+2. Pick a notification target. Recommended:
+   - Slack `#engineering` for spike/latency/cron-missed
+   - Email to on-call for new issues and MCP errors
+3. Save.
+
+Once notifications are wired, the rules start firing based on the events flowing through `Sentry.captureException` (anywhere in the codebase) and `Sentry.captureCheckIn` (the four cron jobs).
+
+## Schema notes
+
+Two rule families:
+
+- **Issue rules** (`kind: "issue"`) — trigger on event condition types (first_seen_event, regression_event, etc.). One JSON entry per rule.
+- **Metric rules** (`kind: "metric"`) — trigger on aggregate conditions (count, p95, failure_rate). Each entry creates a Detector (the metric source) and a Workflow (the alert) and links them via `detectorIds`.
+
+The cron-missed-check-in rule is special: it doesn't create a Detector because the cron monitors already exist. The script resolves the slug strings in `detector_slugs` to numeric IDs via `GET /api/0/organizations/{org}/monitors/`. If the cron jobs haven't run yet, the monitors don't exist and the script will skip with a warning.
+
+The Sentry API surface used is documented at:
+- <https://docs.sentry.io/api/monitors/create-an-alert-for-an-organization/>
+- <https://docs.sentry.io/api/monitors/create-a-monitor-for-a-project/>

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -89,7 +89,7 @@ Each dashboard entry has:
   - `columns` — group-by fields
   - `query` — Sentry search filter (e.g., `event.type:error project:kaneo-api`)
   - `orderby` — sort field (e.g., `-count()`)
-  - `limit` — max rows for table widgets
+  - `limit` — required on every query; max is 10. The script uses 10 for all queries.
 
 Performance metrics use `event.type:transaction is_transaction:true` (the dataset migration removed `dataset: transactions`). Error metrics use `event.type:error`. Cron check-in events use `event.type:transaction monitor.check_in_id:*`.
 

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -4,7 +4,7 @@ This directory holds Sentry configuration as code, so the alert rules and dashbo
 
 ## What lives here
 
-- `alerts.json` — alert rules. Five rules cover first-seen issues, error spikes, missed cron check-ins, slow p95 latency, and MCP error rate. Both `kaneo-api` and `kaneo-web` are covered.
+- `alerts.json` — alert rules. Six rules cover first-seen issues, error spikes, missed cron check-ins, slow p95 latency, and MCP error rate. Both `kaneo-api` and `kaneo-web` are covered.
 
 ## What's NOT here yet
 
@@ -15,7 +15,7 @@ This directory holds Sentry configuration as code, so the alert rules and dashbo
 
 ### Option A: provisioning script (recommended)
 
-The script lives at `scripts/provision-sentry-alerts.sh`. It reads `sentry/alerts.json`, asks Sentry which rules already exist, and creates the missing ones. Idempotent — re-runs are safe.
+The script lives at `scripts/provision-sentry-alerts.sh`. It reads `sentry/alerts.json`, finds existing workflows by name, and **post-or-puts** so edited specs propagate. Idempotent — re-runs converge to the spec's state.
 
 ```bash
 # 1. Generate a Sentry auth token (admin scope)
@@ -25,11 +25,13 @@ The script lives at `scripts/provision-sentry-alerts.sh`. It reads `sentry/alert
 # 2. Apply
 SENTRY_API_TOKEN=sntrys_... ./scripts/provision-sentry-alerts.sh
 
-# Dry-run first to see what would be created
+# Dry-run first to see what would be created or updated
 SENTRY_API_TOKEN=sntrys_... ./scripts/provision-sentry-alerts.sh --dry-run
 ```
 
 The script targets the EU region (`https://de.sentry.io`). If Kaneo ever moves to the US region, change the `region` field in `alerts.json` (or override `SENTRY_API_BASE`).
+
+If you rename an alert in `alerts.json`, the old name stays in Sentry alongside the new one. Rename alerts only when you intend to delete the old one manually.
 
 ### Option B: manual setup via the Sentry UI
 

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -2,20 +2,20 @@
 
 This directory holds Sentry configuration as code, so the alert rules and dashboards that Kaneo depends on are version-controlled and reproducible.
 
-## What lives here
+## Contents
 
 - `alerts.json` — alert rules. Six rules cover first-seen issues, error spikes, missed cron check-ins, slow p95 latency, and MCP error rate. Both `kaneo-api` and `kaneo-web` are covered.
+- `dashboards.json` — four Kaneo-specific dashboards (Backend, Frontend, MCP, Cron Monitors) with widgets for the metrics above. The prebuilt Sentry templates are left untouched.
 
 ## What's NOT here yet
 
-- Dashboards. The 10 prebuilt dashboards that Sentry ships are still empty (zero widgets each). Filling them in is the next monitoring item.
-- Cron monitor creation. These are auto-created the first time each cron job runs (`Sentry.captureCheckIn` from `apps/api/src/scheduler/index.ts`).
+- Cron monitor alert. The cron jobs in `apps/api/src/scheduler/index.ts` call `Sentry.captureCheckIn` with stable slugs (`due-date-reminders`, `project-webhook-reminders`, `seat-reconciliation`, `trial-reminders`). The Sentry monitors are auto-created the first time each job runs after the next deploy. Once they exist, the next run of `provision-sentry-alerts.sh` will resolve the slugs and create the cron-missed workflow.
 
 ## Applying the alerts
 
 ### Option A: provisioning script (recommended)
 
-The script lives at `scripts/provision-sentry-alerts.sh`. It reads `sentry/alerts.json`, finds existing workflows by name, and **post-or-puts** so edited specs propagate. Idempotent — re-runs converge to the spec's state.
+The script lives at `scripts/provision-sentry-alerts.sh`. It reads `sentry/alerts.json`, finds existing workflows by name, and **post-or-puts** so edited specs propagate. 
 
 ```bash
 # 1. Generate a Sentry auth token (admin scope)
@@ -56,8 +56,44 @@ Two rule families:
 - **Issue rules** (`kind: "issue"`) — trigger on event condition types (first_seen_event, regression_event, etc.). One JSON entry per rule.
 - **Metric rules** (`kind: "metric"`) — trigger on aggregate conditions (count, p95, failure_rate). Each entry creates a Detector (the metric source) and a Workflow (the alert) and links them via `detectorIds`.
 
+## Applying the dashboards
+
+`scripts/provision-sentry-dashboards.sh` reads `sentry/dashboards.json` and creates-or-updates each dashboard by title. The script preserves any filter settings (projects, environment, period) the maintainer has set in the Sentry UI by reading the current dashboard first and only swapping the widgets array.
+
+```bash
+SENTRY_API_TOKEN=sntrys_... ./scripts/provision-sentry-dashboards.sh
+SENTRY_API_TOKEN=sntrys_... ./scripts/provision-sentry-dashboards.sh --dry-run
+```
+
+The prebuilt Sentry dashboards (Backend Overview, Frontend Overview, etc.) are **not** touched. Kaneo-specific dashboards are created with the `Kaneo:` prefix.
+
+## Schema notes
+
+### Alerts
+
+Two rule families:
+
+- **Issue rules** (`kind: "issue"`) — trigger on event condition types (first_seen_event, regression_event, etc.). One JSON entry per rule.
+- **Metric rules** (`kind: "metric"`) — trigger on aggregate conditions (count, p95, failure_rate). Each entry creates a Detector (the metric source) and a Workflow (the alert) and links them via `detectorIds`.
+
 The cron-missed-check-in rule is special: it doesn't create a Detector because the cron monitors already exist. The script resolves the slug strings in `detector_slugs` to numeric IDs via `GET /api/0/organizations/{org}/monitors/`. If the cron jobs haven't run yet, the monitors don't exist and the script will skip with a warning.
+
+### Dashboards
+
+Each dashboard entry has:
+- `title` — dashboard name
+- `widgets` — array of `{ title, displayType, interval, queries }` objects
+- `queries` — array of `{ fields, aggregates, columns, query, orderby, limit }`
+  - `fields` — columns to display
+  - `aggregates` — aggregate functions to compute (e.g., `count()`, `p95(transaction.duration)`)
+  - `columns` — group-by fields
+  - `query` — Sentry search filter (e.g., `event.type:error project:kaneo-api`)
+  - `orderby` — sort field (e.g., `-count()`)
+  - `limit` — max rows for table widgets
+
+Performance metrics use `event.type:transaction is_transaction:true` (the dataset migration removed `dataset: transactions`). Error metrics use `event.type:error`. Cron check-in events use `event.type:transaction monitor.check_in_id:*`.
 
 The Sentry API surface used is documented at:
 - <https://docs.sentry.io/api/monitors/create-an-alert-for-an-organization/>
 - <https://docs.sentry.io/api/monitors/create-a-monitor-for-a-project/>
+- <https://docs.sentry.io/api/dashboards/create-a-new-dashboard-for-an-organization/>

--- a/sentry/alerts.json
+++ b/sentry/alerts.json
@@ -150,7 +150,7 @@
 				"dataSources": [
 					{
 						"dataset": "events_analytics_platform",
-						"query": "transaction:*/api/mcp/* http.status_code:>=500 is_transaction:true",
+						"query": "transaction:*/api/mcp/* is_transaction:true",
 						"queryType": 1,
 						"aggregate": "failure_rate()",
 						"timeWindow": 3600,

--- a/sentry/alerts.json
+++ b/sentry/alerts.json
@@ -1,9 +1,12 @@
 {
-	"version": 1,
+	"version": 2,
 	"organization": "kaneo",
 	"region": "de",
 	"api_base": "https://de.sentry.io/api/0",
 	"_comment_actions": "Actions are intentionally minimal. After the script applies this config, configure per-alert notifications in the Sentry UI (Settings > Alerts). Recommended: Slack #engineering or email on-call.",
+	"_comment_condition_result": "The Sentry API requires `conditionResult` on every condition. For issue alerts it's a boolean (true fires). For metric alerts it maps to issue priority: 75 = high, 50 = low, 0 = resolved.",
+	"_comment_event_types": "dataSources need `eventTypes`. Errors: [\"default\", \"error\"]. Transactions: [\"trace_item_span\"].",
+	"_comment_condition_group": "Detectors need a top-level `conditionGroup` defining the threshold (gt/lte/anomaly_detection).",
 	"alerts": [
 		{
 			"name": "Kaneo API: New issue",
@@ -15,10 +18,14 @@
 				"enabled": true,
 				"triggers": {
 					"logicType": "any-short",
-					"conditions": [{ "type": "first_seen_event", "comparison": true }],
-					"actions": []
-				},
-				"actionFilters": []
+					"conditions": [
+						{
+							"type": "first_seen_event",
+							"comparison": true,
+							"conditionResult": true
+						}
+					]
+				}
 			}
 		},
 		{
@@ -37,23 +44,28 @@
 					{
 						"dataset": "events",
 						"query": "event.type:error",
-						"queryType": 1,
+						"queryType": 0,
 						"aggregate": "count()",
 						"timeWindow": 300,
-						"environment": "production"
+						"environment": "production",
+						"eventTypes": ["default", "error"]
 					}
 				],
-				"workflows": []
+				"conditionGroup": {
+					"logicType": "any",
+					"conditions": [
+						{
+							"type": "gt",
+							"comparison": 50,
+							"conditionResult": 75
+						}
+					],
+					"actions": []
+				}
 			},
 			"workflow": {
 				"name": "Kaneo API: New error spike",
-				"enabled": true,
-				"triggers": {
-					"logicType": "any-short",
-					"conditions": [{ "type": "gt", "comparison": 50 }],
-					"actions": []
-				},
-				"actionFilters": []
+				"enabled": true
 			}
 		},
 		{
@@ -69,18 +81,7 @@
 			"_comment_detector_slugs": "Slugs are the human-readable identifiers from the captureCheckIn calls. The provisioning script resolves these to numeric detector IDs via GET /api/0/organizations/{org}/monitors/.",
 			"workflow": {
 				"name": "Cron: missed check-in (any)",
-				"enabled": true,
-				"triggers": {
-					"logicType": "any-short",
-					"conditions": [
-						{
-							"type": "monitor_check_in_failure",
-							"comparison": true
-						}
-					],
-					"actions": []
-				},
-				"actionFilters": []
+				"enabled": true
 			}
 		},
 		{
@@ -102,20 +103,25 @@
 						"queryType": 1,
 						"aggregate": "p95(transaction.duration)",
 						"timeWindow": 600,
-						"environment": "production"
+						"environment": "production",
+						"eventTypes": ["trace_item_span"]
 					}
 				],
-				"workflows": []
+				"conditionGroup": {
+					"logicType": "any",
+					"conditions": [
+						{
+							"type": "gt",
+							"comparison": 1500,
+							"conditionResult": 50
+						}
+					],
+					"actions": []
+				}
 			},
 			"workflow": {
 				"name": "Kaneo API: Slow p95 latency",
-				"enabled": true,
-				"triggers": {
-					"logicType": "any-short",
-					"conditions": [{ "type": "gt", "comparison": 1500 }],
-					"actions": []
-				},
-				"actionFilters": []
+				"enabled": true
 			}
 		},
 		{
@@ -137,20 +143,25 @@
 						"queryType": 1,
 						"aggregate": "failure_rate()",
 						"timeWindow": 3600,
-						"environment": "production"
+						"environment": "production",
+						"eventTypes": ["trace_item_span"]
 					}
 				],
-				"workflows": []
+				"conditionGroup": {
+					"logicType": "any",
+					"conditions": [
+						{
+							"type": "gt",
+							"comparison": 0.05,
+							"conditionResult": 75
+						}
+					],
+					"actions": []
+				}
 			},
 			"workflow": {
 				"name": "Kaneo API: MCP error rate",
-				"enabled": true,
-				"triggers": {
-					"logicType": "any-short",
-					"conditions": [{ "type": "gt", "comparison": 0.05 }],
-					"actions": []
-				},
-				"actionFilters": []
+				"enabled": true
 			}
 		},
 		{
@@ -163,10 +174,14 @@
 				"enabled": true,
 				"triggers": {
 					"logicType": "any-short",
-					"conditions": [{ "type": "first_seen_event", "comparison": true }],
-					"actions": []
-				},
-				"actionFilters": []
+					"conditions": [
+						{
+							"type": "first_seen_event",
+							"comparison": true,
+							"conditionResult": true
+						}
+					]
+				}
 			}
 		}
 	]

--- a/sentry/alerts.json
+++ b/sentry/alerts.json
@@ -7,6 +7,7 @@
 	"_comment_condition_result": "The Sentry API requires `conditionResult` on every condition. For issue alerts it's a boolean (true fires). For metric alerts it maps to issue priority: 75 = high, 50 = low, 0 = resolved.",
 	"_comment_event_types": "dataSources need `eventTypes`. Errors: [\"default\", \"error\"]. Transactions: [\"trace_item_span\"].",
 	"_comment_condition_group": "Detectors need a top-level `conditionGroup` defining the threshold (gt/lte/anomaly_detection).",
+	"_comment_dataset": "Sentry is migrating transaction-based alerts away from `dataset: transactions`. Use `dataset: events_analytics_platform` (with `is_transaction:true` in the query) for transaction-based metrics.",
 	"alerts": [
 		{
 			"name": "Kaneo API: New issue",
@@ -103,8 +104,8 @@
 				},
 				"dataSources": [
 					{
-						"dataset": "transactions",
-						"query": "transaction.duration:>0 transaction:*/api/*",
+						"dataset": "events_analytics_platform",
+						"query": "transaction.duration:>0 transaction:*/api/* is_transaction:true",
 						"queryType": 1,
 						"aggregate": "p95(transaction.duration)",
 						"timeWindow": 600,
@@ -148,8 +149,8 @@
 				},
 				"dataSources": [
 					{
-						"dataset": "transactions",
-						"query": "transaction:*/api/mcp/* http.status_code:>=500",
+						"dataset": "events_analytics_platform",
+						"query": "transaction:*/api/mcp/* http.status_code:>=500 is_transaction:true",
 						"queryType": 1,
 						"aggregate": "failure_rate()",
 						"timeWindow": 3600,

--- a/sentry/alerts.json
+++ b/sentry/alerts.json
@@ -1,0 +1,173 @@
+{
+	"version": 1,
+	"organization": "kaneo",
+	"region": "de",
+	"api_base": "https://de.sentry.io/api/0",
+	"_comment_actions": "Actions are intentionally minimal. After the script applies this config, configure per-alert notifications in the Sentry UI (Settings > Alerts). Recommended: Slack #engineering or email on-call.",
+	"alerts": [
+		{
+			"name": "Kaneo API: New issue",
+			"description": "First time a new issue is seen in kaneo-api. Triages everything that isn't yet bucketed.",
+			"kind": "issue",
+			"projects": ["kaneo-api"],
+			"workflow": {
+				"name": "Kaneo API: New issue",
+				"enabled": true,
+				"triggers": {
+					"logicType": "any-short",
+					"conditions": [{ "type": "first_seen_event", "comparison": true }],
+					"actions": []
+				},
+				"actionFilters": []
+			}
+		},
+		{
+			"name": "Kaneo API: New error spike",
+			"description": "More than 50 error events in 5 minutes. Detector is created alongside this workflow.",
+			"kind": "metric",
+			"project": "kaneo-api",
+			"detector": {
+				"name": "Kaneo API: Error spike detector",
+				"description": "count(error events) > 50 in a 5-minute window",
+				"type": "metric_issue",
+				"config": {
+					"detectionType": "static"
+				},
+				"dataSources": [
+					{
+						"dataset": "events",
+						"query": "event.type:error",
+						"queryType": 1,
+						"aggregate": "count()",
+						"timeWindow": 300,
+						"environment": "production"
+					}
+				],
+				"workflows": []
+			},
+			"workflow": {
+				"name": "Kaneo API: New error spike",
+				"enabled": true,
+				"triggers": {
+					"logicType": "any-short",
+					"conditions": [{ "type": "gt", "comparison": 50 }],
+					"actions": []
+				},
+				"actionFilters": []
+			}
+		},
+		{
+			"name": "Cron: missed check-in (any)",
+			"description": "A monitored cron job missed its check-in (or reported an error). Covers all 4 crons created by Sentry.captureCheckIn in apps/api/src/scheduler/index.ts.",
+			"kind": "metric",
+			"detector_slugs": [
+				"due-date-reminders",
+				"project-webhook-reminders",
+				"seat-reconciliation",
+				"trial-reminders"
+			],
+			"_comment_detector_slugs": "Slugs are the human-readable identifiers from the captureCheckIn calls. The provisioning script resolves these to numeric detector IDs via GET /api/0/organizations/{org}/monitors/.",
+			"workflow": {
+				"name": "Cron: missed check-in (any)",
+				"enabled": true,
+				"triggers": {
+					"logicType": "any-short",
+					"conditions": [
+						{
+							"type": "monitor_check_in_failure",
+							"comparison": true
+						}
+					],
+					"actions": []
+				},
+				"actionFilters": []
+			}
+		},
+		{
+			"name": "Kaneo API: Slow p95 latency",
+			"description": "p95 of transaction.duration > 1500ms in any 10-minute window on /api/* routes.",
+			"kind": "metric",
+			"project": "kaneo-api",
+			"detector": {
+				"name": "Kaneo API: Slow p95 latency detector",
+				"description": "p95(transaction.duration) > 1500ms over 10 minutes",
+				"type": "metric_issue",
+				"config": {
+					"detectionType": "static"
+				},
+				"dataSources": [
+					{
+						"dataset": "transactions",
+						"query": "transaction.duration:>0 transaction:*/api/*",
+						"queryType": 1,
+						"aggregate": "p95(transaction.duration)",
+						"timeWindow": 600,
+						"environment": "production"
+					}
+				],
+				"workflows": []
+			},
+			"workflow": {
+				"name": "Kaneo API: Slow p95 latency",
+				"enabled": true,
+				"triggers": {
+					"logicType": "any-short",
+					"conditions": [{ "type": "gt", "comparison": 1500 }],
+					"actions": []
+				},
+				"actionFilters": []
+			}
+		},
+		{
+			"name": "Kaneo API: MCP error rate",
+			"description": "MCP tool errors exceed 5% over a 1h window. Helps catch regressions before users do.",
+			"kind": "metric",
+			"project": "kaneo-api",
+			"detector": {
+				"name": "Kaneo API: MCP error rate detector",
+				"description": "MCP error rate > 5% over 1 hour",
+				"type": "metric_issue",
+				"config": {
+					"detectionType": "static"
+				},
+				"dataSources": [
+					{
+						"dataset": "transactions",
+						"query": "transaction:*/api/mcp/* http.status_code:>=500",
+						"queryType": 1,
+						"aggregate": "failure_rate()",
+						"timeWindow": 3600,
+						"environment": "production"
+					}
+				],
+				"workflows": []
+			},
+			"workflow": {
+				"name": "Kaneo API: MCP error rate",
+				"enabled": true,
+				"triggers": {
+					"logicType": "any-short",
+					"conditions": [{ "type": "gt", "comparison": 0.05 }],
+					"actions": []
+				},
+				"actionFilters": []
+			}
+		},
+		{
+			"name": "Kaneo Web: New issue",
+			"description": "New React ErrorBoundary or unhandled exception in kaneo-web.",
+			"kind": "issue",
+			"projects": ["kaneo-web"],
+			"workflow": {
+				"name": "Kaneo Web: New issue",
+				"enabled": true,
+				"triggers": {
+					"logicType": "any-short",
+					"conditions": [{ "type": "first_seen_event", "comparison": true }],
+					"actions": []
+				},
+				"actionFilters": []
+			}
+		}
+	]
+}

--- a/sentry/alerts.json
+++ b/sentry/alerts.json
@@ -58,6 +58,11 @@
 							"type": "gt",
 							"comparison": 50,
 							"conditionResult": 75
+						},
+						{
+							"type": "lte",
+							"comparison": 50,
+							"conditionResult": 0
 						}
 					],
 					"actions": []
@@ -114,6 +119,11 @@
 							"type": "gt",
 							"comparison": 1500,
 							"conditionResult": 50
+						},
+						{
+							"type": "lte",
+							"comparison": 1500,
+							"conditionResult": 0
 						}
 					],
 					"actions": []
@@ -154,6 +164,11 @@
 							"type": "gt",
 							"comparison": 0.05,
 							"conditionResult": 75
+						},
+						{
+							"type": "lte",
+							"comparison": 0.05,
+							"conditionResult": 0
 						}
 					],
 					"actions": []

--- a/sentry/dashboards.json
+++ b/sentry/dashboards.json
@@ -20,7 +20,8 @@
 							"aggregates": ["count()"],
 							"columns": ["time"],
 							"query": "event.type:error project:kaneo-api",
-							"orderby": "time"
+							"orderby": "time",
+							"limit": 10
 						}
 					]
 				},
@@ -34,7 +35,8 @@
 							"aggregates": ["p95(transaction.duration)"],
 							"columns": ["time"],
 							"query": "transaction:*/api/* is_transaction:true project:kaneo-api",
-							"orderby": "time"
+							"orderby": "time",
+							"limit": 10
 						}
 					]
 				},
@@ -48,7 +50,8 @@
 							"aggregates": ["count()"],
 							"columns": ["time"],
 							"query": "transaction:*/api/* is_transaction:true project:kaneo-api",
-							"orderby": "time"
+							"orderby": "time",
+							"limit": 10
 						}
 					]
 				},
@@ -83,7 +86,8 @@
 							"aggregates": ["count()"],
 							"columns": ["time"],
 							"query": "event.type:error project:kaneo-web",
-							"orderby": "time"
+							"orderby": "time",
+							"limit": 10
 						}
 					]
 				},
@@ -97,7 +101,8 @@
 							"aggregates": ["p95(transaction.duration)"],
 							"columns": ["time"],
 							"query": "project:kaneo-web is_transaction:true",
-							"orderby": "time"
+							"orderby": "time",
+							"limit": 10
 						}
 					]
 				},
@@ -111,7 +116,8 @@
 							"aggregates": ["p75(measurements.lcp)"],
 							"columns": ["time"],
 							"query": "project:kaneo-web is_transaction:true",
-							"orderby": "time"
+							"orderby": "time",
+							"limit": 10
 						}
 					]
 				},
@@ -146,7 +152,8 @@
 							"aggregates": ["count()"],
 							"columns": ["time"],
 							"query": "transaction:*/api/mcp/* is_transaction:true",
-							"orderby": "time"
+							"orderby": "time",
+							"limit": 10
 						}
 					]
 				},
@@ -160,12 +167,13 @@
 							"aggregates": ["failure_rate()"],
 							"columns": ["time"],
 							"query": "transaction:*/api/mcp/* is_transaction:true",
-							"orderby": "time"
+							"orderby": "time",
+							"limit": 10
 						}
 					]
 				},
 				{
-					"title": "MCP tool usage (top 20)",
+					"title": "MCP tool usage (top 10)",
 					"displayType": "table",
 					"interval": "24h",
 					"queries": [
@@ -175,7 +183,7 @@
 							"columns": ["transaction"],
 							"query": "transaction:*/api/mcp/* is_transaction:true",
 							"orderby": "-count()",
-							"limit": 20
+							"limit": 10
 						}
 					]
 				},
@@ -189,7 +197,8 @@
 							"aggregates": ["p95(transaction.duration)"],
 							"columns": ["time"],
 							"query": "transaction:*/api/mcp/* is_transaction:true",
-							"orderby": "time"
+							"orderby": "time",
+							"limit": 10
 						}
 					]
 				}
@@ -210,7 +219,7 @@
 							"columns": ["monitor.slug"],
 							"query": "event.type:transaction monitor.check_in_id:*",
 							"orderby": "-count()",
-							"limit": 20
+							"limit": 10
 						}
 					]
 				},
@@ -224,7 +233,8 @@
 							"aggregates": ["count()"],
 							"columns": ["time"],
 							"query": "event.type:transaction monitor.check_in_id:*",
-							"orderby": "time"
+							"orderby": "time",
+							"limit": 10
 						}
 					]
 				},
@@ -238,7 +248,8 @@
 							"aggregates": ["count()"],
 							"columns": ["time"],
 							"query": "event.type:transaction monitor.check_in_id:* monitor.status:missed_or_failed",
-							"orderby": "time"
+							"orderby": "time",
+							"limit": 10
 						}
 					]
 				}

--- a/sentry/dashboards.json
+++ b/sentry/dashboards.json
@@ -1,0 +1,248 @@
+{
+	"version": 1,
+	"organization": "kaneo",
+	"region": "de",
+	"api_base": "https://de.sentry.io/api/0",
+	"_comment": "Each dashboard here becomes a top-level dashboard in Sentry. The script creates-or-updates by title. Widgets are versioned here so dashboard changes are auditable.",
+	"_comment_field_types": "Widget queries use Sentry's discover query syntax. Performance widgets use dataset: events_analytics_platform (with is_transaction:true) per the current Sentry API. Error widgets use dataset: events.",
+	"dashboards": [
+		{
+			"title": "Kaneo: Backend Overview",
+			"description": "API errors, latency, and request volume for kaneo-api.",
+			"widgets": [
+				{
+					"title": "Error events (count over time)",
+					"displayType": "line",
+					"interval": "1h",
+					"queries": [
+						{
+							"fields": ["count()", "time"],
+							"aggregates": ["count()"],
+							"columns": ["time"],
+							"query": "event.type:error project:kaneo-api",
+							"orderby": "time"
+						}
+					]
+				},
+				{
+					"title": "API p95 latency (ms)",
+					"displayType": "line",
+					"interval": "1h",
+					"queries": [
+						{
+							"fields": ["p95(transaction.duration)", "time"],
+							"aggregates": ["p95(transaction.duration)"],
+							"columns": ["time"],
+							"query": "transaction:*/api/* is_transaction:true project:kaneo-api",
+							"orderby": "time"
+						}
+					]
+				},
+				{
+					"title": "API request volume",
+					"displayType": "line",
+					"interval": "1h",
+					"queries": [
+						{
+							"fields": ["count()", "time"],
+							"aggregates": ["count()"],
+							"columns": ["time"],
+							"query": "transaction:*/api/* is_transaction:true project:kaneo-api",
+							"orderby": "time"
+						}
+					]
+				},
+				{
+					"title": "Top errors by exception type",
+					"displayType": "table",
+					"interval": "24h",
+					"queries": [
+						{
+							"fields": ["exception.type", "count()"],
+							"aggregates": ["count()"],
+							"columns": ["exception.type"],
+							"query": "event.type:error project:kaneo-api",
+							"orderby": "-count()",
+							"limit": 10
+						}
+					]
+				}
+			]
+		},
+		{
+			"title": "Kaneo: Frontend Overview",
+			"description": "Web errors, page loads, and web vitals for kaneo-web.",
+			"widgets": [
+				{
+					"title": "Web error events (count over time)",
+					"displayType": "line",
+					"interval": "1h",
+					"queries": [
+						{
+							"fields": ["count()", "time"],
+							"aggregates": ["count()"],
+							"columns": ["time"],
+							"query": "event.type:error project:kaneo-web",
+							"orderby": "time"
+						}
+					]
+				},
+				{
+					"title": "Page load p95 (ms)",
+					"displayType": "line",
+					"interval": "1h",
+					"queries": [
+						{
+							"fields": ["p95(transaction.duration)", "time"],
+							"aggregates": ["p95(transaction.duration)"],
+							"columns": ["time"],
+							"query": "project:kaneo-web is_transaction:true",
+							"orderby": "time"
+						}
+					]
+				},
+				{
+					"title": "LCP (p75, ms)",
+					"displayType": "line",
+					"interval": "1h",
+					"queries": [
+						{
+							"fields": ["p75(measurements.lcp)", "time"],
+							"aggregates": ["p75(measurements.lcp)"],
+							"columns": ["time"],
+							"query": "project:kaneo-web is_transaction:true",
+							"orderby": "time"
+						}
+					]
+				},
+				{
+					"title": "Top error pages",
+					"displayType": "table",
+					"interval": "24h",
+					"queries": [
+						{
+							"fields": ["transaction", "count()"],
+							"aggregates": ["count()"],
+							"columns": ["transaction"],
+							"query": "event.type:error project:kaneo-web",
+							"orderby": "-count()",
+							"limit": 10
+						}
+					]
+				}
+			]
+		},
+		{
+			"title": "Kaneo: MCP",
+			"description": "MCP tool traffic, error rate, and latency.",
+			"widgets": [
+				{
+					"title": "MCP request volume",
+					"displayType": "line",
+					"interval": "1h",
+					"queries": [
+						{
+							"fields": ["count()", "time"],
+							"aggregates": ["count()"],
+							"columns": ["time"],
+							"query": "transaction:*/api/mcp/* is_transaction:true",
+							"orderby": "time"
+						}
+					]
+				},
+				{
+					"title": "MCP error rate",
+					"displayType": "line",
+					"interval": "1h",
+					"queries": [
+						{
+							"fields": ["failure_rate()", "time"],
+							"aggregates": ["failure_rate()"],
+							"columns": ["time"],
+							"query": "transaction:*/api/mcp/* is_transaction:true",
+							"orderby": "time"
+						}
+					]
+				},
+				{
+					"title": "MCP tool usage (top 20)",
+					"displayType": "table",
+					"interval": "24h",
+					"queries": [
+						{
+							"fields": ["transaction", "count()"],
+							"aggregates": ["count()"],
+							"columns": ["transaction"],
+							"query": "transaction:*/api/mcp/* is_transaction:true",
+							"orderby": "-count()",
+							"limit": 20
+						}
+					]
+				},
+				{
+					"title": "MCP p95 latency (ms)",
+					"displayType": "line",
+					"interval": "1h",
+					"queries": [
+						{
+							"fields": ["p95(transaction.duration)", "time"],
+							"aggregates": ["p95(transaction.duration)"],
+							"columns": ["time"],
+							"query": "transaction:*/api/mcp/* is_transaction:true",
+							"orderby": "time"
+						}
+					]
+				}
+			]
+		},
+		{
+			"title": "Kaneo: Cron Monitors",
+			"description": "Scheduled-job check-ins from apps/api/src/scheduler/index.ts. Monitors appear in Sentry once each cron has run at least once.",
+			"widgets": [
+				{
+					"title": "Check-in status by monitor",
+					"displayType": "table",
+					"interval": "24h",
+					"queries": [
+						{
+							"fields": ["monitor.slug", "count()"],
+							"aggregates": ["count()"],
+							"columns": ["monitor.slug"],
+							"query": "event.type:transaction monitor.check_in_id:*",
+							"orderby": "-count()",
+							"limit": 20
+						}
+					]
+				},
+				{
+					"title": "Check-in events over time",
+					"displayType": "line",
+					"interval": "1h",
+					"queries": [
+						{
+							"fields": ["count()", "time"],
+							"aggregates": ["count()"],
+							"columns": ["time"],
+							"query": "event.type:transaction monitor.check_in_id:*",
+							"orderby": "time"
+						}
+					]
+				},
+				{
+					"title": "Check-in errors over time",
+					"displayType": "line",
+					"interval": "1h",
+					"queries": [
+						{
+							"fields": ["count()", "time"],
+							"aggregates": ["count()"],
+							"columns": ["time"],
+							"query": "event.type:transaction monitor.check_in_id:* monitor.status:missed_or_failed",
+							"orderby": "time"
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/sentry/dashboards.json
+++ b/sentry/dashboards.json
@@ -247,7 +247,7 @@
 							"fields": ["count()", "time"],
 							"aggregates": ["count()"],
 							"columns": ["time"],
-							"query": "event.type:transaction monitor.check_in_id:* monitor.status:missed_or_failed",
+							"query": "event.type:transaction monitor.check_in_id:* (monitor.status:missed OR monitor.status:error)",
 							"orderby": "time",
 							"limit": 10
 						}


### PR DESCRIPTION
## Description

Sentry alerts and dashboards are now in the repo as code. The Sentry MCP only reads — writing requires the REST API, so keeping the spec in the repo makes the rules auditable and reproducible.

Six alerts and four dashboards cover the basics: first-seen issues, error spikes, missed crons, slow latency, MCP errors, plus views for the API, web, MCP, and cron monitors.

Two bash scripts provision them. Both are idempotent — they look up by name and update in place, so editing the spec just propagates.

## Related Issue(s)

Fixes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [x] Other (please describe): observability tooling (Sentry alerts and dashboards)

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [x] Other (please describe): provision scripts ran end-to-end against live Sentry. 5 alerts and 4 dashboards landed. The cron monitor alert waits for cron jobs to run post-deploy — documented in the additional notes below.

## Screenshots (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I understand and take responsibility for every change, and I wrote this pull request description in my own words
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The cron "missed check-in" alert depends on the four `Sentry.captureCheckIn` monitors existing in Sentry. They appear after the first cron run post-deploy. Re-run the alerts script after the next cron tick to pick them up.

To apply after merge:

```bash
SENTRY_API_TOKEN=sntrys_... ./scripts/provision-sentry-alerts.sh
SENTRY_API_TOKEN=sntrys_... ./scripts/provision-sentry-dashboards.sh
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Sentry alert provisioning for issue, metric, and missed-check-in alerts.
  * Added automated Sentry dashboard provisioning for backend, frontend, MCP, and cron-monitor insights.
  * Added dry-run support, validation, error reporting, and create/update handling for monitoring resources.
  * Added configuration for API errors, latency, web vitals, tool usage, request volume, and monitor health.

* **Documentation**
  * Documented the optional Sentry API token configuration and required access scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->