### PR TITLE
fix(api): gzip API responses to shrink large board payloads

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,6 +9,7 @@ import type { Session, User } from "better-auth/types";
 import { eq, sql } from "drizzle-orm";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
 import { Hono } from "hono";
+import { compress } from "hono/compress";
 import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import {
@@ -203,6 +204,11 @@ export function createApp() {
       },
     }),
   );
+
+  // Large boards return multi-MB JSON (board/task list responses embed
+  // labels and external links per task); gzip cuts that by 85-95% since
+  // JSON with repeated keys compresses extremely well.
+  app.use(compress());
 
   const api = new Hono<ApiVariables>();
 


### PR DESCRIPTION
## Summary

Fixes #1630. Enables gzip compression (`hono/compress`) on API responses. Board/task-list endpoints inline full `labels` and `externalLinks` per task with no pagination on the primary board fetch, so boards with a few thousand tasks return multi-MB JSON — every field is genuinely used by the board card UI (label chips, PR status badges), so trimming the response shape isn't a safe option without a larger UX change. Compression is a small, safe win at the transport layer instead.

## Measured impact

Seeded a local board matching a real-world large-board case (2,802 tasks, 2,805 labels) and compared `GET /task/tasks/:projectId`:

| | Before | After |
|---|---|---|
| Response size | 1,730,391 bytes | 59,121 bytes |
| Reduction | — | **96.6%** |

Verified the gzip and non-gzip (`Accept-Encoding: identity`) responses are byte-for-byte identical after decompression — no data/shape change, transport only.

## Test plan

- [x] `pnpm test:unit` — 380/381 passing (pre-existing unrelated failure: an S3 credential test picks up ambient `AWS_PROFILE` from the local shell; fails identically on `main` without this change)
- [x] Manual repro: seeded Postgres directly with 2,802 tasks / 2,805 labels, ran the API locally, compared `curl` with/without `Accept-Encoding: gzip`
- [x] Diffed decompressed gzip body against the uncompressed body — identical


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * API responses are now compressed when supported, improving transfer speeds and reducing bandwidth usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->