### PR TITLE
fix(web): protect unsaved task input

### DIFF
--- a/apps/web/src/components/shared/modals/create-task-modal.test.tsx
+++ b/apps/web/src/components/shared/modals/create-task-modal.test.tsx
@@ -85,7 +85,37 @@ vi.mock("react-i18next", () => ({
   initReactI18next: { type: "3rdParty", init: vi.fn() },
 }));
 
-describe("CreateTaskModal project picker", () => {
+describe("CreateTaskModal", () => {
+  it("keeps unsaved input until the user confirms discarding it", async () => {
+    useLocation.mockReturnValue({
+      pathname: "/dashboard/workspace/workspace-1/project/project-1/board",
+    });
+    const onClose = vi.fn();
+
+    render(<CreateTaskModal open onClose={onClose} />);
+
+    const titleInput = screen.getByPlaceholderText(
+      "common:modals.createTask.taskTitlePlaceholder",
+    );
+    fireEvent.change(titleInput, { target: { value: "Unsaved task" } });
+
+    const backdrop = document.querySelector('[data-slot="dialog-backdrop"]');
+    expect(backdrop).not.toBeNull();
+    fireEvent.pointerDown(backdrop as Element);
+    fireEvent.pointerUp(backdrop as Element);
+    fireEvent.click(backdrop as Element);
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText("common:modals.createTask.discardTitle"),
+    ).toBeTruthy();
+    expect(titleInput).toHaveValue("Unsaved task");
+
+    fireEvent.click(screen.getByText("common:modals.createTask.discardButton"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it("shows a project picker and creates the task in the chosen project", async () => {
     useLocation.mockReturnValue({
       pathname: "/dashboard/workspace/workspace-1",

--- a/apps/web/src/components/shared/modals/create-task-modal.test.tsx
+++ b/apps/web/src/components/shared/modals/create-task-modal.test.tsx
@@ -86,7 +86,7 @@ vi.mock("react-i18next", () => ({
 }));
 
 describe("CreateTaskModal", () => {
-  it("keeps unsaved input until the user confirms discarding it", async () => {
+  it("keeps unsaved input while discard confirmation is open", async () => {
     useLocation.mockReturnValue({
       pathname: "/dashboard/workspace/workspace-1/project/project-1/board",
     });
@@ -111,9 +111,55 @@ describe("CreateTaskModal", () => {
     ).toBeTruthy();
     expect(titleInput).toHaveValue("Unsaved task");
 
+    fireEvent.keyDown(document, { key: "Enter", ctrlKey: true });
+
+    expect(createTask).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes after the user confirms discarding unsaved input", async () => {
+    useLocation.mockReturnValue({
+      pathname: "/dashboard/workspace/workspace-1/project/project-1/board",
+    });
+    const onClose = vi.fn();
+
+    render(<CreateTaskModal open onClose={onClose} />);
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "common:modals.createTask.taskTitlePlaceholder",
+      ),
+      { target: { value: "Unsaved task" } },
+    );
+    const backdrop = document.querySelector('[data-slot="dialog-backdrop"]');
+    fireEvent.pointerDown(backdrop as Element);
+    fireEvent.pointerUp(backdrop as Element);
+    fireEvent.click(backdrop as Element);
+
+    await screen.findByText("common:modals.createTask.discardTitle");
+
     fireEvent.click(screen.getByText("common:modals.createTask.discardButton"));
 
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a selected project as unsaved input", async () => {
+    useLocation.mockReturnValue({
+      pathname: "/dashboard/workspace/workspace-1",
+    });
+
+    render(<CreateTaskModal open onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByText("common:modals.createTask.selectProject"));
+    fireEvent.click(await screen.findByText("Beta"));
+    const backdrop = document.querySelector('[data-slot="dialog-backdrop"]');
+    fireEvent.pointerDown(backdrop as Element);
+    fireEvent.pointerUp(backdrop as Element);
+    fireEvent.click(backdrop as Element);
+
+    expect(
+      await screen.findByText("common:modals.createTask.discardTitle"),
+    ).toBeTruthy();
   });
 
   it("shows a project picker and creates the task in the chosen project", async () => {

--- a/apps/web/src/components/shared/modals/create-task-modal.tsx
+++ b/apps/web/src/components/shared/modals/create-task-modal.tsx
@@ -13,6 +13,15 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import TaskDescriptionEditor from "@/components/task/task-description-editor";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -191,6 +200,7 @@ function CreateTaskModal({
   const [createMore, setCreateMore] = useState(false);
   const [labels, setLabels] = useState<Label[]>([]);
   const [draftTask, setDraftTask] = useState<Task | null>(null);
+  const [discardConfirmationOpen, setDiscardConfirmationOpen] = useState(false);
 
   const [labelsOpen, setLabelsOpen] = useState(false);
   const [labelsStep, setLabelsStep] = useState<PopoverStep>("select");
@@ -241,9 +251,21 @@ function CreateTaskModal({
       (label) => label.name.toLowerCase() === searchValue.toLowerCase(),
     );
 
-  const handleClose = () => {
+  const hasUnsavedChanges = Boolean(
+    title.trim() ||
+      description.trim() ||
+      priority !== "no-priority" ||
+      assigneeId ||
+      startDate ||
+      dueDate ||
+      labels.length > 0 ||
+      draftTask,
+  );
+
+  const closeAndReset = () => {
     const shouldDeleteDraft = draftTask && !didSubmitRef.current;
 
+    setDiscardConfirmationOpen(false);
     setTitle("");
     setDescription("");
     setPriority("no-priority");
@@ -266,6 +288,17 @@ function CreateTaskModal({
         // ignore cleanup failures for abandoned empty drafts
       });
     }
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) return;
+
+    if (hasUnsavedChanges && !didSubmitRef.current) {
+      setDiscardConfirmationOpen(true);
+      return;
+    }
+
+    closeAndReset();
   };
 
   const syncTaskIntoProject = useCallback(
@@ -451,7 +484,7 @@ function CreateTaskModal({
         didSubmitRef.current = false;
         setDraftTask(null);
       } else {
-        handleClose();
+        closeAndReset();
       }
     } catch (error) {
       didSubmitRef.current = false;
@@ -598,7 +631,7 @@ function CreateTaskModal({
   if (!canCreateTaskCapability) return null;
 
   return (
-    <Dialog open={open} onOpenChange={handleClose}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         className="kaneo-create-task-modal max-w-2xl max-h-[90vh] flex flex-col overflow-hidden"
         showCloseButton={false}
@@ -1084,7 +1117,7 @@ function CreateTaskModal({
 
             <Button
               type="button"
-              onClick={handleClose}
+              onClick={() => handleOpenChange(false)}
               variant="outline"
               size="sm"
               className="border-border text-foreground hover:bg-accent"
@@ -1102,6 +1135,37 @@ function CreateTaskModal({
           </DialogFooter>
         </form>
       </DialogContent>
+
+      <AlertDialog
+        open={discardConfirmationOpen}
+        onOpenChange={setDiscardConfirmationOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("common:modals.createTask.discardTitle")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("common:modals.createTask.discardDescription")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose
+              render={<Button type="button" variant="outline" size="sm" />}
+            >
+              {t("common:actions.cancel")}
+            </AlertDialogClose>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={closeAndReset}
+            >
+              {t("common:modals.createTask.discardButton")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Dialog>
   );
 }

--- a/apps/web/src/components/shared/modals/create-task-modal.tsx
+++ b/apps/web/src/components/shared/modals/create-task-modal.tsx
@@ -258,6 +258,7 @@ function CreateTaskModal({
       assigneeId ||
       startDate ||
       dueDate ||
+      selectedProjectId ||
       labels.length > 0 ||
       draftTask,
   );
@@ -272,6 +273,7 @@ function CreateTaskModal({
     setAssigneeId("");
     setStartDate(undefined);
     setDueDate(undefined);
+    setSelectedProjectId("");
     setCreateMore(false);
     setLabels([]);
     setLabelsStep("select");
@@ -527,7 +529,7 @@ function CreateTaskModal({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (!open) return;
+      if (!open || discardConfirmationOpen) return;
 
       if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
         e.preventDefault();
@@ -541,7 +543,7 @@ function CreateTaskModal({
         }
       }
     },
-    [open, title, resolvedProjectId, workspace?.id],
+    [open, discardConfirmationOpen, title, resolvedProjectId, workspace?.id],
   );
 
   useEffect(() => {

--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Label konnte nicht erstellt werden",
 				"createMore": "Weitere erstellen",
 				"createButton": "Aufgabe erstellen",
+				"discardTitle": "Aufgabe verwerfen?",
+				"discardDescription": "Deine ungespeicherten Aufgabendetails gehen verloren.",
+				"discardButton": "Aufgabe verwerfen",
 				"untitledTask": "Unbenannte Aufgabe",
 				"labelColors": {
 					"stone": "Stein",

--- a/i18n/el-GR.json
+++ b/i18n/el-GR.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Αποτυχία δημιουργίας ετικέτας",
 				"createMore": "Δημιουργία περισσότερων",
 				"createButton": "Δημιουργία εργασίας",
+				"discardTitle": "Απόρριψη εργασίας;",
+				"discardDescription": "Οι μη αποθηκευμένες λεπτομέρειες της εργασίας θα χαθούν.",
+				"discardButton": "Απόρριψη εργασίας",
 				"untitledTask": "Εργασία χωρίς τίτλο",
 				"labelColors": {
 					"stone": "Πέτρα",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Failed to create label",
 				"createMore": "Create more",
 				"createButton": "Create Task",
+				"discardTitle": "Discard task?",
+				"discardDescription": "Your unsaved task details will be lost.",
+				"discardButton": "Discard task",
 				"untitledTask": "Untitled task",
 				"labelColors": {
 					"stone": "Stone",

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Error al crear la etiqueta",
 				"createMore": "Crear más",
 				"createButton": "Crear tarea",
+				"discardTitle": "¿Descartar tarea?",
+				"discardDescription": "Los detalles de la tarea que no hayas guardado se perderán.",
+				"discardButton": "Descartar tarea",
 				"untitledTask": "Tarea sin título",
 				"labelColors": {
 					"stone": "Piedra",

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Échec de la création du label",
 				"createMore": "Créer plus",
 				"createButton": "Créer la tâche",
+				"discardTitle": "Abandonner la tâche ?",
+				"discardDescription": "Les détails non enregistrés de la tâche seront perdus.",
+				"discardButton": "Abandonner la tâche",
 				"untitledTask": "Tâche sans titre",
 				"labelColors": {
 					"stone": "Pierre",

--- a/i18n/hi-IN.json
+++ b/i18n/hi-IN.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "लेबल बनाने में विफल",
 				"createMore": "और बनाएँ",
 				"createButton": "कार्य बनाएँ",
+				"discardTitle": "कार्य छोड़ें?",
+				"discardDescription": "आपके सहेजे नहीं गए कार्य विवरण खो जाएँगे।",
+				"discardButton": "कार्य छोड़ें",
 				"untitledTask": "बिना शीर्षक कार्य",
 				"labelColors": {
 					"stone": "पत्थर",

--- a/i18n/id-ID.json
+++ b/i18n/id-ID.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Gagal membuat label",
 				"createMore": "Buat lagi",
 				"createButton": "Buat Tugas",
+				"discardTitle": "Buang tugas?",
+				"discardDescription": "Detail tugas yang belum disimpan akan hilang.",
+				"discardButton": "Buang tugas",
 				"untitledTask": "Tugas tanpa judul",
 				"labelColors": {
 					"stone": "Abu Batu",

--- a/i18n/it-IT.json
+++ b/i18n/it-IT.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Creazione etichetta fallita",
 				"createMore": "Crea altro",
 				"createButton": "Crea Attività",
+				"discardTitle": "Scartare l'attività?",
+				"discardDescription": "I dettagli non salvati dell'attività andranno persi.",
+				"discardButton": "Scarta attività",
 				"untitledTask": "Attività senza titolo",
 				"labelColors": {
 					"stone": "Pietra",

--- a/i18n/ja-JP.json
+++ b/i18n/ja-JP.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "ラベルの作成に失敗しました",
 				"createMore": "続けて作成",
 				"createButton": "タスクを作成",
+				"discardTitle": "タスクを破棄しますか？",
+				"discardDescription": "保存されていないタスクの詳細は失われます。",
+				"discardButton": "タスクを破棄",
 				"untitledTask": "無題のタスク",
 				"labelColors": {
 					"stone": "ストーン",

--- a/i18n/ko-KR.json
+++ b/i18n/ko-KR.json
@@ -139,9 +139,9 @@
 				"labelCreateError": "라벨 생성에 실패했습니다",
 				"createMore": "계속 만들기",
 				"createButton": "작업 만들기",
-				"discardTitle": "작업을 취소할까요?",
+				"discardTitle": "작성 중인 작업을 버릴까요?",
 				"discardDescription": "저장하지 않은 작업 세부 정보가 손실됩니다.",
-				"discardButton": "작업 취소",
+				"discardButton": "작업 버리기",
 				"untitledTask": "제목 없는 작업",
 				"labelColors": {
 					"stone": "스톤",

--- a/i18n/ko-KR.json
+++ b/i18n/ko-KR.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "라벨 생성에 실패했습니다",
 				"createMore": "계속 만들기",
 				"createButton": "작업 만들기",
+				"discardTitle": "작업을 취소할까요?",
+				"discardDescription": "저장하지 않은 작업 세부 정보가 손실됩니다.",
+				"discardButton": "작업 취소",
 				"untitledTask": "제목 없는 작업",
 				"labelColors": {
 					"stone": "스톤",

--- a/i18n/mk-MK.json
+++ b/i18n/mk-MK.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Неуспешно креирање на етикета",
 				"createMore": "Креирај уште",
 				"createButton": "Креирај задача",
+				"discardTitle": "Да се отфрли задачата?",
+				"discardDescription": "Незачуваните детали за задачата ќе се изгубат.",
+				"discardButton": "Отфрли ја задачата",
 				"untitledTask": "Задача без наслов",
 				"labelColors": {
 					"stone": "Камен",

--- a/i18n/nl-NL.json
+++ b/i18n/nl-NL.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Aanmaken van label mislukt",
 				"createMore": "Meer aanmaken",
 				"createButton": "Taak aanmaken",
+				"discardTitle": "Taak verwerpen?",
+				"discardDescription": "Je niet-opgeslagen taakgegevens gaan verloren.",
+				"discardButton": "Taak verwerpen",
 				"untitledTask": "Naamloze taak",
 				"labelColors": {
 					"stone": "Steen",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Falha ao criar etiqueta",
 				"createMore": "Criar mais",
 				"createButton": "Criar tarefa",
+				"discardTitle": "Descartar tarefa?",
+				"discardDescription": "Os detalhes não salvos da tarefa serão perdidos.",
+				"discardButton": "Descartar tarefa",
 				"untitledTask": "Tarefa sem título",
 				"labelColors": {
 					"stone": "Pedra",

--- a/i18n/ru-RU.json
+++ b/i18n/ru-RU.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Не удалось создать метку",
 				"createMore": "Создать ещё",
 				"createButton": "Создать задачу",
+				"discardTitle": "Отменить задачу?",
+				"discardDescription": "Несохранённые данные задачи будут потеряны.",
+				"discardButton": "Отменить задачу",
 				"untitledTask": "Задача без названия",
 				"labelColors": {
 					"stone": "Камень",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -515,6 +515,15 @@
 								"createButton": {
 									"type": "string"
 								},
+								"discardTitle": {
+									"type": "string"
+								},
+								"discardDescription": {
+									"type": "string"
+								},
+								"discardButton": {
+									"type": "string"
+								},
 								"untitledTask": {
 									"type": "string"
 								},
@@ -593,6 +602,9 @@
 								"labelCreateError",
 								"createMore",
 								"createButton",
+								"discardTitle",
+								"discardDescription",
+								"discardButton",
 								"untitledTask",
 								"labelColors"
 							]

--- a/i18n/tr-TR.json
+++ b/i18n/tr-TR.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Etiket oluşturulamadı",
 				"createMore": "Daha fazla oluştur",
 				"createButton": "Talep Oluştur",
+				"discardTitle": "Görev iptal edilsin mi?",
+				"discardDescription": "Kaydedilmemiş görev ayrıntıları kaybolacak.",
+				"discardButton": "Görevi iptal et",
 				"untitledTask": "Başlıksız talep",
 				"labelColors": {
 					"stone": "Taş",

--- a/i18n/tr-TR.json
+++ b/i18n/tr-TR.json
@@ -139,9 +139,9 @@
 				"labelCreateError": "Etiket oluşturulamadı",
 				"createMore": "Daha fazla oluştur",
 				"createButton": "Talep Oluştur",
-				"discardTitle": "Görev iptal edilsin mi?",
-				"discardDescription": "Kaydedilmemiş görev ayrıntıları kaybolacak.",
-				"discardButton": "Görevi iptal et",
+				"discardTitle": "Kaydedilmemiş talep taslağı silinsin mi?",
+				"discardDescription": "Kaydedilmemiş talep ayrıntıları kaybolacak.",
+				"discardButton": "Talep taslağını sil",
 				"untitledTask": "Başlıksız talep",
 				"labelColors": {
 					"stone": "Taş",

--- a/i18n/uk-UA.json
+++ b/i18n/uk-UA.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Не вдалося створити мітку",
 				"createMore": "Створити ще",
 				"createButton": "Створити завдання",
+				"discardTitle": "Відхилити завдання?",
+				"discardDescription": "Незбережені дані завдання буде втрачено.",
+				"discardButton": "Відхилити завдання",
 				"untitledTask": "Завдання без назви",
 				"labelColors": {
 					"stone": "Камінь",

--- a/i18n/vi-VN.json
+++ b/i18n/vi-VN.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "Không thể tạo nhãn",
 				"createMore": "Tạo thêm",
 				"createButton": "Tạo công việc",
+				"discardTitle": "Hủy công việc?",
+				"discardDescription": "Các chi tiết công việc chưa lưu sẽ bị mất.",
+				"discardButton": "Hủy công việc",
 				"untitledTask": "Công việc chưa đặt tên",
 				"labelColors": {
 					"stone": "Đá",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -139,6 +139,9 @@
 				"labelCreateError": "创建标签失败",
 				"createMore": "继续创建",
 				"createButton": "创建任务",
+				"discardTitle": "放弃任务？",
+				"discardDescription": "未保存的任务详情将会丢失。",
+				"discardButton": "放弃任务",
 				"untitledTask": "未命名任务",
 				"labelColors": {
 					"stone": "石板灰",


### PR DESCRIPTION
## Description

Keep the create-task dialog open when closing would discard entered data, and require explicit confirmation before resetting the form.

## Related Issue(s)

Fixes #1693

## Type of Change

- [x] Bug fix
- [x] Test addition or update

## How Has This Been Tested?

- [x] Focused component tests
- [x] Web typecheck
- [x] Production web build
- [x] Translation validation

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix is effective
- [x] New and existing relevant tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a confirmation prompt when closing the task creation window with unsaved changes, including selected projects.
  - Users can continue editing or explicitly discard their unfinished task.
  - Added translated confirmation text across supported languages.

- **Bug Fixes**
  - Prevented accidental loss of task details when closing the creation window.
  - Prevented keyboard submission while the discard confirmation is open.

- **Tests**
  - Added coverage for retaining unsaved input, selected projects, confirmation behavior, and task dismissal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->