### PR TITLE
fix(web): use fallback MIME type for unknown files

### DIFF
--- a/apps/web/src/lib/upload-task-image.test.ts
+++ b/apps/web/src/lib/upload-task-image.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { uploadTaskImage } from "./upload-task-image";
+
+const mocks = vi.hoisted(() => ({
+  createImageUpload: vi.fn(),
+  finalizeImageUpload: vi.fn(),
+}));
+
+vi.mock("@/fetchers/task/create-image-upload", () => ({
+  default: mocks.createImageUpload,
+  finalizeImageUpload: mocks.finalizeImageUpload,
+}));
+
+describe("uploadTaskImage", () => {
+  beforeEach(() => {
+    mocks.createImageUpload.mockResolvedValue({
+      key: "task/file.conf",
+      uploadUrl: "https://storage.example/upload",
+      headers: {},
+    });
+    mocks.finalizeImageUpload.mockResolvedValue({
+      url: "https://storage.example/file.conf",
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("uses a generic content type when the browser cannot detect one", async () => {
+    const file = new File(["server config"], "server.conf");
+
+    const asset = await uploadTaskImage({
+      taskId: "task-1",
+      surface: "comment",
+      file,
+    });
+
+    expect(file.type).toBe("");
+    expect(mocks.createImageUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: "application/octet-stream" }),
+    );
+    expect(mocks.finalizeImageUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: "application/octet-stream" }),
+    );
+    expect(asset.mimeType).toBe("application/octet-stream");
+    expect(asset.kind).toBe("attachment");
+  });
+
+  it("preserves a browser-provided content type", async () => {
+    const file = new File(["image"], "image.png", { type: "image/png" });
+
+    const asset = await uploadTaskImage({
+      taskId: "task-1",
+      surface: "description",
+      file,
+    });
+
+    expect(mocks.createImageUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: "image/png" }),
+    );
+    expect(mocks.finalizeImageUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: "image/png" }),
+    );
+    expect(asset.mimeType).toBe("image/png");
+    expect(asset.kind).toBe("image");
+  });
+});

--- a/apps/web/src/lib/upload-task-image.ts
+++ b/apps/web/src/lib/upload-task-image.ts
@@ -46,10 +46,12 @@ export async function uploadTaskImage({
     }
   }
 
+  const contentType = file.type || "application/octet-stream";
+
   const upload = await createImageUpload({
     taskId,
     filename: file.name || "image",
-    contentType: file.type,
+    contentType,
     size: file.size,
     surface,
   });
@@ -68,7 +70,7 @@ export async function uploadTaskImage({
     taskId,
     key: upload.key,
     filename: file.name || "image",
-    contentType: file.type,
+    contentType,
     size: file.size,
     surface,
   });
@@ -78,7 +80,7 @@ export async function uploadTaskImage({
     alt: getImageAltText(file.name || "image"),
     filename: file.name || "file",
     kind: isSupportedImageFile(file) ? "image" : "attachment",
-    mimeType: file.type,
+    mimeType: contentType,
     size: file.size,
   };
 }


### PR DESCRIPTION
## Description

Browsers leave `File.type` empty for extensions they do not recognize. Task attachments then sent an empty `contentType` to the upload endpoint, which rejects the request before storage upload.

This change normalizes an empty browser MIME type to `application/octet-stream` once and uses it consistently for upload creation, finalization, and returned attachment metadata. Browser-provided MIME types are unchanged, and unknown files remain attachments rather than being treated as images.

## Related Issue(s)

Fixes #1473

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Other (please describe): web typecheck, targeted Biome check, and repository build

Commands run:

- `pnpm --filter @kaneo/web test` — 37 files, 114 tests passed
- `pnpm --filter @kaneo/web typecheck` — passed
- `pnpm exec biome check apps/web/src/lib/upload-task-image.ts apps/web/src/lib/upload-task-image.test.ts` — passed
- pre-commit repository build — 7/7 Turbo tasks passed

## Screenshots (if applicable)

Not applicable; this changes upload request metadata and has no visual UI change.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I understand and take responsibility for every change, and I wrote this pull request description in my own words
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The regression covers both the empty-type fallback and preservation of a browser-provided `image/png` type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image uploads when the file type is unavailable by applying a reliable fallback format.
  * Ensured the correct file type is consistently reflected during upload processing and in asset details.
* **Tests**
  * Added coverage for missing and explicitly provided file types, including upload completion and asset metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->