### PR TITLE
refactor(planka-import): drop the dead author parameter from formatComment

### DIFF
--- a/packages/planka-import/src/mapping.test.ts
+++ b/packages/planka-import/src/mapping.test.ts
@@ -139,31 +139,25 @@ describe("buildDescription", () => {
 
 describe("formatComment", () => {
   it("keeps the body clean and notes the original date", () => {
-    const result = formatComment(
-      {
-        id: "c1",
-        cardId: "a",
-        userId: "u1",
-        text: "Looks good",
-        createdAt: "2026-03-04T10:00:00.000Z",
-      },
-      { id: "u1", email: "sam@example.com", name: "Sam", username: null },
-    );
+    const result = formatComment({
+      id: "c1",
+      cardId: "a",
+      userId: "u1",
+      text: "Looks good",
+      createdAt: "2026-03-04T10:00:00.000Z",
+    });
 
     expect(result).toBe("Looks good\n\n_Originally posted on 2026-03-04._");
   });
 
   it("returns the text unchanged when there is no date", () => {
-    const result = formatComment(
-      {
-        id: "c1",
-        cardId: "a",
-        userId: null,
-        text: "Orphaned",
-        createdAt: null,
-      },
-      undefined,
-    );
+    const result = formatComment({
+      id: "c1",
+      cardId: "a",
+      userId: null,
+      text: "Orphaned",
+      createdAt: null,
+    });
 
     expect(result).toBe("Orphaned");
   });

--- a/packages/planka-import/src/mapping.ts
+++ b/packages/planka-import/src/mapping.ts
@@ -93,10 +93,7 @@ export function displayName(user: PlankaUser | undefined): string {
   );
 }
 
-export function formatComment(
-  comment: PlankaComment,
-  _author: PlankaUser | undefined,
-): string {
+export function formatComment(comment: PlankaComment): string {
   const date = comment.createdAt
     ? new Date(comment.createdAt).toISOString().slice(0, 10)
     : null;

--- a/packages/planka-import/src/migrate.ts
+++ b/packages/planka-import/src/migrate.ts
@@ -325,7 +325,7 @@ async function migrateBoard(context: {
       const author = comment.userId ? usersById.get(comment.userId) : undefined;
       await kaneo.createComment(
         task.id,
-        formatComment(comment, author),
+        formatComment(comment),
         displayName(author),
       );
       report.comments++;


### PR DESCRIPTION
Follow-up to #1613.

## Context

`formatComment` has taken an `author` argument it never reads since 15f68683 ("fix(planka-import): explain unmatched assignees, keep dependencies, attribute comments"). That commit moved attribution to the API: the caller now passes `displayName(author)` as `createComment`'s `externalUserName`, with `externalSource: "planka"`, and the inline markdown byline was removed from the comment body.

#1613 renamed the argument to `_author` to clear the lint warning. That silenced the symptom but kept a dead parameter in the public signature.

## Change

Remove the parameter and update the caller and the two test call sites.

Attribution behaviour is unchanged. `migrate.ts` still binds `author` locally because `displayName(author)` needs it, so the only thing that goes away is the unused argument. Reintroducing the author into the comment text would double-attribute every imported comment, since the API already renders the external user, so this deliberately does not do that.

## Verification

- `packages/planka-import` tests: 54 passed
- `biome check packages/planka-import/src`: clean
- `tsc --noEmit`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified comment formatting during imports without changing the displayed comment content.
  * Comment authors continue to appear separately when comments are created.
* **Tests**
  * Updated comment migration tests, including comments without dates, to reflect the streamlined formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->