### PR TITLE
fix(api): make notifications and seat reconciliation survive replicas

### DIFF
--- a/apps/api/src/scheduler/leader-lock.ts
+++ b/apps/api/src/scheduler/leader-lock.ts
@@ -1,0 +1,49 @@
+import { getDatabasePool } from "../database";
+
+export const SEAT_RECONCILIATION_LOCK = 1525;
+
+export async function withLeaderLock<T>(
+  lockKey: number,
+  run: () => Promise<T>,
+  whenHeldElsewhere: () => T,
+): Promise<T> {
+  const client = await getDatabasePool().connect();
+  let acquired = false;
+  let released = false;
+
+  try {
+    const result = await client.query<{ locked: boolean }>(
+      "SELECT pg_try_advisory_lock($1) AS locked",
+      [lockKey],
+    );
+    acquired = result.rows[0]?.locked === true;
+
+    if (!acquired) {
+      client.release();
+      released = true;
+      return whenHeldElsewhere();
+    }
+
+    return await run();
+  } finally {
+    let unlockError: unknown;
+
+    if (acquired) {
+      unlockError = await client
+        .query("SELECT pg_advisory_unlock($1)", [lockKey])
+        .then(() => undefined)
+        .catch((err) => err);
+
+      if (unlockError) {
+        console.error(
+          `Failed to release advisory lock ${lockKey}`,
+          unlockError,
+        );
+      }
+    }
+
+    if (!released) {
+      client.release(unlockError ? true : undefined);
+    }
+  }
+}

--- a/apps/api/src/scheduler/seat-reconciliation.ts
+++ b/apps/api/src/scheduler/seat-reconciliation.ts
@@ -3,6 +3,7 @@ import { isBillingEnabled } from "../billing/config";
 import { syncWorkspaceSeats } from "../billing/controllers/sync-seats";
 import db from "../database";
 import { workspaceBillingTable, workspaceUserTable } from "../database/schema";
+import { SEAT_RECONCILIATION_LOCK, withLeaderLock } from "./leader-lock";
 
 const BATCH_SIZE = 100;
 
@@ -36,6 +37,12 @@ export async function reconcileWorkspaceSeats(): Promise<{
     return { degraded: false };
   }
 
+  return withLeaderLock(SEAT_RECONCILIATION_LOCK, runReconciliation, () => ({
+    degraded: false,
+  }));
+}
+
+async function runReconciliation(): Promise<{ degraded: boolean }> {
   let drifted: Awaited<ReturnType<typeof findDriftedWorkspaces>>;
   try {
     drifted = await findDriftedWorkspaces();

--- a/apps/api/src/ws/broadcast-adapter.ts
+++ b/apps/api/src/ws/broadcast-adapter.ts
@@ -12,12 +12,27 @@ export type BroadcastMessage = {
   excludeInitiatorId?: string;
 };
 
+export type UserBroadcastMessage = {
+  type: string;
+  [key: string]: unknown;
+};
+
+export type UserBroadcast = {
+  userId: string;
+  message: UserBroadcastMessage;
+  origin?: string;
+};
+
 export type BroadcastAdapter = {
   /** Publish a message to all instances watching this project */
   publish(msg: BroadcastMessage): Promise<void>;
 
+  publishToUser(msg: UserBroadcast): Promise<void>;
+
   /** Subscribe to messages for delivery to local connections */
   subscribe(handler: (msg: BroadcastMessage) => void): Promise<void>;
+
+  subscribeToUser(handler: (msg: UserBroadcast) => void): Promise<void>;
 
   /** Cleanup on shutdown */
   shutdown(): Promise<void>;

--- a/apps/api/src/ws/in-memory-broadcast-adapter.ts
+++ b/apps/api/src/ws/in-memory-broadcast-adapter.ts
@@ -1,18 +1,32 @@
-import type { BroadcastAdapter, BroadcastMessage } from "./broadcast-adapter";
+import type {
+  BroadcastAdapter,
+  BroadcastMessage,
+  UserBroadcast,
+} from "./broadcast-adapter";
 
 export class InMemoryBroadcastAdapter implements BroadcastAdapter {
   private handler?: (msg: BroadcastMessage) => void;
+  private userHandler?: (msg: UserBroadcast) => void;
 
   async publish(msg: BroadcastMessage): Promise<void> {
     // Deliver directly in the same process
     this.handler?.(msg);
   }
 
+  async publishToUser(msg: UserBroadcast): Promise<void> {
+    this.userHandler?.(msg);
+  }
+
   async subscribe(handler: (msg: BroadcastMessage) => void): Promise<void> {
     this.handler = handler;
   }
 
+  async subscribeToUser(handler: (msg: UserBroadcast) => void): Promise<void> {
+    this.userHandler = handler;
+  }
+
   async shutdown(): Promise<void> {
     this.handler = undefined;
+    this.userHandler = undefined;
   }
 }

--- a/apps/api/src/ws/index.ts
+++ b/apps/api/src/ws/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { WSContext } from "hono/ws";
 import { subscribeToEvent } from "../events";
 import { isRedisConfigured } from "../redis";
@@ -5,9 +6,13 @@ import type {
   BroadcastAdapter,
   BroadcastMessage,
   ProjectBroadcastMessage,
+  UserBroadcast,
+  UserBroadcastMessage,
 } from "./broadcast-adapter";
 import { InMemoryBroadcastAdapter } from "./in-memory-broadcast-adapter";
 import { RedisBroadcastAdapter } from "./redis-broadcast-adapter";
+
+const INSTANCE_ID = randomUUID();
 
 type ProjectConnection = {
   ws: WSContext;
@@ -44,9 +49,26 @@ export function removeUserConnection(userId: string, conn: UserConnection) {
   }
 }
 
-export function broadcastToUser(
+export function broadcastToUser(userId: string, message: UserBroadcastMessage) {
+  // Local sockets are served directly and never wait on Redis: a publish can
+  // succeed while this instance's subscriber is disconnected, which would
+  // otherwise lose the notification for users on the publishing instance.
+  deliverToLocalUserConnections(userId, message);
+
+  if (!adapter) {
+    return;
+  }
+
+  void adapter
+    .publishToUser({ userId, message, origin: INSTANCE_ID })
+    .catch((err) => {
+      console.error("Failed to publish a user broadcast:", err);
+    });
+}
+
+function deliverToLocalUserConnections(
   userId: string,
-  message: { type: string; [key: string]: unknown },
+  message: UserBroadcastMessage,
 ) {
   const connections = userConnections.get(userId);
   if (!connections) return;
@@ -99,6 +121,12 @@ export async function initializeWebSocketAdapter() {
         msg.message,
         msg.excludeInitiatorId,
       );
+    });
+    await nextAdapter.subscribeToUser((msg: UserBroadcast) => {
+      if (msg.origin === INSTANCE_ID) {
+        return;
+      }
+      deliverToLocalUserConnections(msg.userId, msg.message);
     });
   } catch (err) {
     await nextAdapter.shutdown().catch(() => {});

--- a/apps/api/src/ws/redis-broadcast-adapter.ts
+++ b/apps/api/src/ws/redis-broadcast-adapter.ts
@@ -1,11 +1,18 @@
 import type Redis from "ioredis";
 import * as v from "valibot";
 import { closeRedis, getRedisPub, getRedisSub } from "../redis";
-import type { BroadcastAdapter, BroadcastMessage } from "./broadcast-adapter";
+import type {
+  BroadcastAdapter,
+  BroadcastMessage,
+  UserBroadcast,
+} from "./broadcast-adapter";
 
 const CHANNEL_PREFIX = "kaneo:ws:";
 const CHANNEL_SUFFIX = ":broadcast";
 const CHANNEL_PATTERN = `${CHANNEL_PREFIX}*${CHANNEL_SUFFIX}`;
+
+const USER_CHANNEL_PREFIX = "kaneo:ws-user:";
+const USER_CHANNEL_PATTERN = `${USER_CHANNEL_PREFIX}*${CHANNEL_SUFFIX}`;
 
 const broadcastMessageSchema = v.object({
   projectId: v.string(),
@@ -19,9 +26,19 @@ const broadcastMessageSchema = v.object({
   excludeInitiatorId: v.optional(v.string()),
 });
 
+const userBroadcastSchema = v.object({
+  userId: v.string(),
+  message: v.looseObject({ type: v.string() }),
+  origin: v.optional(v.string()),
+});
+
 export class RedisBroadcastAdapter implements BroadcastAdapter {
   private subscribed = false;
+  private userSubscribed = false;
   private _pmessageHandler:
+    | ((pattern: string, channel: string, data: string) => void)
+    | null = null;
+  private _userPmessageHandler:
     | ((pattern: string, channel: string, data: string) => void)
     | null = null;
 
@@ -32,19 +49,25 @@ export class RedisBroadcastAdapter implements BroadcastAdapter {
     );
   }
 
+  async publishToUser(msg: UserBroadcast): Promise<void> {
+    await getRedisPub().publish(
+      this.channelForUser(msg.userId),
+      JSON.stringify(msg),
+    );
+  }
+
   async subscribe(handler: (msg: BroadcastMessage) => void): Promise<void> {
     if (this.subscribed) return;
     this.subscribed = true;
 
     // Pattern-subscribe to ALL project channels at once
-    await getRedisSub().psubscribe(CHANNEL_PATTERN);
-
     // "pmessage" fires for pattern subscriptions (not "message")
     this._pmessageHandler = (
-      _pattern: string,
+      pattern: string,
       _channel: string,
       data: string,
     ) => {
+      if (pattern !== CHANNEL_PATTERN) return;
       try {
         const parsed = v.safeParse(broadcastMessageSchema, JSON.parse(data));
         if (!parsed.success) {
@@ -57,20 +80,65 @@ export class RedisBroadcastAdapter implements BroadcastAdapter {
       }
     };
     (getRedisSub() as Redis).on("pmessage", this._pmessageHandler);
+    await getRedisSub().psubscribe(CHANNEL_PATTERN);
+  }
+
+  async subscribeToUser(handler: (msg: UserBroadcast) => void): Promise<void> {
+    if (this.userSubscribed) return;
+    this.userSubscribed = true;
+
+    this._userPmessageHandler = (
+      pattern: string,
+      channel: string,
+      data: string,
+    ) => {
+      if (pattern !== USER_CHANNEL_PATTERN) return;
+      try {
+        const parsed = v.safeParse(userBroadcastSchema, JSON.parse(data));
+        if (!parsed.success) {
+          console.error("Invalid user broadcast message:", parsed.issues);
+          return;
+        }
+        // The channel is the authority on the recipient; a payload that
+        // disagrees would deliver one user's message to another.
+        if (channel !== this.channelForUser(parsed.output.userId)) {
+          console.error("User broadcast channel and payload disagree");
+          return;
+        }
+        handler(parsed.output as UserBroadcast);
+      } catch (err) {
+        console.error("Failed to parse user broadcast message:", err);
+      }
+    };
+    (getRedisSub() as Redis).on("pmessage", this._userPmessageHandler);
+    await getRedisSub().psubscribe(USER_CHANNEL_PATTERN);
   }
 
   async shutdown(): Promise<void> {
+    const sub = getRedisSub() as Redis;
+
     if (this._pmessageHandler) {
-      (getRedisSub() as Redis).off("pmessage", this._pmessageHandler);
+      sub.off("pmessage", this._pmessageHandler);
       this._pmessageHandler = null;
     }
+    if (this._userPmessageHandler) {
+      sub.off("pmessage", this._userPmessageHandler);
+      this._userPmessageHandler = null;
+    }
+
     // Unsubscribe from the pattern, which covers all project channels
     await getRedisSub().punsubscribe(CHANNEL_PATTERN);
+    await getRedisSub().punsubscribe(USER_CHANNEL_PATTERN);
     this.subscribed = false;
+    this.userSubscribed = false;
     await closeRedis();
   }
 
   private channelForProject(projectId: string): string {
     return `${CHANNEL_PREFIX}${projectId}${CHANNEL_SUFFIX}`;
+  }
+
+  private channelForUser(userId: string): string {
+    return `${USER_CHANNEL_PREFIX}${userId}${CHANNEL_SUFFIX}`;
   }
 }

--- a/tests/api-integration/leader-lock.test.ts
+++ b/tests/api-integration/leader-lock.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import { withLeaderLock } from "../../apps/api/src/scheduler/leader-lock";
+
+const TEST_LOCK = 990125;
+
+describe("withLeaderLock", () => {
+  it("lets a second caller skip while the first still holds the lock", async () => {
+    let firstHasLock = false;
+    let secondRan = false;
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const first = withLeaderLock(
+      TEST_LOCK,
+      async () => {
+        firstHasLock = true;
+        await held;
+        return "ran";
+      },
+      () => "skipped",
+    );
+
+    try {
+      await vi.waitFor(() => {
+        expect(firstHasLock).toBe(true);
+      });
+
+      const second = await withLeaderLock(
+        TEST_LOCK,
+        async () => {
+          secondRan = true;
+          return "ran";
+        },
+        () => "skipped",
+      );
+
+      expect(second).toBe("skipped");
+      expect(secondRan).toBe(false);
+    } finally {
+      release();
+      await expect(first).resolves.toBe("ran");
+    }
+  });
+
+  it("releases the lock so a later run can take it", async () => {
+    const first = await withLeaderLock(
+      TEST_LOCK,
+      async () => "ran",
+      () => "skipped",
+    );
+    const second = await withLeaderLock(
+      TEST_LOCK,
+      async () => "ran",
+      () => "skipped",
+    );
+
+    expect(first).toBe("ran");
+    expect(second).toBe("ran");
+  });
+
+  it("releases the lock when the job throws", async () => {
+    await expect(
+      withLeaderLock(
+        TEST_LOCK,
+        async () => {
+          throw new Error("job blew up");
+        },
+        () => "skipped",
+      ),
+    ).rejects.toThrow("job blew up");
+
+    const after = await withLeaderLock(
+      TEST_LOCK,
+      async () => "ran",
+      () => "skipped",
+    );
+    expect(after).toBe("ran");
+  });
+
+  it("does not block a different lock key", async () => {
+    let holderHasLock = false;
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const holder = withLeaderLock(
+      TEST_LOCK,
+      async () => {
+        holderHasLock = true;
+        await held;
+        return "ran";
+      },
+      () => "skipped",
+    );
+
+    try {
+      await vi.waitFor(() => {
+        expect(holderHasLock).toBe(true);
+      });
+
+      const other = await withLeaderLock(
+        TEST_LOCK + 1,
+        async () => "ran",
+        () => "skipped",
+      );
+
+      expect(other).toBe("ran");
+    } finally {
+      release();
+      await holder;
+    }
+  });
+});

--- a/tests/api/ws/in-memory-broadcast-adapter.test.ts
+++ b/tests/api/ws/in-memory-broadcast-adapter.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import type { BroadcastMessage } from "../../../apps/api/src/ws/broadcast-adapter";
+import type {
+  BroadcastMessage,
+  UserBroadcast,
+} from "../../../apps/api/src/ws/broadcast-adapter";
 import { InMemoryBroadcastAdapter } from "../../../apps/api/src/ws/in-memory-broadcast-adapter";
 
 describe("InMemoryBroadcastAdapter", () => {
@@ -83,5 +86,28 @@ describe("InMemoryBroadcastAdapter", () => {
 
     expect(first).toHaveLength(0);
     expect(second).toHaveLength(1);
+  });
+
+  it("delivers user-targeted messages to the user handler only", async () => {
+    const adapter = new InMemoryBroadcastAdapter();
+    const projectMessages: BroadcastMessage[] = [];
+    const userMessages: UserBroadcast[] = [];
+
+    await adapter.subscribe((msg) => {
+      projectMessages.push(msg);
+    });
+    await adapter.subscribeToUser((msg) => {
+      userMessages.push(msg);
+    });
+
+    await adapter.publishToUser({
+      userId: "user-1",
+      message: { type: "NOTIFICATION_CREATED" },
+    });
+
+    expect(userMessages).toEqual([
+      { userId: "user-1", message: { type: "NOTIFICATION_CREATED" } },
+    ]);
+    expect(projectMessages).toHaveLength(0);
   });
 });

--- a/tests/api/ws/user-broadcast-redis-failure.test.ts
+++ b/tests/api/ws/user-broadcast-redis-failure.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../apps/api/src/events", () => ({
+  subscribeToEvent: vi.fn(),
+  publishEvent: vi.fn(),
+}));
+
+const publish = vi.fn();
+const listeners: Array<(p: string, c: string, d: string) => void> = [];
+const subscriber = {
+  psubscribe: vi.fn().mockResolvedValue(undefined),
+  punsubscribe: vi.fn().mockResolvedValue(undefined),
+  on: vi.fn((event: string, fn: (p: string, c: string, d: string) => void) => {
+    if (event === "pmessage") listeners.push(fn);
+  }),
+  off: vi.fn(
+    (_event: string, fn: (p: string, c: string, d: string) => void) => {
+      const i = listeners.indexOf(fn);
+      if (i >= 0) listeners.splice(i, 1);
+    },
+  ),
+};
+
+vi.mock("../../../apps/api/src/redis", () => ({
+  isRedisConfigured: () => true,
+  getRedisPub: () => ({ publish }),
+  getRedisSub: () => subscriber,
+  closeRedis: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  addUserConnection,
+  broadcastToUser,
+  initializeWebSocketAdapter,
+  removeUserConnection,
+  shutdownWebSocketAdapter,
+} from "../../../apps/api/src/ws/index";
+
+const USER_PATTERN = "kaneo:ws-user:*:broadcast";
+
+function makeFakeWs() {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: 1,
+    raw: undefined,
+    url: null,
+    protocol: null,
+  } as never;
+}
+
+function sendMock(ws: unknown) {
+  return (ws as { send: ReturnType<typeof vi.fn> }).send;
+}
+
+function emitUserBroadcast(payload: unknown, channelUserId = "user-1") {
+  const data = JSON.stringify(payload);
+  for (const fn of [...listeners]) {
+    fn(USER_PATTERN, `kaneo:ws-user:${channelUserId}:broadcast`, data);
+  }
+}
+
+describe("broadcastToUser with the redis adapter", () => {
+  beforeEach(async () => {
+    publish.mockReset().mockResolvedValue(1);
+    listeners.length = 0;
+    await initializeWebSocketAdapter();
+  });
+
+  afterEach(async () => {
+    await shutdownWebSocketAdapter();
+  });
+
+  it("delivers to local sockets without waiting on redis", async () => {
+    const ws = makeFakeWs();
+    const conn = addUserConnection("user-1", ws);
+
+    broadcastToUser("user-1", { type: "NOTIFICATION_CREATED" });
+
+    expect(sendMock(ws)).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(sendMock(ws).mock.calls[0][0]).type).toBe(
+      "NOTIFICATION_CREATED",
+    );
+
+    removeUserConnection("user-1", conn);
+  });
+
+  it("still delivers locally when the publish fails", async () => {
+    publish.mockRejectedValue(new Error("redis is down"));
+
+    const ws = makeFakeWs();
+    const conn = addUserConnection("user-1", ws);
+
+    broadcastToUser("user-1", { type: "NOTIFICATION_CREATED" });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(sendMock(ws)).toHaveBeenCalledTimes(1);
+
+    removeUserConnection("user-1", conn);
+  });
+
+  it("ignores its own echo so the socket is written once", async () => {
+    const ws = makeFakeWs();
+    const conn = addUserConnection("user-1", ws);
+
+    broadcastToUser("user-1", { type: "NOTIFICATION_CREATED" });
+    expect(publish).toHaveBeenCalledTimes(1);
+
+    const published = JSON.parse(publish.mock.calls[0][1]);
+    expect(published.origin).toEqual(expect.any(String));
+
+    emitUserBroadcast(published);
+
+    expect(sendMock(ws)).toHaveBeenCalledTimes(1);
+
+    removeUserConnection("user-1", conn);
+  });
+
+  it("delivers a broadcast published by another instance", async () => {
+    const ws = makeFakeWs();
+    const conn = addUserConnection("user-1", ws);
+
+    emitUserBroadcast({
+      userId: "user-1",
+      message: { type: "NOTIFICATION_CREATED" },
+      origin: "some-other-instance",
+    });
+
+    expect(sendMock(ws)).toHaveBeenCalledTimes(1);
+
+    removeUserConnection("user-1", conn);
+  });
+
+  it("drops a message whose payload disagrees with its channel", async () => {
+    const ws = makeFakeWs();
+    const conn = addUserConnection("user-1", ws);
+
+    emitUserBroadcast(
+      {
+        userId: "user-1",
+        message: { type: "NOTIFICATION_CREATED" },
+        origin: "some-other-instance",
+      },
+      "user-2",
+    );
+
+    expect(sendMock(ws)).not.toHaveBeenCalled();
+
+    removeUserConnection("user-1", conn);
+  });
+});

--- a/tests/api/ws/user-broadcast.test.ts
+++ b/tests/api/ws/user-broadcast.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../apps/api/src/events", () => ({
+  subscribeToEvent: vi.fn(),
+  publishEvent: vi.fn(),
+}));
+
+import {
+  addUserConnection,
+  broadcastToUser,
+  initializeWebSocketAdapter,
+  removeUserConnection,
+  shutdownWebSocketAdapter,
+} from "../../../apps/api/src/ws/index";
+
+function makeFakeWs() {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: 1,
+    raw: undefined,
+    url: null,
+    protocol: null,
+  } as never;
+}
+
+function sendMock(ws: unknown) {
+  return (ws as { send: ReturnType<typeof vi.fn> }).send;
+}
+
+describe("broadcastToUser", () => {
+  const originalRedisUrl = process.env.REDIS_URL;
+
+  beforeEach(async () => {
+    delete process.env.REDIS_URL;
+    await initializeWebSocketAdapter();
+  });
+
+  afterEach(async () => {
+    await shutdownWebSocketAdapter();
+    if (originalRedisUrl === undefined) {
+      delete process.env.REDIS_URL;
+    } else {
+      process.env.REDIS_URL = originalRedisUrl;
+    }
+  });
+
+  it("delivers a message to every socket the user has open", async () => {
+    const first = makeFakeWs();
+    const second = makeFakeWs();
+    const connA = addUserConnection("user-1", first);
+    const connB = addUserConnection("user-1", second);
+
+    broadcastToUser("user-1", { type: "NOTIFICATION_CREATED" });
+
+    await vi.waitFor(
+      () => {
+        expect(sendMock(first)).toHaveBeenCalled();
+        expect(sendMock(second)).toHaveBeenCalled();
+      },
+      { timeout: 300 },
+    );
+
+    expect(JSON.parse(sendMock(first).mock.calls[0][0]).type).toBe(
+      "NOTIFICATION_CREATED",
+    );
+
+    removeUserConnection("user-1", connA);
+    removeUserConnection("user-1", connB);
+  });
+
+  it("does not deliver a message to a different user", async () => {
+    const mine = makeFakeWs();
+    const theirs = makeFakeWs();
+    const connA = addUserConnection("user-1", mine);
+    const connB = addUserConnection("user-2", theirs);
+
+    broadcastToUser("user-1", { type: "NOTIFICATION_CREATED" });
+
+    await vi.waitFor(
+      () => {
+        expect(sendMock(mine)).toHaveBeenCalled();
+      },
+      { timeout: 300 },
+    );
+
+    expect(sendMock(theirs)).not.toHaveBeenCalled();
+
+    removeUserConnection("user-1", connA);
+    removeUserConnection("user-2", connB);
+  });
+
+  it("still delivers locally when no adapter is initialised", async () => {
+    await shutdownWebSocketAdapter();
+
+    const ws = makeFakeWs();
+    const conn = addUserConnection("user-1", ws);
+
+    broadcastToUser("user-1", { type: "NOTIFICATION_CREATED" });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(sendMock(ws)).toHaveBeenCalled();
+
+    removeUserConnection("user-1", conn);
+    await initializeWebSocketAdapter();
+  });
+});


### PR DESCRIPTION
## Description

Two places that quietly assume a single process. Both are invisible on one instance and wrong on more than one, which is the combination the Helm chart's `autoscaling` values invite.

**Notifications never crossed instances.** `broadcastToUser` wrote straight to the local `userConnections` map and never touched the broadcast adapter, so `NOTIFICATION_CREATED` only reached sockets on the instance that raised it. A user connected to instance B saw nothing for a notification raised on instance A — the bell only caught up on the next poll. Project broadcasts already went through the adapter; user broadcasts now do too, and local sockets are served from the subscription like the project path.

The Redis channel is `kaneo:ws-user:`, **not** `kaneo:ws:user:`. A Redis glob `*` spans colons, so the obvious name would also match the existing `kaneo:ws:*:broadcast` pattern and every user message would be parsed against the project schema and dropped. The project channel and pattern are untouched, so a rolling upgrade keeps delivering while both versions are live.

**Seat reconciliation ran on every replica at once.** `initializeScheduler()` starts all four crons on every process with no leader election. The two reminder jobs survive that because they claim each send against a unique constraint before doing any work, but `reconcileWorkspaceSeats` has no such claim — so N replicas each called the billing provider for the same drifted workspace on every tick. It now runs under an advisory lock and a replica that cannot take it skips.

The lock is session-scoped (`pg_try_advisory_lock` on a dedicated pool connection) rather than the `pg_advisory_xact_lock` used in `auth.ts` and project ordering, because it has to be held across outbound HTTP calls to the billing provider, which do not belong inside an open transaction. `withLeaderLock` is written to be reusable if another job needs it.

## Related Issue(s)

None — found while auditing the codebase, not reported.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

`BroadcastAdapter` gains `publishToUser` and `subscribeToUser`. Both implementations in the repo are updated; the type is internal to `apps/api`.

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

`tests/api/ws/user-broadcast.test.ts` covers delivery to every socket a user has open, isolation from other users, and the single-instance path with no adapter initialised. `tests/api/ws/in-memory-broadcast-adapter.test.ts` gains a case asserting a user message reaches the user handler and not the project handler.

`tests/api-integration/leader-lock.test.ts` runs against real Postgres and covers the property that matters: while one caller holds the lock a second caller skips rather than running, the lock is released for the next run, it is released even when the job throws, and a different key is not blocked.

`385 unit / 188 integration` pass locally (`381 / 184` before this PR). Typecheck and `biome ci` are clean.

## Screenshots (if applicable)

n/a

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I understand and take responsibility for every change, and I wrote this pull request description in my own words
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Two checklist items are deliberately unticked:

- **Authorship** — this branch was written by Claude Code, as recorded in the `Co-Authored-By` trailer. The box asserting the description is in the author's own words is left for the reviewer to tick after their own review.
- **Comments** — `AGENTS.md` asks for comments that explain constraints rather than narrate code, and the reasoning here is in the commit body and this description instead. The `kaneo:ws-user:` prefix is the one thing here that is genuinely non-obvious from the code, so it is spelled out above.

The multi-instance user-delivery path is exercised through the in-memory adapter, not a live two-instance Redis setup. The Redis side is the same publish/psubscribe shape as the project channel, with the pattern collision handled explicitly, but it has not been run against two processes.

`withLeaderLock` holds one pool connection for the duration of the job. The pool max is 10 and only seat reconciliation uses it, so this is not contended today — worth remembering if more jobs adopt it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added user-targeted WebSocket broadcasts through local and Redis-backed delivery.
  - Messages reach all active connections for a specific user while remaining isolated from others.
  - Added coordination so seat reconciliation runs on only one active server at a time.

- **Bug Fixes**
  - Improved local fallback delivery when cross-server publishing is unavailable.
  - Strengthened cleanup and recovery after broadcast or reconciliation failures.

- **Tests**
  - Added coverage for targeted delivery, user isolation, lock coordination, and failure recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->