### PR TITLE
fix(web): let task labels use card width

### DIFF
--- a/apps/web/src/components/kanban-board/task-labels.test.tsx
+++ b/apps/web/src/components/kanban-board/task-labels.test.tsx
@@ -14,4 +14,15 @@ describe("TaskLabels", () => {
 
     expect(screen.getByText("Bug")).toBeVisible();
   });
+
+  it("uses the card width instead of an arbitrary label-name cap", () => {
+    const name = "Client: Totem";
+    render(<TaskLabels labels={[{ id: "label-1", name, color: "purple" }]} />);
+
+    const labelName = screen.getByText(name);
+    expect(labelName).not.toHaveClass("max-w-20");
+    expect(labelName).toHaveClass("min-w-0", "truncate");
+    expect(labelName).toHaveAttribute("title", name);
+    expect(labelName.parentElement).toHaveClass("max-w-full", "min-w-0");
+  });
 });

--- a/apps/web/src/components/kanban-board/task-labels.test.tsx
+++ b/apps/web/src/components/kanban-board/task-labels.test.tsx
@@ -20,9 +20,13 @@ describe("TaskLabels", () => {
     render(<TaskLabels labels={[{ id: "label-1", name, color: "purple" }]} />);
 
     const labelName = screen.getByText(name);
+    const badge = labelName.closest('[data-slot="badge"]');
     expect(labelName).not.toHaveClass("max-w-20");
     expect(labelName).toHaveClass("min-w-0", "truncate");
     expect(labelName).toHaveAttribute("title", name);
-    expect(labelName.parentElement).toHaveClass("max-w-full", "min-w-0");
+    expect(badge).toHaveClass("max-w-full", "min-w-0");
+    expect(badge?.querySelector('[aria-hidden="true"]')).toHaveClass(
+      "shrink-0",
+    );
   });
 });

--- a/apps/web/src/components/kanban-board/task-labels.tsx
+++ b/apps/web/src/components/kanban-board/task-labels.tsx
@@ -41,13 +41,14 @@ export function TaskLabels({
 
   return (
     <div className="flex min-w-0 flex-wrap gap-1">
-      {labels.map((label: { id: string; name: string; color: string }) => (
+      {labels.map((label) => (
         <Badge
           key={label.id}
           variant="outline"
           className="max-w-full min-w-0 px-2 py-0.5 text-[10px] flex items-center"
         >
           <span
+            aria-hidden="true"
             className="inline-block w-1.5 h-1.5 mr-1 shrink-0 rounded-full"
             style={{
               backgroundColor: validColor(label.color),

--- a/apps/web/src/components/kanban-board/task-labels.tsx
+++ b/apps/web/src/components/kanban-board/task-labels.tsx
@@ -40,20 +40,22 @@ export function TaskLabels({
   if (!labels.length) return null;
 
   return (
-    <div className="flex flex-wrap gap-1">
+    <div className="flex min-w-0 flex-wrap gap-1">
       {labels.map((label: { id: string; name: string; color: string }) => (
         <Badge
           key={label.id}
           variant="outline"
-          className="px-2 py-0.5 text-[10px] flex items-center"
+          className="max-w-full min-w-0 px-2 py-0.5 text-[10px] flex items-center"
         >
           <span
-            className="inline-block w-1.5 h-1.5 mr-1 rounded-full"
+            className="inline-block w-1.5 h-1.5 mr-1 shrink-0 rounded-full"
             style={{
               backgroundColor: validColor(label.color),
             }}
           />
-          <span className="max-w-20 truncate">{label.name}</span>
+          <span className="min-w-0 truncate" title={label.name}>
+            {label.name}
+          </span>
         </Badge>
       ))}
     </div>


### PR DESCRIPTION
## Description

Task labels on board cards were capped at 5rem even when the card had more room, so category-prefixed labels such as `Client: Totem` lost the value that distinguishes them.

This removes the fixed text-width cap and lets each badge use the available card width. Labels that are genuinely wider than the card still truncate safely, keep their color marker visible, and expose the complete name as native title text.

## Related Issue(s)

Fixes #1620

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests — `pnpm --filter @kaneo/web test` (42 files, 155 tests passed)
- [ ] Integration tests
- [ ] Manual testing
- [x] Other: `pnpm --filter @kaneo/web typecheck`, targeted Biome check, and `pnpm --filter @kaneo/web build`

## Screenshots (if applicable)

Not applicable; the component regression verifies that normal label names no longer receive the fixed 5rem cap while oversized names remain constrained by the card.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I understand and take responsibility for every change, and I wrote this pull request description in my own words
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The change is limited to task-label layout; label storage, ordering, filtering, and card sizing are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task label layout on Kanban cards to prevent overflow.
  * Long label names now truncate cleanly and show the full name on hover.
  * Color indicators remain properly sized while labels adapt to available card width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->