### PR TITLE
fix(web): preserve imported label colors

### DIFF
--- a/apps/web/src/components/board/board-toolbar.tsx
+++ b/apps/web/src/components/board/board-toolbar.tsx
@@ -15,7 +15,6 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/menu";
-import labelColors from "@/constants/label-colors";
 import {
   type BoardFilters,
   DUE_DATE_FILTER_VALUES,
@@ -23,6 +22,7 @@ import {
 import { getColumnIcon } from "@/lib/column";
 import { getInitials } from "@/lib/get-initials";
 import { getPriorityLabel } from "@/lib/i18n/domain";
+import { resolveLabelColor } from "@/lib/label-color";
 import { getPriorityIcon } from "@/lib/priority";
 import type { SortConfig } from "@/lib/sort-tasks";
 import type { ProjectWithTasks } from "@/types/project";
@@ -493,9 +493,7 @@ export default function BoardToolbar({
                           <span
                             className="h-2.5 w-2.5 shrink-0 rounded-full"
                             style={{
-                              backgroundColor:
-                                labelColors.find((c) => c.value === label.color)
-                                  ?.color || "var(--color-neutral-400)",
+                              backgroundColor: resolveLabelColor(label.color),
                             }}
                           />
                           <span className="max-w-20 truncate">

--- a/apps/web/src/components/bulk-selection/backlog-bulk-toolbar.tsx
+++ b/apps/web/src/components/bulk-selection/backlog-bulk-toolbar.tsx
@@ -43,7 +43,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import labelColors from "@/constants/label-colors";
 import { useBulkOperations } from "@/hooks/mutations/task/use-bulk-operations";
 import useGetLabelsByWorkspace from "@/hooks/queries/label/use-get-labels-by-workspace";
 import useActiveWorkspace from "@/hooks/queries/workspace/use-active-workspace";
@@ -52,6 +51,7 @@ import { useWorkspacePermission } from "@/hooks/use-workspace-permission";
 import { getColumnIcon } from "@/lib/column";
 import { getInitials } from "@/lib/get-initials";
 import { getPriorityLabel } from "@/lib/i18n/domain";
+import { resolveLabelColor } from "@/lib/label-color";
 import { getPriorityIcon } from "@/lib/priority";
 import { toast } from "@/lib/toast";
 import useBacklogBulkSelectionStore from "@/store/backlog-bulk-selection";
@@ -345,9 +345,7 @@ function BacklogBulkToolbar() {
             <span
               className="inline-block w-3 h-3 rounded-full shrink-0"
               style={{
-                backgroundColor:
-                  labelColors.find((c) => c.value === label.color)?.color ||
-                  "var(--color-neutral-400)",
+                backgroundColor: resolveLabelColor(label.color),
               }}
             />
           ),

--- a/apps/web/src/components/bulk-selection/bulk-toolbar.tsx
+++ b/apps/web/src/components/bulk-selection/bulk-toolbar.tsx
@@ -36,7 +36,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import labelColors from "@/constants/label-colors";
 import { useBulkOperations } from "@/hooks/mutations/task/use-bulk-operations";
 import useGetLabelsByWorkspace from "@/hooks/queries/label/use-get-labels-by-workspace";
 import useActiveWorkspace from "@/hooks/queries/workspace/use-active-workspace";
@@ -45,6 +44,7 @@ import { useWorkspacePermission } from "@/hooks/use-workspace-permission";
 import { getColumnIcon } from "@/lib/column";
 import { getInitials } from "@/lib/get-initials";
 import { getPriorityLabel } from "@/lib/i18n/domain";
+import { resolveLabelColor } from "@/lib/label-color";
 import { getPriorityIcon } from "@/lib/priority";
 import { toast } from "@/lib/toast";
 import useBulkSelectionStore from "@/store/bulk-selection";
@@ -364,9 +364,7 @@ function BulkToolbar() {
             <span
               className="inline-block w-3 h-3 rounded-full shrink-0"
               style={{
-                backgroundColor:
-                  labelColors.find((c) => c.value === label.color)?.color ||
-                  "var(--color-neutral-400)",
+                backgroundColor: resolveLabelColor(label.color),
               }}
             />
           ),

--- a/apps/web/src/components/kanban-board/task-labels.tsx
+++ b/apps/web/src/components/kanban-board/task-labels.tsx
@@ -1,36 +1,6 @@
 import { Badge } from "@/components/ui/badge";
+import { resolveLabelColor } from "@/lib/label-color";
 import type Task from "@/types/task";
-
-const labelColors = [
-  { value: "gray", label: "Stone", color: "var(--color-stone-500)" },
-  { value: "dark-gray", label: "Slate", color: "var(--color-slate-500)" },
-  { value: "purple", label: "Lavender", color: "var(--color-violet-500)" },
-  { value: "teal", label: "Sage", color: "var(--color-emerald-600)" },
-  { value: "green", label: "Forest", color: "var(--color-green-600)" },
-  { value: "yellow", label: "Amber", color: "var(--color-amber-600)" },
-  { value: "orange", label: "Terracotta", color: "var(--color-orange-600)" },
-  { value: "pink", label: "Rose", color: "var(--color-rose-600)" },
-  { value: "red", label: "Crimson", color: "var(--color-red-600)" },
-];
-
-function isValidHtmlColor(color: string): boolean {
-  const s = new Option().style;
-  s.color = color;
-  return s.color !== "";
-}
-
-function validColor(value: string): string {
-  const mapped = labelColors.find((c) => c.value === value)?.color;
-  if (mapped) {
-    return mapped;
-  }
-
-  if (isValidHtmlColor(value)) {
-    return value;
-  }
-
-  return "var(--color-neutral-400)";
-}
 
 export function TaskLabels({
   labels,
@@ -50,7 +20,7 @@ export function TaskLabels({
           <span
             className="inline-block w-1.5 h-1.5 mr-1 rounded-full"
             style={{
-              backgroundColor: validColor(label.color),
+              backgroundColor: resolveLabelColor(label.color),
             }}
           />
           <span className="max-w-20 truncate">{label.name}</span>

--- a/apps/web/src/components/public-project/public-task-labels.tsx
+++ b/apps/web/src/components/public-project/public-task-labels.tsx
@@ -1,5 +1,5 @@
 import { Badge } from "@/components/ui/badge";
-import labelColors from "@/constants/label-colors";
+import { resolveLabelColor } from "@/lib/label-color";
 
 type PublicTaskLabelsProps = {
   labels: Array<{ id: string; name: string; color: string }>;
@@ -19,9 +19,7 @@ export function PublicTaskLabels({ labels }: PublicTaskLabelsProps) {
           <span
             className="inline-block w-1.5 h-1.5 mr-1 rounded-full"
             style={{
-              backgroundColor:
-                labelColors.find((c) => c.value === label.color)?.color ||
-                "var(--color-neutral-400)",
+              backgroundColor: resolveLabelColor(label.color),
             }}
           />
           <span className="max-w-20 truncate">{label.name}</span>

--- a/apps/web/src/components/shared/modals/create-task-modal.tsx
+++ b/apps/web/src/components/shared/modals/create-task-modal.tsx
@@ -49,6 +49,7 @@ import { useWorkspacePermission } from "@/hooks/use-workspace-permission";
 import { cn } from "@/lib/cn";
 import { formatDateMedium } from "@/lib/format";
 import { getInitials } from "@/lib/get-initials";
+import { resolveLabelColor } from "@/lib/label-color";
 import { getPriorityIcon } from "@/lib/priority";
 import { toast } from "@/lib/toast";
 import useProjectStore from "@/store/project";
@@ -663,9 +664,7 @@ function CreateTaskModal({
                     <span
                       className="inline-block w-2 h-2 mr-1.5 rounded-full"
                       style={{
-                        backgroundColor:
-                          labelColors.find((c) => c.value === label.color)
-                            ?.color || "var(--color-neutral-400)",
+                        backgroundColor: resolveLabelColor(label.color),
                       }}
                     />
                     <span className="max-w-20 truncate">{label.name}</span>
@@ -978,10 +977,7 @@ function CreateTaskModal({
                             <span
                               className="w-2 h-2 rounded-full flex-shrink-0"
                               style={{
-                                backgroundColor:
-                                  labelColors.find(
-                                    (c) => c.value === label.color,
-                                  )?.color || "var(--color-neutral-400)",
+                                backgroundColor: resolveLabelColor(label.color),
                               }}
                             />
                             <span className="max-w-20 truncate">

--- a/apps/web/src/components/task/task-labels-popover.tsx
+++ b/apps/web/src/components/task/task-labels-popover.tsx
@@ -16,6 +16,7 @@ import useGetLabelsByWorkspace from "@/hooks/queries/label/use-get-labels-by-wor
 import { useWorkspacePermission } from "@/hooks/use-workspace-permission";
 import { cn } from "@/lib/cn";
 import { getTaskLabelOptions } from "@/lib/get-task-label-options";
+import { resolveLabelColor } from "@/lib/label-color";
 import { toast } from "@/lib/toast";
 import type Task from "@/types/task";
 
@@ -231,9 +232,7 @@ export default function TaskLabelsPopover({
             <span
               className="w-2 h-2 rounded-full flex-shrink-0"
               style={{
-                backgroundColor:
-                  labelColors.find((c) => c.value === label.color)?.color ||
-                  "var(--color-neutral-400)",
+                backgroundColor: resolveLabelColor(label.color),
               }}
             />
             <span className="max-w-20 truncate">{label.name}</span>

--- a/apps/web/src/components/task/task-properties-sidebar.tsx
+++ b/apps/web/src/components/task/task-properties-sidebar.tsx
@@ -18,7 +18,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import labelColors from "@/constants/label-colors";
 import { useGetColumns } from "@/hooks/queries/column/use-get-columns";
 import useGetGiteaIntegration from "@/hooks/queries/gitea-integration/use-get-gitea-integration";
 import useGetGithubIntegration from "@/hooks/queries/github-integration/use-get-github-integration";
@@ -37,6 +36,7 @@ import {
 import { formatDateShort } from "@/lib/format";
 import { getInitials } from "@/lib/get-initials";
 import { getPriorityLabel, getStatusDisplayLabel } from "@/lib/i18n/domain";
+import { resolveLabelColor } from "@/lib/label-color";
 import { getPriorityIcon } from "@/lib/priority";
 import { toast } from "@/lib/toast";
 import TaskAssigneePopover from "./task-assignee-popover";
@@ -736,9 +736,7 @@ export default function TaskPropertiesSidebar({
                         <span
                           className="w-1.5 h-1.5 rounded-full flex-shrink-0"
                           style={{
-                            backgroundColor:
-                              labelColors.find((c) => c.value === label.color)
-                                ?.color || "var(--color-neutral-400)",
+                            backgroundColor: resolveLabelColor(label.color),
                           }}
                         />
                         <span className="truncate max-w-[60px]">

--- a/apps/web/src/lib/label-color.test.ts
+++ b/apps/web/src/lib/label-color.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { FALLBACK_LABEL_COLOR, resolveLabelColor } from "./label-color";
+
+describe("resolveLabelColor", () => {
+  it("maps Kaneo's named label colors to their CSS variables", () => {
+    expect(resolveLabelColor("red")).toBe("var(--color-red-600)");
+  });
+
+  it("preserves custom hex colors imported from external systems", () => {
+    expect(resolveLabelColor("#e83855")).toBe("#e83855");
+    expect(resolveLabelColor("#ABC")).toBe("#ABC");
+  });
+
+  it("uses the neutral fallback for invalid colors", () => {
+    expect(resolveLabelColor("not a color")).toBe(FALLBACK_LABEL_COLOR);
+  });
+});

--- a/apps/web/src/lib/label-color.test.ts
+++ b/apps/web/src/lib/label-color.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { FALLBACK_LABEL_COLOR, resolveLabelColor } from "./label-color";
+
+afterEach(() => vi.unstubAllGlobals());
 
 describe("resolveLabelColor", () => {
   it("maps Kaneo's named label colors to their CSS variables", () => {
@@ -13,5 +15,24 @@ describe("resolveLabelColor", () => {
 
   it("uses the neutral fallback for invalid colors", () => {
     expect(resolveLabelColor("not a color")).toBe(FALLBACK_LABEL_COLOR);
+  });
+
+  it("preserves non-hex colors supported by the browser", () => {
+    const color = "rgb(232 56 85)";
+    const supports = vi.fn(() => true);
+    vi.stubGlobal("CSS", { supports });
+
+    const resolved = resolveLabelColor(color);
+
+    expect(resolved).toBe(color);
+    expect(supports).toHaveBeenCalledWith("color", color);
+  });
+
+  it("uses the fallback when the browser rejects a non-hex color", () => {
+    vi.stubGlobal("CSS", { supports: () => false });
+
+    const resolved = resolveLabelColor("not a color");
+
+    expect(resolved).toBe(FALLBACK_LABEL_COLOR);
   });
 });

--- a/apps/web/src/lib/label-color.ts
+++ b/apps/web/src/lib/label-color.ts
@@ -1,0 +1,19 @@
+import labelColors from "@/constants/label-colors";
+
+const FALLBACK_LABEL_COLOR = "var(--color-neutral-400)";
+const HEX_COLOR = /^#(?:[\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i;
+
+export function resolveLabelColor(value: string): string {
+  const mapped = labelColors.find((color) => color.value === value)?.color;
+  if (mapped) return mapped;
+
+  if (HEX_COLOR.test(value)) return value;
+
+  if (typeof CSS !== "undefined" && CSS.supports?.("color", value)) {
+    return value;
+  }
+
+  return FALLBACK_LABEL_COLOR;
+}
+
+export { FALLBACK_LABEL_COLOR };

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/settings/workspace/labels.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/settings/workspace/labels.tsx
@@ -45,6 +45,7 @@ import useUpdateLabel from "@/hooks/mutations/label/use-update-label";
 import useGetLabelsByWorkspace from "@/hooks/queries/label/use-get-labels-by-workspace";
 import { useWorkspacePermission } from "@/hooks/use-workspace-permission";
 import { cn } from "@/lib/cn";
+import { resolveLabelColor } from "@/lib/label-color";
 import { toast } from "@/lib/toast";
 
 export const Route = createFileRoute(
@@ -213,10 +214,6 @@ function RouteComponent() {
     }
   };
 
-  const getColorVar = (colorValue: string) =>
-    labelColors.find((c) => c.value === colorValue)?.color ??
-    "var(--color-neutral-400)";
-
   return (
     <>
       <PageTitle title={t("settings:workspaceLabels.pageTitle")} />
@@ -287,7 +284,7 @@ function RouteComponent() {
                         <span
                           className="w-3 h-3 rounded-full flex-shrink-0"
                           style={{
-                            backgroundColor: getColorVar(label.color),
+                            backgroundColor: resolveLabelColor(label.color),
                           }}
                         />
                         <span className="text-sm truncate">{label.name}</span>

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog.tsx
@@ -22,7 +22,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/menu";
-import labelColors from "@/constants/label-colors";
 import { shortcuts } from "@/constants/shortcuts";
 import { useUpdateTask } from "@/hooks/mutations/task/use-update-task";
 import useGetLabelsByWorkspace from "@/hooks/queries/label/use-get-labels-by-workspace";
@@ -32,6 +31,7 @@ import { useRegisterShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { DUE_DATE_FILTER_VALUES } from "@/hooks/use-task-filters";
 import { getInitials } from "@/lib/get-initials";
 import { getPriorityLabel } from "@/lib/i18n/domain";
+import { resolveLabelColor } from "@/lib/label-color";
 import { getPriorityIcon } from "@/lib/priority";
 import type { SortConfig } from "@/lib/sort-tasks";
 import { sortTasks } from "@/lib/sort-tasks";
@@ -501,9 +501,7 @@ function RouteComponent() {
                         <span
                           className="w-2.5 h-2.5 rounded-full flex-shrink-0"
                           style={{
-                            backgroundColor:
-                              labelColors.find((c) => c.value === label.color)
-                                ?.color || "var(--color-neutral-400)",
+                            backgroundColor: resolveLabelColor(label.color),
                           }}
                         />
                         <span>
@@ -667,10 +665,7 @@ function RouteComponent() {
                             <span
                               className="w-3 h-3 rounded-full flex-shrink-0"
                               style={{
-                                backgroundColor:
-                                  labelColors.find(
-                                    (c) => c.value === label.color,
-                                  )?.color || "var(--color-neutral-400)",
+                                backgroundColor: resolveLabelColor(label.color),
                               }}
                             />
                             <span className="max-w-20 truncate">


### PR DESCRIPTION
## Description

Preserve custom imported label colors across cards, filters, pickers, settings, and bulk actions while retaining the neutral fallback for invalid values.

## Related Issue(s)

Fixes #1684

## Type of Change

- [x] Bug fix
- [x] Test addition or update

## How Has This Been Tested?

- [x] Focused unit and component tests
- [x] Web typecheck
- [x] Production web build

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix is effective
- [x] New and existing relevant tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label color rendering across boards, backlogs, task views, filters, and workspace settings.
  * Custom and supported CSS colors are now displayed correctly, with invalid values falling back to a neutral color.
  * Label colors are now resolved more consistently throughout the application.

* **Tests**
  * Added coverage for named colors, custom hex colors, supported CSS colors, and invalid color fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->