### PR TITLE
fix: hide "Mark as planned" for backlog tasks

### DIFF
--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.test.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.test.tsx
@@ -1,6 +1,5 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu";
 import type Task from "@/types/task";
 import TaskCardContextMenuContent from "./task-card-context-menu-content";
 
@@ -8,6 +7,29 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
+
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ContextMenuItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ContextMenuSeparator: () => <div />,
+  ContextMenuSub: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ContextMenuSubContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ContextMenuSubTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ContextMenuCheckboxItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
 
 vi.mock("@/hooks/queries/column/use-get-columns", () => ({
   useGetColumns: () => ({
@@ -73,7 +95,7 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
-const task: Task = {
+const task = {
   id: "task-1",
   title: "Test task",
   number: 1,
@@ -88,48 +110,38 @@ const task: Task = {
   assigneeId: null,
   assigneeName: null,
   projectId: "project-1",
-};
+} as const satisfies Task;
 
 const taskCardContext = {
   projectId: "project-1",
   worskpaceId: "workspace-1",
 };
 
-function renderContextMenu(testTask: Task) {
+function renderTask(taskToRender: Task) {
   render(
-    <ContextMenu>
-      <ContextMenuTrigger asChild>
-        <div data-testid="trigger">Open menu</div>
-      </ContextMenuTrigger>
-
-      <TaskCardContextMenuContent
-        task={testTask}
-        taskCardContext={taskCardContext}
-        onDeleteClick={vi.fn()}
-      />
-    </ContextMenu>,
+    <TaskCardContextMenuContent
+      task={taskToRender}
+      taskCardContext={taskCardContext}
+      onDeleteClick={vi.fn()}
+    />,
   );
-
-  fireEvent.contextMenu(screen.getByTestId("trigger"));
 }
 
 describe("TaskCardContextMenuContent", () => {
-  it("hides Mark as planned for planned tasks", async () => {
-    renderContextMenu({
+  it("hides Mark as planned for planned tasks", () => {
+    renderTask({
       ...task,
       status: "planned",
     });
 
     expect(
-      await screen.queryByText("tasks:actions.markAsPlanned"),
+      screen.queryByText("tasks:actions.markAsPlanned"),
     ).not.toBeInTheDocument();
   });
 
-  it("shows Mark as planned for tasks that are not planned", async () => {
-    renderContextMenu(task);
+  it("shows Mark as planned for tasks that are not planned", () => {
+    renderTask(task);
 
-    expect(
-      await screen.findByText("tasks:actions.markAsPlanned"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("tasks:actions.markAsPlanned")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.test.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.test.tsx
@@ -9,26 +9,42 @@ afterEach(() => {
 });
 
 vi.mock("@/components/ui/context-menu", () => ({
-  ContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ContextMenuContent: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  ContextMenuItem: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  ContextMenuSeparator: () => <div />,
-  ContextMenuSub: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  ContextMenuSubContent: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  ContextMenuSubTrigger: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  ContextMenuCheckboxItem: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
+  ContextMenu: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }): React.JSX.Element => <>{children}</>,
+  ContextMenuContent: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }): React.JSX.Element => <div>{children}</div>,
+  ContextMenuItem: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }): React.JSX.Element => <div>{children}</div>,
+  ContextMenuSeparator: (): React.JSX.Element => <div />,
+  ContextMenuSub: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }): React.JSX.Element => <div>{children}</div>,
+  ContextMenuSubContent: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }): React.JSX.Element => <div>{children}</div>,
+  ContextMenuSubTrigger: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }): React.JSX.Element => <div>{children}</div>,
+  ContextMenuCheckboxItem: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }): React.JSX.Element => <div>{children}</div>,
 }));
 
 vi.mock("@/hooks/queries/column/use-get-columns", () => ({
@@ -76,7 +92,8 @@ vi.mock("@/hooks/mutations/task/use-update-task-title", () => ({
 
 vi.mock("@/hooks/use-workspace-permission", () => ({
   useWorkspacePermission: () => ({
-    canManageTasks: () => true,
+    canUpdateTasks: () => true,
+    canDeleteTasks: () => true,
     canAssignTasks: () => true,
   }),
 }));

--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.test.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.test.tsx
@@ -1,0 +1,135 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu";
+import type Task from "@/types/task";
+import TaskCardContextMenuContent from "./task-card-context-menu-content";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+vi.mock("@/hooks/queries/column/use-get-columns", () => ({
+  useGetColumns: () => ({
+    data: [],
+  }),
+}));
+
+vi.mock(
+  "@/hooks/queries/workspace-users/use-get-active-workspace-users",
+  () => ({
+    useGetActiveWorkspaceUsers: () => ({
+      data: { members: [] },
+    }),
+  }),
+);
+
+vi.mock("@/hooks/mutations/task/use-update-task", () => ({
+  useUpdateTask: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/mutations/task/use-update-task-assignee", () => ({
+  useUpdateTaskAssignee: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/mutations/task/use-update-task-description", () => ({
+  useUpdateTaskDescription: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/mutations/task/use-update-task-due-date", () => ({
+  useUpdateTaskDueDate: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/mutations/task/use-update-task-status", () => ({
+  useUpdateTaskStatus: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/mutations/task/use-update-task-status-priority", () => ({
+  useUpdateTaskPriority: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/mutations/task/use-update-task-title", () => ({
+  useUpdateTaskTitle: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-workspace-permission", () => ({
+  useWorkspacePermission: () => ({
+    canManageTasks: () => true,
+    canAssignTasks: () => true,
+  }),
+}));
+
+vi.mock("@/store/project", () => ({
+  default: () => ({
+    project: {
+      columns: [],
+    },
+  }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const task: Task = {
+  id: "task-1",
+  title: "Test task",
+  number: 1,
+  description: null,
+  status: "to-do",
+  priority: null,
+  startDate: null,
+  dueDate: null,
+  position: 1,
+  createdAt: "2026-08-05T00:00:00.000Z",
+  userId: null,
+  assigneeId: null,
+  assigneeName: null,
+  projectId: "project-1",
+};
+
+const taskCardContext = {
+  projectId: "project-1",
+  worskpaceId: "workspace-1",
+};
+
+function renderContextMenu(testTask: Task) {
+  render(
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div data-testid="trigger">Open menu</div>
+      </ContextMenuTrigger>
+
+      <TaskCardContextMenuContent
+        task={testTask}
+        taskCardContext={taskCardContext}
+        onDeleteClick={vi.fn()}
+      />
+    </ContextMenu>,
+  );
+
+  fireEvent.contextMenu(screen.getByTestId("trigger"));
+}
+
+describe("TaskCardContextMenuContent", () => {
+  it("hides Mark as planned for planned tasks", async () => {
+    renderContextMenu({
+      ...task,
+      status: "planned",
+    });
+
+    expect(
+      await screen.queryByText("tasks:actions.markAsPlanned"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Mark as planned for tasks that are not planned", async () => {
+    renderContextMenu(task);
+
+    expect(
+      await screen.findByText("tasks:actions.markAsPlanned"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
+++ b/apps/web/src/components/kanban-board/task-card-context-menu/task-card-context-menu-content.tsx
@@ -307,11 +307,13 @@ export default function TaskCardContextMenuContent({
                 <span>{t("tasks:actions.archive")}</span>
               </ContextMenuItem>
 
-              <ContextMenuItem
-                onClick={() => handleChange("status", "planned")}
-              >
-                <span>{t("tasks:actions.markAsPlanned")}</span>
-              </ContextMenuItem>
+              {task.status !== "planned" && (
+                <ContextMenuItem
+                  onClick={() => handleChange("status", "planned")}
+                >
+                  <span>{t("tasks:actions.markAsPlanned")}</span>
+                </ContextMenuItem>
+              )}
             </>
           )}
 


### PR DESCRIPTION
## Related Issue(s)

Fixes #1645

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

Before: "Mark as planned" is shown for tasks already in the backlog.

After: "Mark as planned" is hidden for tasks already in the backlog.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I understand and take responsibility for every change, and I wrote this pull request description in my own words
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The “Mark as planned” action is now hidden for tasks that are already marked as planned, reducing redundant menu options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->