### PR TITLE
refactor: simplify conditional checks with optional chaining and clean up lint warnings

### DIFF
--- a/apps/api/src/mcp/controllers/oauth-consent.ts
+++ b/apps/api/src/mcp/controllers/oauth-consent.ts
@@ -123,7 +123,7 @@ export async function decideMcpAuthorizationRequest(params: {
   if (!request) throwOAuthError(404, "invalid_or_expired_request");
 
   const client = await getClient(request.clientId);
-  if (!client || !client.redirectUris.includes(request.redirectUri)) {
+  if (!client?.redirectUris.includes(request.redirectUri)) {
     throwOAuthError(400, "invalid_client");
   }
 

--- a/apps/api/src/plugins/gitea/webhook-handler.ts
+++ b/apps/api/src/plugins/gitea/webhook-handler.ts
@@ -81,7 +81,7 @@ export async function handleGiteaWebhookRequest(
     where: eq(integrationTable.id, integrationId),
   });
 
-  if (!integration || integration.type !== "gitea") {
+  if (integration?.type !== "gitea") {
     return { success: false, error: "Gitea integration not found" };
   }
 

--- a/apps/api/src/plugins/github/utils/sync-label-to-github.ts
+++ b/apps/api/src/plugins/github/utils/sync-label-to-github.ts
@@ -51,12 +51,12 @@ async function getGitHubContext(taskId: string) {
     },
   });
 
-  if (!externalLink || externalLink.resourceType !== "issue") {
+  if (externalLink?.resourceType !== "issue") {
     return null;
   }
 
   const integration = externalLink.integration;
-  if (!integration || integration.type !== "github") {
+  if (integration?.type !== "github") {
     return null;
   }
 

--- a/apps/web/src/components/activity/comment-editor.tsx
+++ b/apps/web/src/components/activity/comment-editor.tsx
@@ -1157,7 +1157,7 @@ export default function CommentEditor({
       const resolvedLanguage = language === "auto" ? "" : language;
       const { nodePos } = hoveredCodeBlock;
       const node = editor.state.doc.nodeAt(nodePos);
-      if (!node || node.type.name !== "codeBlock") return;
+      if (node?.type.name !== "codeBlock") return;
 
       editor
         .chain()
@@ -1404,7 +1404,7 @@ export default function CommentEditor({
   const copyHoveredCodeBlock = useCallback(async () => {
     if (!editor || !hoveredCodeBlock) return;
     const node = editor.state.doc.nodeAt(hoveredCodeBlock.nodePos);
-    if (!node || node.type.name !== "codeBlock") return;
+    if (node?.type.name !== "codeBlock") return;
 
     const content = node.textContent || "";
     if (!content) return;

--- a/apps/web/src/components/kanban-board/index.tsx
+++ b/apps/web/src/components/kanban-board/index.tsx
@@ -187,7 +187,7 @@ function KanbanBoard({ project, disableDragDrop = false }: KanbanBoardProps) {
     setActiveId(null);
   };
 
-  if (!project || !project?.columns) {
+  if (!project?.columns) {
     return (
       <div className="flex h-full w-full flex-col bg-linear-to-b from-muted/25 to-background">
         <header className="mb-6 mt-6 space-y-6 shrink-0 px-6">

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/index.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/index.tsx
@@ -390,8 +390,7 @@ function RouteComponent() {
                 strategy={verticalListSortingStrategy}
               >
                 {orderedProjects?.map((project) => {
-                  if (!project || !project.id || !project.statistics)
-                    return null;
+                  if (!project?.id || !project.statistics) return null;
 
                   const IconComponent =
                     icons[project.icon as keyof typeof icons] || icons.Layout;

--- a/packages/planka-import/src/mapping.ts
+++ b/packages/planka-import/src/mapping.ts
@@ -95,7 +95,7 @@ export function displayName(user: PlankaUser | undefined): string {
 
 export function formatComment(
   comment: PlankaComment,
-  author: PlankaUser | undefined,
+  _author: PlankaUser | undefined,
 ): string {
   const date = comment.createdAt
     ? new Date(comment.createdAt).toISOString().slice(0, 10)


### PR DESCRIPTION
### Summary
- Adopt optional chaining in `apps/api/src/plugins/github/utils/sync-label-to-github.ts`, `apps/api/src/plugins/gitea/webhook-handler.ts`, and `apps/api/src/mcp/controllers/oauth-consent.ts`.
- Refactor null checks across `apps/web/src/components/kanban-board/index.tsx`, `apps/web/src/components/activity/comment-editor.tsx`, and `apps/web/src/routes/.../workspace/$workspaceId/index.tsx` to satisfy Biome complexity rules.
- Fix unused parameter in `packages/planka-import/src/mapping.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth authorization error handling for missing clients or redirect URIs.
  * Preserved valid Gitea and GitHub integrations during synchronization and webhook processing.
  * Improved loading and validation behavior for project boards and dashboard entries.
  * Added safer handling for missing content when editing or copying code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->