### PR TITLE
feat(tasks): show subtask progress on cards and list rows

### DIFF
--- a/apps/api/src/column/controllers/update-column.ts
+++ b/apps/api/src/column/controllers/update-column.ts
@@ -2,6 +2,8 @@ import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import db from "../../database";
 import { columnTable } from "../../database/schema";
+import { publishEvent } from "../../events";
+import { getColumnSubtaskParentProjects } from "../../task/get-subtask-parent-projects";
 
 async function updateColumn(
   id: string,
@@ -33,6 +35,19 @@ async function updateColumn(
 
   if (!updated) {
     throw new HTTPException(500, { message: "Failed to update column" });
+  }
+
+  if (existing.isFinal !== updated.isFinal) {
+    const parents = await getColumnSubtaskParentProjects(
+      updated.projectId,
+      updated.slug,
+    );
+    await publishEvent("subtask-parents.refresh", {
+      projects: [
+        { projectId: updated.projectId },
+        ...parents.filter((p) => p.projectId !== updated.projectId),
+      ],
+    });
   }
 
   return updated;

--- a/apps/api/src/column/controllers/update-column.ts
+++ b/apps/api/src/column/controllers/update-column.ts
@@ -3,7 +3,7 @@ import { HTTPException } from "hono/http-exception";
 import db from "../../database";
 import { columnTable } from "../../database/schema";
 import { publishEvent } from "../../events";
-import { getColumnSubtaskParentProjects } from "../../task/get-subtask-parent-projects";
+import { getProjectSubtaskParentProjects } from "../../task/get-subtask-parent-projects";
 
 async function updateColumn(
   id: string,
@@ -38,7 +38,7 @@ async function updateColumn(
   }
 
   if (existing.isFinal !== updated.isFinal) {
-    const parents = await getColumnSubtaskParentProjects(
+    const parents = await getProjectSubtaskParentProjects(
       updated.projectId,
       updated.slug,
     );

--- a/apps/api/src/project/controllers/delete-project.ts
+++ b/apps/api/src/project/controllers/delete-project.ts
@@ -2,10 +2,14 @@ import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 import db from "../../database";
 import { projectTable } from "../../database/schema";
+import { publishEvent } from "../../events";
+import { getProjectSubtaskParentProjects } from "../../task/get-subtask-parent-projects";
 import getProject from "./get-project";
 
 async function deleteProject(id: string, workspaceId: string) {
   const existingProject = await getProject(id, workspaceId);
+
+  const parents = await getProjectSubtaskParentProjects(id);
 
   const [deletedProject] = await db
     .delete(projectTable)
@@ -17,6 +21,10 @@ async function deleteProject(id: string, workspaceId: string) {
       message: "Failed to delete project",
     });
   }
+
+  await publishEvent("subtask-parents.refresh", {
+    projects: parents.filter((parent) => parent.projectId !== id),
+  });
 
   return existingProject;
 }

--- a/apps/api/src/project/controllers/get-public-project.ts
+++ b/apps/api/src/project/controllers/get-public-project.ts
@@ -23,7 +23,7 @@ export async function getPublicProject(id: string) {
     });
   }
 
-  const result = await getTasks(id);
+  const result = await getTasks(id, { publicOnly: true });
 
   if (!result.data) {
     throw new HTTPException(404, {

--- a/apps/api/src/task/controllers/bulk-update-tasks.ts
+++ b/apps/api/src/task/controllers/bulk-update-tasks.ts
@@ -13,6 +13,7 @@ import { publishEvent } from "../../events";
 import { removeLabelFromGitea } from "../../plugins/gitea/utils/sync-label-to-gitea";
 import { removeLabelFromGitHub } from "../../plugins/github/utils/sync-label-to-github";
 import { assertAssignableUser } from "../../utils/assert-assignable-user";
+import { getSubtaskParentProjects } from "../get-subtask-parent-projects";
 import {
   assertValidPriority,
   assertValidTaskStatus,
@@ -207,6 +208,8 @@ async function bulkUpdateTasks({
     }
 
     case "delete": {
+      // Relations cascade away with the children, so capture parents first.
+      const parentProjects = await getSubtaskParentProjects(foundIds);
       const result = await db
         .delete(taskTable)
         .where(inArray(taskTable.id, foundIds));
@@ -221,6 +224,9 @@ async function bulkUpdateTasks({
           title: task.title,
         });
       }
+      await publishEvent("subtask-parents.refresh", {
+        projects: parentProjects,
+      });
       break;
     }
 

--- a/apps/api/src/task/controllers/bulk-update-tasks.ts
+++ b/apps/api/src/task/controllers/bulk-update-tasks.ts
@@ -122,6 +122,11 @@ async function bulkUpdateTasks({
 
         updatedCount += result.rowCount ?? projectTaskIds.length;
 
+        const parentProjects = await getSubtaskParentProjects(projectTaskIds);
+        await publishEvent("subtask-parents.refresh", {
+          projects: parentProjects,
+        });
+
         for (const taskId of projectTaskIds) {
           await publishEvent("task.status_changed", {
             taskId,
@@ -129,6 +134,7 @@ async function bulkUpdateTasks({
             userId,
             newStatus: value,
             type: "status_changed",
+            skipSubtaskParentRefresh: true,
           });
         }
 

--- a/apps/api/src/task/controllers/get-tasks.ts
+++ b/apps/api/src/task/controllers/get-tasks.ts
@@ -19,8 +19,10 @@ import {
   taskTable,
   userTable,
 } from "../../database/schema";
+import { getSubtaskCounts } from "../get-subtask-counts";
 
 type GetTasksOptions = {
+  publicOnly?: boolean;
   assigneeId?: string;
   dueAfter?: string;
   dueBefore?: string;
@@ -152,6 +154,12 @@ async function getTasks(projectId: string, options: GetTasksOptions = {}) {
 
   const taskIds = paginatedTasks.map((task) => task.id);
 
+  const subtaskCounts = await getSubtaskCounts(
+    taskIds,
+    project.workspaceId,
+    options.publicOnly ?? false,
+  );
+
   const labelsData =
     taskIds.length > 0
       ? await db
@@ -231,6 +239,7 @@ async function getTasks(projectId: string, options: GetTasksOptions = {}) {
       .filter((task) => task.status === column.slug)
       .map((task) => ({
         ...task,
+        subtaskCounts: subtaskCounts.get(task.id) ?? { completed: 0, total: 0 },
         labels: taskLabelsMap.get(task.id) || [],
         externalLinks: taskExternalLinksMap.get(task.id) || [],
       })),
@@ -240,6 +249,7 @@ async function getTasks(projectId: string, options: GetTasksOptions = {}) {
     .filter((task) => task.status === "archived")
     .map((task) => ({
       ...task,
+      subtaskCounts: subtaskCounts.get(task.id) ?? { completed: 0, total: 0 },
       labels: taskLabelsMap.get(task.id) || [],
       externalLinks: taskExternalLinksMap.get(task.id) || [],
     }));
@@ -248,6 +258,7 @@ async function getTasks(projectId: string, options: GetTasksOptions = {}) {
     .filter((task) => task.status === "planned")
     .map((task) => ({
       ...task,
+      subtaskCounts: subtaskCounts.get(task.id) ?? { completed: 0, total: 0 },
       labels: taskLabelsMap.get(task.id) || [],
       externalLinks: taskExternalLinksMap.get(task.id) || [],
     }));

--- a/apps/api/src/task/get-subtask-counts.ts
+++ b/apps/api/src/task/get-subtask-counts.ts
@@ -1,0 +1,48 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+import db from "../database";
+import {
+  columnTable,
+  projectTable,
+  taskRelationTable,
+  taskTable,
+} from "../database/schema";
+
+/** Load direct-child progress for the entire page, independent of board filters. */
+export async function getSubtaskCounts(
+  taskIds: string[],
+  workspaceId: string,
+  publicOnly: boolean,
+) {
+  if (taskIds.length === 0) {
+    return new Map<string, { completed: number; total: number }>();
+  }
+
+  const rows = await db
+    .select({
+      taskId: taskRelationTable.sourceTaskId,
+      total: sql<number>`count(distinct ${taskTable.id})`.mapWith(Number),
+      completed:
+        sql<number>`count(distinct ${taskTable.id}) filter (where exists (
+        select 1 from ${columnTable}
+        where ${columnTable.projectId} = ${taskTable.projectId}
+          and ${columnTable.slug} = ${taskTable.status}
+          and ${columnTable.isFinal} = true
+      ))`.mapWith(Number),
+    })
+    .from(taskRelationTable)
+    .innerJoin(taskTable, eq(taskRelationTable.targetTaskId, taskTable.id))
+    .innerJoin(projectTable, eq(taskTable.projectId, projectTable.id))
+    .where(
+      and(
+        inArray(taskRelationTable.sourceTaskId, taskIds),
+        eq(taskRelationTable.relationType, "subtask"),
+        eq(projectTable.workspaceId, workspaceId),
+        publicOnly ? eq(projectTable.isPublic, true) : undefined,
+      ),
+    )
+    .groupBy(taskRelationTable.sourceTaskId);
+
+  return new Map(
+    rows.map(({ taskId, completed, total }) => [taskId, { completed, total }]),
+  );
+}

--- a/apps/api/src/task/get-subtask-parent-projects.ts
+++ b/apps/api/src/task/get-subtask-parent-projects.ts
@@ -26,10 +26,10 @@ export async function getRelationSourceProject(sourceTaskId: string) {
     .where(eq(taskTable.id, sourceTaskId));
 }
 
-/** Final-column changes affect every parent of a task using that column's slug. */
-export async function getColumnSubtaskParentProjects(
+/** Find affected parent boards before a project cascade or column change. */
+export async function getProjectSubtaskParentProjects(
   projectId: string,
-  status: string,
+  status?: string,
 ) {
   const child = alias(taskTable, "child");
   return db
@@ -40,7 +40,7 @@ export async function getColumnSubtaskParentProjects(
     .where(
       and(
         eq(child.projectId, projectId),
-        eq(child.status, status),
+        status === undefined ? undefined : eq(child.status, status),
         eq(taskRelationTable.relationType, "subtask"),
       ),
     );

--- a/apps/api/src/task/get-subtask-parent-projects.ts
+++ b/apps/api/src/task/get-subtask-parent-projects.ts
@@ -1,16 +1,18 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import db from "../database";
 import { taskRelationTable, taskTable } from "../database/schema";
 
 /** Find boards whose counters depend on a child, including other projects. */
-export async function getSubtaskParentProjects(taskId: string) {
+export async function getSubtaskParentProjects(taskIds: string[]) {
+  if (taskIds.length === 0) return [];
   return db
     .selectDistinct({ projectId: taskTable.projectId })
     .from(taskRelationTable)
     .innerJoin(taskTable, eq(taskRelationTable.sourceTaskId, taskTable.id))
     .where(
       and(
-        eq(taskRelationTable.targetTaskId, taskId),
+        inArray(taskRelationTable.targetTaskId, taskIds),
         eq(taskRelationTable.relationType, "subtask"),
       ),
     );
@@ -22,4 +24,24 @@ export async function getRelationSourceProject(sourceTaskId: string) {
     .select({ projectId: taskTable.projectId })
     .from(taskTable)
     .where(eq(taskTable.id, sourceTaskId));
+}
+
+/** Final-column changes affect every parent of a task using that column's slug. */
+export async function getColumnSubtaskParentProjects(
+  projectId: string,
+  status: string,
+) {
+  const child = alias(taskTable, "child");
+  return db
+    .selectDistinct({ projectId: taskTable.projectId })
+    .from(taskRelationTable)
+    .innerJoin(taskTable, eq(taskRelationTable.sourceTaskId, taskTable.id))
+    .innerJoin(child, eq(taskRelationTable.targetTaskId, child.id))
+    .where(
+      and(
+        eq(child.projectId, projectId),
+        eq(child.status, status),
+        eq(taskRelationTable.relationType, "subtask"),
+      ),
+    );
 }

--- a/apps/api/src/task/get-subtask-parent-projects.ts
+++ b/apps/api/src/task/get-subtask-parent-projects.ts
@@ -1,0 +1,25 @@
+import { and, eq } from "drizzle-orm";
+import db from "../database";
+import { taskRelationTable, taskTable } from "../database/schema";
+
+/** Find boards whose counters depend on a child, including other projects. */
+export async function getSubtaskParentProjects(taskId: string) {
+  return db
+    .selectDistinct({ projectId: taskTable.projectId })
+    .from(taskRelationTable)
+    .innerJoin(taskTable, eq(taskRelationTable.sourceTaskId, taskTable.id))
+    .where(
+      and(
+        eq(taskRelationTable.targetTaskId, taskId),
+        eq(taskRelationTable.relationType, "subtask"),
+      ),
+    );
+}
+
+/** Deleted relations are gone by broadcast time; their source task still exists. */
+export async function getRelationSourceProject(sourceTaskId: string) {
+  return db
+    .select({ projectId: taskTable.projectId })
+    .from(taskTable)
+    .where(eq(taskTable.id, sourceTaskId));
+}

--- a/apps/api/src/task/response.ts
+++ b/apps/api/src/task/response.ts
@@ -74,6 +74,15 @@ export const boardTaskSchema = z
     assigneeId: z.string().nullable(),
     assigneeImage: z.string().nullable(),
     projectId: z.string(),
+    subtaskCounts: z
+      .object({
+        completed: z.number().int().nonnegative(),
+        total: z.number().int().nonnegative(),
+      })
+      .openapi({
+        description:
+          "Direct subtasks in the workspace; completed means a final column in the child project. Public boards count only children in public projects.",
+      }),
     labels: z.array(taskLabelSchema),
     externalLinks: z.array(taskExternalLinkSchema),
   })

--- a/apps/api/src/ws/index.ts
+++ b/apps/api/src/ws/index.ts
@@ -2,6 +2,10 @@ import { randomUUID } from "node:crypto";
 import type { WSContext } from "hono/ws";
 import { subscribeToEvent } from "../events";
 import { isRedisConfigured } from "../redis";
+import {
+  getRelationSourceProject,
+  getSubtaskParentProjects,
+} from "../task/get-subtask-parent-projects";
 import type {
   BroadcastAdapter,
   BroadcastMessage,
@@ -264,6 +268,26 @@ type TaskEvent = {
   targetTaskId: string | undefined;
 };
 
+// Send only an invalidation to parent boards, without exposing child task data.
+function refreshParentBoards(
+  projects: { projectId: string }[],
+  currentProjectId: string,
+  initiatorId?: string,
+) {
+  for (const { projectId } of projects) {
+    if (projectId === currentProjectId) continue;
+    broadcastToProject(
+      projectId,
+      {
+        type: "TASK_RELATION_UPDATED",
+        projectId,
+        taskId: "",
+      },
+      initiatorId,
+    );
+  }
+}
+
 const taskUpdateEvents = [
   "task.created",
   "task.updated",
@@ -309,6 +333,11 @@ subscribeToEvent<{
   broadcastToProject(
     fromProjectId,
     { type: "TASK_MOVED", projectId: fromProjectId, taskId },
+    initiatorId,
+  );
+  refreshParentBoards(
+    await getSubtaskParentProjects(taskId),
+    fromProjectId,
     initiatorId,
   );
 });
@@ -387,5 +416,18 @@ for (const eventName of taskUpdateEvents) {
       },
       initiatorId,
     );
+    if (eventName === "task.status_changed") {
+      refreshParentBoards(
+        await getSubtaskParentProjects(taskId),
+        projectId,
+        initiatorId,
+      );
+    } else if (eventName === "task-relation.deleted" && data.sourceTaskId) {
+      refreshParentBoards(
+        await getRelationSourceProject(data.sourceTaskId),
+        projectId,
+        initiatorId,
+      );
+    }
   });
 }

--- a/apps/api/src/ws/index.ts
+++ b/apps/api/src/ws/index.ts
@@ -259,6 +259,7 @@ export function broadcastToProject(
 }
 
 type TaskEvent = {
+  skipSubtaskParentRefresh?: boolean;
   id: string | undefined;
   projectId: string;
   userId: string;
@@ -415,7 +416,7 @@ for (const eventName of taskUpdateEvents) {
       },
       initiatorId,
     );
-    if (eventName === "task.status_changed") {
+    if (eventName === "task.status_changed" && !data.skipSubtaskParentRefresh) {
       refreshParentBoards(await getSubtaskParentProjects([taskId]), projectId);
     } else if (eventName === "task-relation.deleted" && data.sourceTaskId) {
       refreshParentBoards(

--- a/apps/api/src/ws/index.ts
+++ b/apps/api/src/ws/index.ts
@@ -268,25 +268,28 @@ type TaskEvent = {
   targetTaskId: string | undefined;
 };
 
-// Send only an invalidation to parent boards, without exposing child task data.
+// Include the initiating window: its local mutation refreshes the child project,
+// while it may be displaying a different parent board. Never send child data.
 function refreshParentBoards(
   projects: { projectId: string }[],
-  currentProjectId: string,
-  initiatorId?: string,
+  currentProjectId = "",
 ) {
   for (const { projectId } of projects) {
     if (projectId === currentProjectId) continue;
-    broadcastToProject(
+    broadcastToProject(projectId, {
+      type: "TASK_RELATION_UPDATED",
       projectId,
-      {
-        type: "TASK_RELATION_UPDATED",
-        projectId,
-        taskId: "",
-      },
-      initiatorId,
-    );
+      taskId: "",
+    });
   }
 }
+
+subscribeToEvent<{ projects: { projectId: string }[] }>(
+  "subtask-parents.refresh",
+  async ({ projects }) => {
+    refreshParentBoards(projects);
+  },
+);
 
 const taskUpdateEvents = [
   "task.created",
@@ -335,11 +338,7 @@ subscribeToEvent<{
     { type: "TASK_MOVED", projectId: fromProjectId, taskId },
     initiatorId,
   );
-  refreshParentBoards(
-    await getSubtaskParentProjects(taskId),
-    fromProjectId,
-    initiatorId,
-  );
+  refreshParentBoards(await getSubtaskParentProjects([taskId]), fromProjectId);
 });
 
 subscribeToEvent<{
@@ -417,16 +416,11 @@ for (const eventName of taskUpdateEvents) {
       initiatorId,
     );
     if (eventName === "task.status_changed") {
-      refreshParentBoards(
-        await getSubtaskParentProjects(taskId),
-        projectId,
-        initiatorId,
-      );
+      refreshParentBoards(await getSubtaskParentProjects([taskId]), projectId);
     } else if (eventName === "task-relation.deleted" && data.sourceTaskId) {
       refreshParentBoards(
         await getRelationSourceProject(data.sourceTaskId),
         projectId,
-        initiatorId,
       );
     }
   });

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -363,6 +363,24 @@
           "projectId": {
             "type": "string"
           },
+          "subtaskCounts": {
+            "type": "object",
+            "properties": {
+              "completed": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "total": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "completed",
+              "total"
+            ],
+            "description": "Direct subtasks in the workspace; completed means a final column in the child project. Public boards count only children in public projects."
+          },
           "labels": {
             "type": "array",
             "items": {
@@ -392,6 +410,7 @@
           "assigneeId",
           "assigneeImage",
           "projectId",
+          "subtaskCounts",
           "labels",
           "externalLinks"
         ]

--- a/apps/web/src/components/backlog-list-view/backlog-task-row.tsx
+++ b/apps/web/src/components/backlog-list-view/backlog-task-row.tsx
@@ -5,6 +5,7 @@ import { format } from "date-fns";
 import { Calendar, CalendarClock, CalendarX } from "lucide-react";
 import { type CSSProperties, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { TaskProgressBadges } from "@/components/task/task-progress-badges";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -169,11 +170,10 @@ export default function BacklogTaskRow({ task }: BacklogTaskRowProps) {
                 <span className="text-sm text-foreground truncate">
                   {task.title}
                 </span>
-                {showLabels && (
-                  <div className="flex items-center gap-1">
-                    <TaskLabels labels={task.labels ?? []} />
-                  </div>
-                )}
+                <div className="flex items-center gap-1">
+                  <TaskProgressBadges task={task} />
+                  {showLabels && <TaskLabels labels={task.labels ?? []} />}
+                </div>
               </div>
             </div>
 

--- a/apps/web/src/components/kanban-board/task-card.tsx
+++ b/apps/web/src/components/kanban-board/task-card.tsx
@@ -8,10 +8,10 @@ import {
   CalendarX,
   GitMerge,
   GitPullRequest,
-  SquareCheck,
 } from "lucide-react";
 import { type CSSProperties, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { TaskProgressBadges } from "@/components/task/task-progress-badges";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -32,14 +32,12 @@ import {
 import { useDeleteTask } from "@/hooks/mutations/task/use-delete-task";
 import useActiveWorkspace from "@/hooks/queries/workspace/use-active-workspace";
 import { useGetActiveWorkspaceUsers } from "@/hooks/queries/workspace-users/use-get-active-workspace-users";
-import { cn } from "@/lib/cn";
 import {
   dueDateStatusColors,
   getDueDateStatus,
   isTaskCompleted,
 } from "@/lib/due-date-status";
 import { getInitials } from "@/lib/get-initials";
-import { getTaskItemStats } from "@/lib/get-task-item-stats";
 import { getPriorityIcon } from "@/lib/priority";
 import { toast } from "@/lib/toast";
 import useBulkSelectionStore from "@/store/bulk-selection";
@@ -75,16 +73,11 @@ function TaskCard({ task, disableDragDrop = false }: TaskCardProps) {
     showDueDates,
     showLabels,
     showTaskNumbers,
-    showTaskItemCounts,
   } = useUserPreferencesStore();
   const [isDeleteTaskModalOpen, setIsDeleteTaskModalOpen] = useState(false);
   const { toggleSelection, isSelected, isFocused } = useBulkSelectionStore();
   const isTaskSelected = isSelected(task.id);
   const isTaskFocused = isFocused(task.id);
-  const taskItemStats = useMemo(
-    () => getTaskItemStats(task.description),
-    [task.description],
-  );
 
   const pullRequests = useMemo(() => {
     return (task.externalLinks ?? []).filter(
@@ -259,27 +252,14 @@ function TaskCard({ task, disableDragDrop = false }: TaskCardProps) {
               </div>
             )}
 
-            <div className="flex items-center gap-1.5">
+            <div className="flex flex-wrap items-center gap-1.5">
               {showPriority && (
                 <span className="inline-flex items-center gap-1 rounded border border-border/70 bg-muted/55 px-2 py-1 text-[10px] font-medium text-muted-foreground h-5.5">
                   {getPriorityIcon(task.priority ?? "")}
                 </span>
               )}
 
-              {showTaskItemCounts && taskItemStats.total > 0 && (
-                <span
-                  className={cn(
-                    "flex items-center gap-1 text-[10px] px-2 py-1 rounded bg-muted/50 text-muted-foreground h-5.5",
-                    {
-                      "bg-success/10 text-success-foreground":
-                        taskItemStats.completed === taskItemStats.total,
-                    },
-                  )}
-                >
-                  <SquareCheck className="h-[12px] w-[12px]" />
-                  {taskItemStats.completed}/{taskItemStats.total}
-                </span>
-              )}
+              <TaskProgressBadges task={task} />
 
               {showDueDates && task.dueDate && (
                 <div

--- a/apps/web/src/components/list-view/task-row.test.tsx
+++ b/apps/web/src/components/list-view/task-row.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type Task from "@/types/task";
+import BacklogTaskRow from "../backlog-list-view/backlog-task-row";
 import TaskRow from "./task-row";
 
 const useExternalLinks = vi.fn((_taskId: string) => ({ data: [] }));
@@ -101,6 +102,19 @@ const task: Task = {
 };
 
 describe("TaskRow", () => {
+  it.each(["planned", "archived"])(
+    "renders progress for %s backlog parents without per-row requests",
+    (status) => {
+      render(<BacklogTaskRow task={{ ...task, status }} />);
+
+      expect(
+        screen.getByRole("button", { name: "tasks:subtasks.progress" }),
+      ).toHaveTextContent("2/5");
+      expect(useExternalLinks).not.toHaveBeenCalled();
+      expect(useGetLabelsByTask).not.toHaveBeenCalled();
+    },
+  );
+
   it("renders labels and pull requests from the task payload without per-row requests", () => {
     render(<TaskRow task={task} projectSlug="kan" />);
 

--- a/apps/web/src/components/list-view/task-row.test.tsx
+++ b/apps/web/src/components/list-view/task-row.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type Task from "@/types/task";
 import BacklogTaskRow from "../backlog-list-view/backlog-task-row";
+import { PublicTaskCard } from "../public-project/task-card";
+import { PublicTaskRow } from "../public-project/task-row";
 import TaskRow from "./task-row";
 
 const useExternalLinks = vi.fn((_taskId: string) => ({ data: [] }));
@@ -102,6 +104,27 @@ const task: Task = {
 };
 
 describe("TaskRow", () => {
+  it.each([PublicTaskCard, PublicTaskRow])(
+    "renders public progress without nesting interactive controls",
+    (Component) => {
+      const onTaskClick = vi.fn();
+      const { container } = render(
+        <Component
+          task={{ ...task, externalLinks: [] }}
+          projectSlug="kan"
+          onTaskClick={onTaskClick}
+        />,
+      );
+      expect(screen.getByTitle("tasks:subtasks.progress")).toHaveTextContent(
+        "2/5",
+      );
+      expect(container.querySelector("button button")).toBeNull();
+      expect(screen.getAllByRole("button")).toHaveLength(1);
+      expect(useExternalLinks).not.toHaveBeenCalled();
+      expect(useGetLabelsByTask).not.toHaveBeenCalled();
+    },
+  );
+
   it.each(["planned", "archived"])(
     "renders progress for %s backlog parents without per-row requests",
     (status) => {

--- a/apps/web/src/components/list-view/task-row.test.tsx
+++ b/apps/web/src/components/list-view/task-row.test.tsx
@@ -85,6 +85,7 @@ const task: Task = {
   assigneeName: null,
   projectId: "project-1",
   labels: [{ id: "label-1", name: "Bug", color: "red" }],
+  subtaskCounts: { completed: 2, total: 5 },
   externalLinks: [
     {
       id: "link-1",
@@ -105,6 +106,9 @@ describe("TaskRow", () => {
 
     expect(screen.getByText("Bug")).toBeVisible();
     expect(screen.getByText("#42")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "tasks:subtasks.progress" }),
+    ).toHaveTextContent("2/5");
     expect(useExternalLinks).not.toHaveBeenCalled();
     expect(useGetLabelsByTask).not.toHaveBeenCalled();
   });

--- a/apps/web/src/components/list-view/task-row.tsx
+++ b/apps/web/src/components/list-view/task-row.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { type CSSProperties, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { TaskProgressBadges } from "@/components/task/task-progress-badges";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -214,6 +215,7 @@ function TaskRow({ task, projectSlug }: TaskRowProps) {
                   {task.title}
                 </span>
                 <div className="flex items-center gap-1">
+                  <TaskProgressBadges task={task} />
                   {showLabels && <TaskLabels labels={task.labels ?? []} />}
 
                   {pullRequests.length === 1 && (

--- a/apps/web/src/components/public-project/task-card.tsx
+++ b/apps/web/src/components/public-project/task-card.tsx
@@ -1,5 +1,6 @@
 import { Calendar, CalendarClock, CalendarX } from "lucide-react";
 import { useRef } from "react";
+import { TaskProgressBadges } from "@/components/task/task-progress-badges";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   dueDateStatusColors,
@@ -122,7 +123,8 @@ export function PublicTaskCard({
         </div>
       )}
 
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <TaskProgressBadges task={task} asText />
         {task.priority && (
           <span className="inline-flex items-center gap-1.5 px-2 py-1 rounded border border-border bg-sidebar text-[10px] font-medium text-muted-foreground">
             {getPriorityIcon(task.priority ?? "")}

--- a/apps/web/src/components/public-project/task-row.tsx
+++ b/apps/web/src/components/public-project/task-row.tsx
@@ -1,5 +1,6 @@
 import { Calendar, CalendarClock, CalendarX } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { TaskProgressBadges } from "@/components/task/task-progress-badges";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   dueDateStatusColors,
@@ -58,7 +59,8 @@ export function PublicTaskRow({
         </div>
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <TaskProgressBadges task={task} asText />
         {task.assigneeName && (
           <div className="flex items-center gap-1.5">
             <Avatar className="h-5 w-5">

--- a/apps/web/src/components/task/task-progress-badges.test.tsx
+++ b/apps/web/src/components/task/task-progress-badges.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { TaskProgressBadges } from "./task-progress-badges";
+
+const preferences = vi.hoisted(() => ({ showTaskItemCounts: true }));
+vi.mock("@/store/user-preferences", () => ({
+  useUserPreferencesStore: () => preferences,
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, values: { completed: number; total: number }) =>
+      `${values.completed} of ${values.total} ${key.includes("subtasks") ? "subtasks" : "checklist items"} completed`,
+  }),
+}));
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  preferences.showTaskItemCounts = true;
+});
+
+describe("TaskProgressBadges", () => {
+  it("keeps checklist and subtask completion independent", () => {
+    render(
+      <TaskProgressBadges
+        task={{
+          description: "- [x] One\n- [ ] Two\n- [ ] Three",
+          subtaskCounts: { completed: 2, total: 2 },
+        }}
+      />,
+    );
+    const subtasks = screen.getByRole("button", {
+      name: "2 of 2 subtasks completed",
+    });
+    const checklist = screen.getByRole("button", {
+      name: "1 of 3 checklist items completed",
+    });
+    expect(subtasks).toHaveTextContent("2/2");
+    expect(subtasks).toHaveClass("text-success-foreground");
+    expect(checklist).toHaveTextContent("1/3");
+    expect(checklist).not.toHaveClass("text-success-foreground");
+  });
+
+  it("shows subtasks when description checklist counts are disabled", () => {
+    preferences.showTaskItemCounts = false;
+    render(
+      <TaskProgressBadges
+        task={{
+          description: "- [ ] One",
+          subtaskCounts: { completed: 0, total: 3 },
+        }}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "0 of 3 subtasks completed" }),
+    ).toBeVisible();
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+  });
+
+  it("hides absent and empty counters", () => {
+    const { rerender } = render(
+      <TaskProgressBadges task={{ description: null }} />,
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    rerender(
+      <TaskProgressBadges
+        task={{
+          description: "Plain text",
+          subtaskCounts: { completed: 0, total: 0 },
+        }}
+      />,
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("provides a tooltip and preserves the card's open action", async () => {
+    const open = vi.fn();
+    render(
+      <TooltipProvider delay={0}>
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: reproduces the task card click boundary */}
+        <div onClick={open} role="presentation">
+          <TaskProgressBadges
+            task={{
+              description: null,
+              subtaskCounts: { completed: 2, total: 5 },
+            }}
+          />
+        </div>
+      </TooltipProvider>,
+    );
+    const badge = screen.getByRole("button", {
+      name: "2 of 5 subtasks completed",
+    });
+    fireEvent.mouseEnter(badge);
+    expect(await screen.findByText("2 of 5 subtasks completed")).toBeVisible();
+    fireEvent.click(badge);
+    expect(open).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/task/task-progress-badges.tsx
+++ b/apps/web/src/components/task/task-progress-badges.tsx
@@ -9,8 +9,10 @@ import type Task from "@/types/task";
 
 export function TaskProgressBadges({
   task,
+  asText = false,
 }: {
   task: Pick<Task, "description" | "subtaskCounts">;
+  asText?: boolean;
 }) {
   const { t } = useTranslation();
   const { showTaskItemCounts } = useUserPreferencesStore();
@@ -39,22 +41,39 @@ export function TaskProgressBadges({
     },
   ];
 
-  return counters.map(({ kind, counts, Icon, label }) =>
-    counts && counts.total > 0 ? (
+  return counters.map(({ kind, counts, Icon, label }) => {
+    if (!counts || counts.total === 0) return null;
+    const className = cn(
+      "inline-flex h-5.5 shrink-0 cursor-inherit items-center gap-1 rounded border border-border/70 bg-muted/50 px-2 py-1 text-[10px] font-medium tabular-nums text-muted-foreground",
+      counts.completed === counts.total &&
+        "border-success/20 bg-success/10 text-success-foreground",
+    );
+    const content = (
+      <>
+        <Icon className="size-3" aria-hidden="true" />
+        {counts.completed}/{counts.total}
+      </>
+    );
+
+    // Public cards are buttons already; their badges must remain plain text.
+    if (asText) {
+      return (
+        <span key={kind} className={className} title={label}>
+          <span className="sr-only">{label}</span>
+          <span aria-hidden="true" className="inline-flex items-center gap-1">
+            {content}
+          </span>
+        </span>
+      );
+    }
+
+    return (
       <Tooltip key={kind}>
-        <TooltipTrigger
-          aria-label={label}
-          className={cn(
-            "inline-flex h-5.5 shrink-0 cursor-inherit items-center gap-1 rounded border border-border/70 bg-muted/50 px-2 py-1 text-[10px] font-medium tabular-nums text-muted-foreground",
-            counts.completed === counts.total &&
-              "border-success/20 bg-success/10 text-success-foreground",
-          )}
-        >
-          <Icon className="size-3" aria-hidden="true" />
-          {counts.completed}/{counts.total}
+        <TooltipTrigger aria-label={label} className={className}>
+          {content}
         </TooltipTrigger>
         <TooltipPopup>{label}</TooltipPopup>
       </Tooltip>
-    ) : null,
-  );
+    );
+  });
 }

--- a/apps/web/src/components/task/task-progress-badges.tsx
+++ b/apps/web/src/components/task/task-progress-badges.tsx
@@ -1,0 +1,60 @@
+import { ListTree, SquareCheck } from "lucide-react";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/cn";
+import { getTaskItemStats } from "@/lib/get-task-item-stats";
+import { useUserPreferencesStore } from "@/store/user-preferences";
+import type Task from "@/types/task";
+
+export function TaskProgressBadges({
+  task,
+}: {
+  task: Pick<Task, "description" | "subtaskCounts">;
+}) {
+  const { t } = useTranslation();
+  const { showTaskItemCounts } = useUserPreferencesStore();
+  const checklist = useMemo(
+    () => getTaskItemStats(task.description),
+    [task.description],
+  );
+  const counters = [
+    {
+      kind: "subtasks",
+      counts: task.subtaskCounts,
+      Icon: ListTree,
+      label: t("tasks:subtasks.progress", {
+        completed: task.subtaskCounts?.completed ?? 0,
+        total: task.subtaskCounts?.total ?? 0,
+      }),
+    },
+    {
+      kind: "checklist",
+      counts: showTaskItemCounts ? checklist : undefined,
+      Icon: SquareCheck,
+      label: t("tasks:checklistProgress", {
+        completed: checklist.completed,
+        total: checklist.total,
+      }),
+    },
+  ];
+
+  return counters.map(({ kind, counts, Icon, label }) =>
+    counts && counts.total > 0 ? (
+      <Tooltip key={kind}>
+        <TooltipTrigger
+          aria-label={label}
+          className={cn(
+            "inline-flex h-5.5 shrink-0 cursor-inherit items-center gap-1 rounded border border-border/70 bg-muted/50 px-2 py-1 text-[10px] font-medium tabular-nums text-muted-foreground",
+            counts.completed === counts.total &&
+              "border-success/20 bg-success/10 text-success-foreground",
+          )}
+        >
+          <Icon className="size-3" aria-hidden="true" />
+          {counts.completed}/{counts.total}
+        </TooltipTrigger>
+        <TooltipPopup>{label}</TooltipPopup>
+      </Tooltip>
+    ) : null,
+  );
+}

--- a/apps/web/src/hooks/mutations/task-relation/invalidate-relation-task-project.test.ts
+++ b/apps/web/src/hooks/mutations/task-relation/invalidate-relation-task-project.test.ts
@@ -1,0 +1,29 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import { invalidateRelationTaskProject } from "./invalidate-relation-task-project";
+
+describe("invalidateRelationTaskProject", () => {
+  it.each(["columns", "plannedTasks", "archivedTasks"])(
+    "refreshes the parent in %s without invalidating unrelated boards",
+    async (location) => {
+      const client = new QueryClient();
+      const parent = { id: "parent" };
+      client.setQueryData(["tasks", "parent-project"], {
+        columns: location === "columns" ? [{ tasks: [parent] }] : [],
+        plannedTasks: location === "plannedTasks" ? [parent] : [],
+        archivedTasks: location === "archivedTasks" ? [parent] : [],
+      });
+      client.setQueryData(["tasks", "unrelated-project"], {
+        columns: [{ tasks: [{ id: "other" }] }],
+      });
+      await invalidateRelationTaskProject(client, "parent");
+      expect(
+        client.getQueryState(["tasks", "parent-project"])?.isInvalidated,
+      ).toBe(true);
+      expect(
+        client.getQueryState(["tasks", "unrelated-project"])?.isInvalidated,
+      ).toBe(false);
+      client.clear();
+    },
+  );
+});

--- a/apps/web/src/hooks/mutations/task-relation/invalidate-relation-task-project.ts
+++ b/apps/web/src/hooks/mutations/task-relation/invalidate-relation-task-project.ts
@@ -1,0 +1,22 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { ProjectWithTasks } from "@/types/project";
+
+/** Refresh only cached boards that contain the relation's parent task. */
+export function invalidateRelationTaskProject(
+  queryClient: QueryClient,
+  taskId: string,
+) {
+  return queryClient.invalidateQueries({
+    queryKey: ["tasks"],
+    predicate: ({ state }) => {
+      const project = state.data as ProjectWithTasks | undefined;
+      return Boolean(
+        project?.columns.some((column) =>
+          column.tasks.some((task) => task.id === taskId),
+        ) ||
+          project?.plannedTasks?.some((task) => task.id === taskId) ||
+          project?.archivedTasks?.some((task) => task.id === taskId),
+      );
+    },
+  });
+}

--- a/apps/web/src/hooks/mutations/task-relation/use-create-task-relation.ts
+++ b/apps/web/src/hooks/mutations/task-relation/use-create-task-relation.ts
@@ -7,6 +7,7 @@ function useCreateTaskRelation() {
   return useMutation({
     mutationFn: createTaskRelation,
     onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
       queryClient.invalidateQueries({
         queryKey: ["task-relations", variables.sourceTaskId],
       });

--- a/apps/web/src/hooks/mutations/task-relation/use-create-task-relation.ts
+++ b/apps/web/src/hooks/mutations/task-relation/use-create-task-relation.ts
@@ -1,13 +1,15 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import createTaskRelation from "@/fetchers/task-relation/create-task-relation";
 
+import { invalidateRelationTaskProject } from "./invalidate-relation-task-project";
+
 function useCreateTaskRelation() {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: createTaskRelation,
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      void invalidateRelationTaskProject(queryClient, variables.sourceTaskId);
       queryClient.invalidateQueries({
         queryKey: ["task-relations", variables.sourceTaskId],
       });

--- a/apps/web/src/hooks/mutations/task-relation/use-delete-task-relation.ts
+++ b/apps/web/src/hooks/mutations/task-relation/use-delete-task-relation.ts
@@ -7,6 +7,7 @@ function useDeleteTaskRelation(taskId: string) {
   return useMutation({
     mutationFn: deleteTaskRelation,
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
       queryClient.invalidateQueries({
         queryKey: ["task-relations", taskId],
       });

--- a/apps/web/src/hooks/mutations/task-relation/use-delete-task-relation.ts
+++ b/apps/web/src/hooks/mutations/task-relation/use-delete-task-relation.ts
@@ -1,13 +1,15 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import deleteTaskRelation from "@/fetchers/task-relation/delete-task-relation";
 
+import { invalidateRelationTaskProject } from "./invalidate-relation-task-project";
+
 function useDeleteTaskRelation(taskId: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: deleteTaskRelation,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    onSuccess: (relation) => {
+      void invalidateRelationTaskProject(queryClient, relation.sourceTaskId);
       queryClient.invalidateQueries({
         queryKey: ["task-relations", taskId],
       });

--- a/apps/web/src/hooks/mutations/task/use-delete-task.ts
+++ b/apps/web/src/hooks/mutations/task/use-delete-task.ts
@@ -20,7 +20,7 @@ export function useDeleteTask() {
         exact: true,
       });
       void queryClient.invalidateQueries({
-        queryKey: ["tasks", deletedTask.projectId],
+        queryKey: ["tasks"],
       });
 
       const { project, setProject } = useProjectStore.getState();

--- a/apps/web/src/hooks/mutations/task/use-delete-task.ts
+++ b/apps/web/src/hooks/mutations/task/use-delete-task.ts
@@ -20,7 +20,7 @@ export function useDeleteTask() {
         exact: true,
       });
       void queryClient.invalidateQueries({
-        queryKey: ["tasks"],
+        queryKey: ["tasks", deletedTask.projectId],
       });
 
       const { project, setProject } = useProjectStore.getState();

--- a/apps/web/src/hooks/mutations/task/use-move-task.ts
+++ b/apps/web/src/hooks/mutations/task/use-move-task.ts
@@ -9,13 +9,16 @@ export function useMoveTask() {
 
   return useMutation({
     mutationFn: moveTask,
-    onSuccess: (_, variables) => {
+    onSuccess: (result, variables) => {
       toast.success(t("tasks:move.success"));
       queryClient.invalidateQueries({
         queryKey: ["task", variables.taskId],
       });
       queryClient.invalidateQueries({
-        queryKey: ["tasks"],
+        queryKey: ["tasks", result.sourceProjectId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["tasks", result.destinationProjectId],
       });
       queryClient.invalidateQueries({
         queryKey: ["projects"],

--- a/apps/web/src/hooks/mutations/task/use-move-task.ts
+++ b/apps/web/src/hooks/mutations/task/use-move-task.ts
@@ -9,16 +9,13 @@ export function useMoveTask() {
 
   return useMutation({
     mutationFn: moveTask,
-    onSuccess: (result, variables) => {
+    onSuccess: (_, variables) => {
       toast.success(t("tasks:move.success"));
       queryClient.invalidateQueries({
         queryKey: ["task", variables.taskId],
       });
       queryClient.invalidateQueries({
-        queryKey: ["tasks", result.sourceProjectId],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["tasks", result.destinationProjectId],
+        queryKey: ["tasks"],
       });
       queryClient.invalidateQueries({
         queryKey: ["projects"],

--- a/apps/web/src/hooks/mutations/task/use-update-task-status.ts
+++ b/apps/web/src/hooks/mutations/task/use-update-task-status.ts
@@ -12,7 +12,7 @@ export function useUpdateTaskStatus() {
         queryKey: ["task", variables.id],
       });
       queryClient.invalidateQueries({
-        queryKey: ["tasks"],
+        queryKey: ["tasks", variables.projectId],
       });
       queryClient.invalidateQueries({
         queryKey: ["notifications"],

--- a/apps/web/src/hooks/mutations/task/use-update-task-status.ts
+++ b/apps/web/src/hooks/mutations/task/use-update-task-status.ts
@@ -12,7 +12,7 @@ export function useUpdateTaskStatus() {
         queryKey: ["task", variables.id],
       });
       queryClient.invalidateQueries({
-        queryKey: ["tasks", variables.projectId],
+        queryKey: ["tasks"],
       });
       queryClient.invalidateQueries({
         queryKey: ["notifications"],

--- a/apps/web/src/hooks/mutations/task/use-update-task.ts
+++ b/apps/web/src/hooks/mutations/task/use-update-task.ts
@@ -12,7 +12,7 @@ export function useUpdateTask() {
         queryKey: ["task", variables.id],
       });
       queryClient.invalidateQueries({
-        queryKey: ["tasks", variables.projectId],
+        queryKey: ["tasks"],
       });
       queryClient.invalidateQueries({
         queryKey: ["notifications"],

--- a/apps/web/src/hooks/mutations/task/use-update-task.ts
+++ b/apps/web/src/hooks/mutations/task/use-update-task.ts
@@ -12,7 +12,7 @@ export function useUpdateTask() {
         queryKey: ["task", variables.id],
       });
       queryClient.invalidateQueries({
-        queryKey: ["tasks"],
+        queryKey: ["tasks", variables.projectId],
       });
       queryClient.invalidateQueries({
         queryKey: ["notifications"],

--- a/apps/web/src/hooks/queries/project/use-get-public-project.ts
+++ b/apps/web/src/hooks/queries/project/use-get-public-project.ts
@@ -5,6 +5,7 @@ function useGetPublicProject(id: string) {
   return useQuery({
     queryKey: ["public-project", id],
     queryFn: () => getPublicProject({ id }),
+    refetchOnMount: true,
   });
 }
 

--- a/apps/web/src/hooks/queries/task/use-get-tasks.test.tsx
+++ b/apps/web/src/hooks/queries/task/use-get-tasks.test.tsx
@@ -1,0 +1,62 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import queryClient from "@/query-client";
+import { useGetTasks } from "./use-get-tasks";
+
+const getTasks = vi.hoisted(() => vi.fn());
+vi.mock("@/fetchers/task/get-tasks", () => ({ default: getTasks }));
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  queryClient.clear();
+  getTasks.mockReset();
+});
+
+describe("useGetTasks", () => {
+  it("refreshes cached parent progress on return without a parent socket", async () => {
+    const parent = {
+      id: "parent-project",
+      columns: [
+        {
+          tasks: [{ id: "parent", subtaskCounts: { completed: 0, total: 1 } }],
+        },
+      ],
+    };
+    getTasks.mockResolvedValue(parent);
+    const firstVisit = renderHook(() => useGetTasks("parent-project"), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(firstVisit.result.current.data).toEqual(parent));
+    firstVisit.unmount();
+
+    // Deleting the child project changes the server while the parent is inactive.
+    // No socket event or local invalidation reaches this cached board.
+    const updatedParent = {
+      ...parent,
+      columns: [
+        {
+          tasks: [{ id: "parent", subtaskCounts: { completed: 0, total: 0 } }],
+        },
+      ],
+    };
+    getTasks.mockResolvedValue(updatedParent);
+    expect(queryClient.getQueryData(["tasks", "parent-project"])).toEqual(
+      parent,
+    );
+    const returnVisit = renderHook(() => useGetTasks("parent-project"), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() =>
+      expect(returnVisit.result.current.data).toEqual(updatedParent),
+    );
+    expect(getTasks).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/hooks/queries/task/use-get-tasks.test.tsx
+++ b/apps/web/src/hooks/queries/task/use-get-tasks.test.tsx
@@ -3,10 +3,15 @@ import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import queryClient from "@/query-client";
+import useGetPublicProject from "../project/use-get-public-project";
 import { useGetTasks } from "./use-get-tasks";
 
 const getTasks = vi.hoisted(() => vi.fn());
+const getPublicProject = vi.hoisted(() => vi.fn());
 vi.mock("@/fetchers/task/get-tasks", () => ({ default: getTasks }));
+vi.mock("@/fetchers/project/get-public-project", () => ({
+  default: getPublicProject,
+}));
 
 function Wrapper({ children }: { children: ReactNode }) {
   return (
@@ -18,9 +23,25 @@ afterEach(() => {
   cleanup();
   queryClient.clear();
   getTasks.mockReset();
+  getPublicProject.mockReset();
 });
 
 describe("useGetTasks", () => {
+  it("refreshes a cached public board when revisited", async () => {
+    queryClient.setQueryData(["public-project", "public-parent"], {
+      columns: [{ tasks: [{ subtaskCounts: { completed: 0, total: 1 } }] }],
+    });
+    const updated = {
+      columns: [{ tasks: [{ subtaskCounts: { completed: 1, total: 1 } }] }],
+    };
+    getPublicProject.mockResolvedValue(updated);
+    const { result } = renderHook(() => useGetPublicProject("public-parent"), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current.data).toEqual(updated));
+    expect(getPublicProject).toHaveBeenCalledWith({ id: "public-parent" });
+  });
+
   it("refreshes cached parent progress on return without a parent socket", async () => {
     const parent = {
       id: "parent-project",

--- a/apps/web/src/hooks/queries/task/use-get-tasks.ts
+++ b/apps/web/src/hooks/queries/task/use-get-tasks.ts
@@ -6,6 +6,8 @@ export function useGetTasks(projectId: string) {
   return useQuery({
     queryKey: ["tasks", projectId],
     queryFn: () => getTasks(projectId),
+    // Inactive boards can miss child updates sent on their project socket.
+    refetchOnMount: true,
     refetchInterval: (query) =>
       isUnauthorizedError(query.state.error) ? false : 30000,
     enabled: !!projectId,

--- a/apps/web/src/types/task/index.ts
+++ b/apps/web/src/types/task/index.ts
@@ -33,6 +33,7 @@ type Task = {
   assigneeImage?: string | null;
   projectId: string;
   columnId?: string | null;
+  subtaskCounts?: { completed: number; total: number };
   labels?: TaskLabel[];
   externalLinks?: TaskExternalLink[];
 };

--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -691,7 +691,9 @@
 			"slackSectionTitle": "Slack-Integration",
 			"slackSectionSubtitle": "Sende Projektaktualisierungen per Incoming Webhook in einen Slack-Kanal.",
 			"telegramSectionTitle": "Telegram-Integration",
-			"telegramSectionSubtitle": "Sende Projektaktualisierungen mit einem Bot in einen Telegram-Chat oder ein Thema."
+			"telegramSectionSubtitle": "Sende Projektaktualisierungen mit einem Bot in einen Telegram-Chat oder ein Thema.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "Projektsichtbarkeit",
@@ -1272,6 +1274,44 @@
 			"updateError": "Label konnte nicht aktualisiert werden",
 			"deleteError": "Label konnte nicht gelöscht werden",
 			"nameRequired": "Label-Name ist erforderlich"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -1561,6 +1561,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "{{completed}} von {{total}} Checklistenpunkten abgeschlossen",
 		"title": "Aufgaben",
 		"status": {
 			"label": "Status",
@@ -1718,6 +1719,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "{{completed}} von {{total}} Unteraufgaben abgeschlossen",
 			"title": "Teilaufgaben",
 			"inputPlaceholder": "Titel der Teilaufgabe...",
 			"addAction": "Hinzufügen",

--- a/i18n/el-GR.json
+++ b/i18n/el-GR.json
@@ -691,7 +691,9 @@
 			"genericWebhookSectionTitle": "Γενικά Webhooks",
 			"genericWebhookSectionSubtitle": "Στείλτε γεγονότα εργασιών έργου σε οποιοδήποτε HTTP endpoint ως JSON.",
 			"slackSectionTitle": "Ενσωμάτωση Slack",
-			"slackSectionSubtitle": "Στείλτε ενημερώσεις εργασιών έργου σε κανάλι Slack μέσω εισερχόμενου webhook."
+			"slackSectionSubtitle": "Στείλτε ενημερώσεις εργασιών έργου σε κανάλι Slack μέσω εισερχόμενου webhook.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "Ορατότητα έργου",
@@ -1272,6 +1274,44 @@
 			"updateError": "Αποτυχία ενημέρωσης ετικέτας",
 			"deleteError": "Αποτυχία διαγραφής ετικέτας",
 			"nameRequired": "Το όνομα ετικέτας είναι υποχρεωτικό"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/el-GR.json
+++ b/i18n/el-GR.json
@@ -1561,6 +1561,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "Ολοκληρώθηκαν {{completed}} από {{total}} στοιχεία λίστας ελέγχου",
 		"title": "Εργασίες",
 		"status": {
 			"label": "Κατάσταση",
@@ -1718,6 +1719,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "Ολοκληρώθηκαν {{completed}} από {{total}} υποεργασίες",
 			"title": "Υποεργασίες",
 			"inputPlaceholder": "Τίτλος υποεργασίας...",
 			"addAction": "Προσθήκη",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1601,6 +1601,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "{{completed}} of {{total}} checklist items completed",
 		"title": "Tasks",
 		"status": {
 			"label": "Status",
@@ -1758,6 +1759,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "{{completed}} of {{total}} subtasks completed",
 			"title": "Sub-tasks",
 			"inputPlaceholder": "Subtask title...",
 			"addAction": "Add",

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -588,7 +588,9 @@
 			"giteaSectionTitle": "Integración con Gitea",
 			"giteaSectionSubtitle": "Sincroniza tareas con una instancia autoalojada de Gitea (issues, PRs, webhooks).",
 			"telegramSectionTitle": "Integración con Telegram",
-			"telegramSectionSubtitle": "Envía actualizaciones de las tareas del proyecto a un chat o tema de Telegram mediante un bot."
+			"telegramSectionSubtitle": "Envía actualizaciones de las tareas del proyecto a un chat o tema de Telegram mediante un bot.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "Visibilidad del Proyecto",
@@ -1273,6 +1275,44 @@
 			"connect": "Conectar Telegram",
 			"saveChanges": "Guardar cambios",
 			"disconnect": "Desconectar"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -1566,6 +1566,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "{{completed}} de {{total}} elementos de la lista completados",
 		"title": "Tareas",
 		"status": {
 			"label": "Estado",
@@ -1723,6 +1724,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "{{completed}} de {{total}} subtareas completadas",
 			"title": "Sub-tareas",
 			"inputPlaceholder": "Título de la subtarea...",
 			"addAction": "Añadir",

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -691,7 +691,9 @@
 			"genericWebhookSectionTitle": "Webhooks génériques",
 			"genericWebhookSectionSubtitle": "Envoyez les événements des tâches du projet vers n'importe quel point de terminaison HTTP au format JSON.",
 			"slackSectionTitle": "Intégration Slack",
-			"slackSectionSubtitle": "Envoyez les mises à jour des tâches du projet dans un canal Slack via un webhook entrant."
+			"slackSectionSubtitle": "Envoyez les mises à jour des tâches du projet dans un canal Slack via un webhook entrant.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "Visibilité du projet",
@@ -1273,6 +1275,44 @@
 			"updateError": "Échec de la mise à jour du label",
 			"deleteError": "Échec de la suppression du label",
 			"nameRequired": "Le nom du label est requis"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -1566,6 +1566,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "{{completed}} éléments de la liste terminés sur {{total}}",
 		"title": "Tâches",
 		"status": {
 			"label": "Statut",
@@ -1723,6 +1724,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "{{completed}} sous-tâches terminées sur {{total}}",
 			"title": "Sous-tâches",
 			"inputPlaceholder": "Titre de la sous-tâche...",
 			"addAction": "Ajouter",

--- a/i18n/hi-IN.json
+++ b/i18n/hi-IN.json
@@ -853,7 +853,9 @@
 			"slackSectionTitle": "Slack एकीकरण",
 			"slackSectionSubtitle": "इनकमिंग वेबहुक के साथ Slack चैनल में प्रोजेक्ट कार्य अपडेट भेजें।",
 			"telegramSectionTitle": "Telegram एकीकरण",
-			"telegramSectionSubtitle": "बॉट के साथ Telegram चैट या टॉपिक में प्रोजेक्ट कार्य अपडेट भेजें।"
+			"telegramSectionSubtitle": "बॉट के साथ Telegram चैट या टॉपिक में प्रोजेक्ट कार्य अपडेट भेजें।",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "प्रोजेक्ट दृश्यता",
@@ -1272,6 +1274,44 @@
 			"merged": "मर्ज किया",
 			"draft": "ड्राफ़्ट",
 			"open": "खुला"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/hi-IN.json
+++ b/i18n/hi-IN.json
@@ -1561,6 +1561,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "चेकलिस्ट के {{total}} में से {{completed}} आइटम पूरे हुए",
 		"title": "कार्य",
 		"status": {
 			"label": "स्थिति",
@@ -1718,6 +1719,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "{{total}} में से {{completed}} उपकार्य पूरे हुए",
 			"title": "उप-कार्य",
 			"inputPlaceholder": "उप-कार्य शीर्षक...",
 			"addAction": "जोड़ें",

--- a/i18n/id-ID.json
+++ b/i18n/id-ID.json
@@ -691,7 +691,9 @@
 			"slackSectionTitle": "Integrasi Slack",
 			"slackSectionSubtitle": "Kirim pembaruan tugas proyek ke kanal Slack dengan incoming webhook.",
 			"telegramSectionTitle": "Integrasi Telegram",
-			"telegramSectionSubtitle": "Kirim pembaruan tugas proyek ke chat atau topik Telegram dengan bot."
+			"telegramSectionSubtitle": "Kirim pembaruan tugas proyek ke chat atau topik Telegram dengan bot.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "Visibilitas Proyek",
@@ -1271,6 +1273,44 @@
 			"updateError": "Gagal memperbarui label",
 			"deleteError": "Gagal menghapus label",
 			"nameRequired": "Nama label wajib diisi"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/id-ID.json
+++ b/i18n/id-ID.json
@@ -1556,6 +1556,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "{{completed}} dari {{total}} item daftar periksa selesai",
 		"title": "Tugas",
 		"status": {
 			"label": "Status",
@@ -1713,6 +1714,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "{{completed}} dari {{total}} subtugas selesai",
 			"title": "Subtugas",
 			"inputPlaceholder": "Judul subtugas...",
 			"addAction": "Tambah",

--- a/i18n/it-IT.json
+++ b/i18n/it-IT.json
@@ -854,7 +854,9 @@
 			"slackSectionTitle": "Integrazione Slack",
 			"slackSectionSubtitle": "Invia aggiornamenti delle attività del progetto in un canale Slack tramite webhook in entrata.",
 			"telegramSectionTitle": "Integrazione Telegram",
-			"telegramSectionSubtitle": "Invia aggiornamenti delle attività del progetto in una chat o topic Telegram con un bot."
+			"telegramSectionSubtitle": "Invia aggiornamenti delle attività del progetto in una chat o topic Telegram con un bot.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "Visibilità Progetto",
@@ -1273,6 +1275,44 @@
 			"merged": "Unito",
 			"draft": "Bozza",
 			"open": "Aperto"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/it-IT.json
+++ b/i18n/it-IT.json
@@ -1566,6 +1566,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "{{completed}} di {{total}} elementi della checklist completati",
 		"title": "Attività",
 		"status": {
 			"label": "Stato",
@@ -1723,6 +1724,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "{{completed}} di {{total}} sottoattività completate",
 			"title": "Sotto-attività",
 			"inputPlaceholder": "Titolo sotto-attività...",
 			"addAction": "Aggiungi",

--- a/i18n/ja-JP.json
+++ b/i18n/ja-JP.json
@@ -852,7 +852,9 @@
 			"slackSectionTitle": "Slack 連携",
 			"slackSectionSubtitle": "Incoming Webhook を使用してプロジェクトのタスク更新を Slack チャンネルに送信します。",
 			"telegramSectionTitle": "Telegram 連携",
-			"telegramSectionSubtitle": "ボットを使用してプロジェクトのタスク更新を Telegram のチャットまたはトピックに送信します。"
+			"telegramSectionSubtitle": "ボットを使用してプロジェクトのタスク更新を Telegram のチャットまたはトピックに送信します。",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "プロジェクトの公開設定",
@@ -1271,6 +1273,44 @@
 			"merged": "マージ済み",
 			"draft": "下書き",
 			"open": "オープン"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/ja-JP.json
+++ b/i18n/ja-JP.json
@@ -1556,6 +1556,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "チェックリスト {{total}} 項目中 {{completed}} 項目完了",
 		"title": "タスク",
 		"status": {
 			"label": "ステータス",
@@ -1713,6 +1714,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "サブタスク {{total}} 件中 {{completed}} 件完了",
 			"title": "サブタスク",
 			"inputPlaceholder": "サブタスクのタイトル...",
 			"addAction": "追加",

--- a/i18n/ko-KR.json
+++ b/i18n/ko-KR.json
@@ -691,7 +691,9 @@
 			"slackSectionTitle": "Slack 연동",
 			"slackSectionSubtitle": "수신 웹훅을 사용하여 프로젝트 작업 업데이트를 Slack 채널로 전송합니다.",
 			"telegramSectionTitle": "Telegram 연동",
-			"telegramSectionSubtitle": "봇을 사용하여 프로젝트 작업 업데이트를 Telegram 채팅 또는 토픽으로 전송합니다."
+			"telegramSectionSubtitle": "봇을 사용하여 프로젝트 작업 업데이트를 Telegram 채팅 또는 토픽으로 전송합니다.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "프로젝트 공개 설정",
@@ -1271,6 +1273,44 @@
 			"updateError": "라벨 업데이트에 실패했습니다",
 			"deleteError": "라벨 삭제에 실패했습니다",
 			"nameRequired": "라벨 이름은 필수입니다"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/ko-KR.json
+++ b/i18n/ko-KR.json
@@ -1556,6 +1556,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "체크리스트 항목 {{total}}개 중 {{completed}}개 완료",
 		"title": "작업",
 		"status": {
 			"label": "상태",
@@ -1713,6 +1714,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "하위 작업 {{total}}개 중 {{completed}}개 완료",
 			"title": "하위 작업",
 			"inputPlaceholder": "하위 작업 제목...",
 			"addAction": "추가",

--- a/i18n/mk-MK.json
+++ b/i18n/mk-MK.json
@@ -691,7 +691,9 @@
 			"genericWebhookSectionTitle": "Општи webhooks",
 			"genericWebhookSectionSubtitle": "Испрати настани за задачи на проектот до кој било HTTP endpoint како JSON.",
 			"slackSectionTitle": "Slack интеграција",
-			"slackSectionSubtitle": "Испрати ажурирања за задачи на проектот во Slack канал преку дојдовен webhook."
+			"slackSectionSubtitle": "Испрати ажурирања за задачи на проектот во Slack канал преку дојдовен webhook.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "Видливост на проект",
@@ -1272,6 +1274,44 @@
 			"updateError": "Неуспешно ажурирање на ознака",
 			"deleteError": "Неуспешно бришење на ознака",
 			"nameRequired": "Името на ознаката е задолжително"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/mk-MK.json
+++ b/i18n/mk-MK.json
@@ -1561,6 +1561,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "Завршени се {{completed}} од {{total}} ставки од списокот",
 		"title": "Задачи",
 		"status": {
 			"label": "Статус",
@@ -1718,6 +1719,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "Завршени се {{completed}} од {{total}} подзадачи",
 			"title": "Подзадачи",
 			"inputPlaceholder": "Наслов на подзадача...",
 			"addAction": "Додади",

--- a/i18n/nl-NL.json
+++ b/i18n/nl-NL.json
@@ -588,7 +588,9 @@
 			"giteaSectionTitle": "Gitea Integratie",
 			"giteaSectionSubtitle": "Synchroniseer taken met een zelf-gehoste Gitea-instantie (issues, PR's, webhooks).",
 			"telegramSectionTitle": "Telegram Integratie",
-			"telegramSectionSubtitle": "Verstuur updates van projecttaken naar een Telegram-chat of -topic met een bot."
+			"telegramSectionSubtitle": "Verstuur updates van projecttaken naar een Telegram-chat of -topic met een bot.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "Projectzichtbaarheid",
@@ -1272,6 +1274,44 @@
 			"connect": "Verbind Telegram",
 			"saveChanges": "Wijzigingen opslaan",
 			"disconnect": "Ontkoppelen"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/nl-NL.json
+++ b/i18n/nl-NL.json
@@ -1561,6 +1561,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "{{completed}} van {{total}} checklistitems voltooid",
 		"title": "Taken",
 		"status": {
 			"label": "Status",
@@ -1718,6 +1719,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "{{completed}} van {{total}} subtaken voltooid",
 			"title": "Subtaken",
 			"inputPlaceholder": "Titel subtaak...",
 			"addAction": "Toevoegen",

--- a/i18n/pl-PL.json
+++ b/i18n/pl-PL.json
@@ -1374,7 +1374,9 @@
 			"subtitle": "Połącz projekt z zewnętrznymi narzędziami i usługami, aby usprawnić obieg pracy.",
 			"telegramSectionSubtitle": "Wysyłaj aktualizacje zadań projektu do czatu lub wątku w Telegramie za pomocą bota.",
 			"telegramSectionTitle": "Integracja z Telegramem",
-			"title": "Integracje projektu"
+			"title": "Integracje projektu",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectSwitcher": {
 			"noProjects": "Brak projektów",
@@ -1750,6 +1752,44 @@
 				"nameRequired": "Nazwa roli jest wymagana",
 				"permissionRequired": "Należy wybrać co najmniej jedno uprawnienie"
 			}
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"tasks": {

--- a/i18n/pl-PL.json
+++ b/i18n/pl-PL.json
@@ -1753,6 +1753,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "Ukończone elementy listy kontrolnej: {{completed}} z {{total}}",
 		"title": "Zadania",
 		"actions": {
 			"archive": "Archiwizuj",
@@ -2157,6 +2158,7 @@
 			"to-do": "Do zrobienia"
 		},
 		"subtasks": {
+			"progress": "Ukończone podzadania: {{completed}} z {{total}}",
 			"addAction": "Dodaj",
 			"completeAria": "Oznacz podzadanie jako ukończone",
 			"createError": "Nie udało się utworzyć podzadania",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -854,7 +854,9 @@
 			"slackSectionTitle": "Integração com Slack",
 			"slackSectionSubtitle": "Envie atualizações de tarefas do projeto para um canal do Slack com um webhook de entrada.",
 			"telegramSectionTitle": "Integração com Telegram",
-			"telegramSectionSubtitle": "Envie atualizações de tarefas do projeto para um chat ou tópico do Telegram com um bot."
+			"telegramSectionSubtitle": "Envie atualizações de tarefas do projeto para um chat ou tópico do Telegram com um bot.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "Visibilidade do projeto",
@@ -1273,6 +1275,44 @@
 			"merged": "Mesclado",
 			"draft": "Rascunho",
 			"open": "Aberto"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -1566,6 +1566,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "{{completed}} de {{total}} itens da lista concluídos",
 		"title": "Tarefas",
 		"status": {
 			"label": "Status",
@@ -1723,6 +1724,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "{{completed}} de {{total}} subtarefas concluídas",
 			"title": "Subtarefas",
 			"inputPlaceholder": "Título da subtarefa...",
 			"addAction": "Adicionar",

--- a/i18n/ru-RU.json
+++ b/i18n/ru-RU.json
@@ -691,7 +691,9 @@
 			"slackSectionTitle": "Интеграция со Slack",
 			"slackSectionSubtitle": "Отправка обновлений по задачам проекта в канал Slack через входящий вебхук.",
 			"telegramSectionTitle": "Интеграция с Telegram",
-			"telegramSectionSubtitle": "Отправка обновлений по задачам проекта в чат или тему Telegram через бота."
+			"telegramSectionSubtitle": "Отправка обновлений по задачам проекта в чат или тему Telegram через бота.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "Видимость проекта",
@@ -1282,6 +1284,44 @@
 			"updateError": "Не удалось обновить метку",
 			"deleteError": "Не удалось удалить метку",
 			"nameRequired": "Название метки обязательно"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/ru-RU.json
+++ b/i18n/ru-RU.json
@@ -1579,6 +1579,7 @@
 		"created": "создал эту задачу"
 	},
 	"tasks": {
+		"checklistProgress": "Выполнено пунктов списка: {{completed}} из {{total}}",
 		"title": "Задачи",
 		"status": {
 			"label": "Статус",
@@ -1736,6 +1737,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "Выполнено подзадач: {{completed}} из {{total}}",
 			"title": "Подзадачи",
 			"inputPlaceholder": "Название подзадачи...",
 			"addAction": "Добавить",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -3325,6 +3325,12 @@
 						"slackSectionSubtitle": {
 							"type": "string"
 						},
+						"mattermostSectionTitle": {
+							"type": "string"
+						},
+						"mattermostSectionSubtitle": {
+							"type": "string"
+						},
 						"telegramSectionTitle": {
 							"type": "string"
 						},
@@ -3346,6 +3352,8 @@
 						"genericWebhookSectionSubtitle",
 						"slackSectionTitle",
 						"slackSectionSubtitle",
+						"mattermostSectionTitle",
+						"mattermostSectionSubtitle",
 						"telegramSectionTitle",
 						"telegramSectionSubtitle"
 					]
@@ -4405,6 +4413,159 @@
 						"disconnect"
 					]
 				},
+				"mattermostIntegration": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"validation": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"webhookInvalid": {
+									"type": "string"
+								}
+							},
+							"required": ["webhookInvalid"]
+						},
+						"toast": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"saved": {
+									"type": "string"
+								},
+								"saveError": {
+									"type": "string"
+								},
+								"enabled": {
+									"type": "string"
+								},
+								"disabled": {
+									"type": "string"
+								},
+								"updateError": {
+									"type": "string"
+								},
+								"removed": {
+									"type": "string"
+								},
+								"removeError": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"saved",
+								"saveError",
+								"enabled",
+								"disabled",
+								"updateError",
+								"removed",
+								"removeError"
+							]
+						},
+						"connectionTitle": {
+							"type": "string"
+						},
+						"connectionHint": {
+							"type": "string"
+						},
+						"connected": {
+							"type": "string"
+						},
+						"paused": {
+							"type": "string"
+						},
+						"webhookLabel": {
+							"type": "string"
+						},
+						"webhookPlaceholder": {
+							"type": "string"
+						},
+						"webhookHint": {
+							"type": "string"
+						},
+						"channelLabel": {
+							"type": "string"
+						},
+						"channelPlaceholder": {
+							"type": "string"
+						},
+						"channelHint": {
+							"type": "string"
+						},
+						"eventsTitle": {
+							"type": "string"
+						},
+						"eventsHint": {
+							"type": "string"
+						},
+						"events": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"taskCreated": {
+									"type": "string"
+								},
+								"taskStatusChanged": {
+									"type": "string"
+								},
+								"taskPriorityChanged": {
+									"type": "string"
+								},
+								"taskTitleChanged": {
+									"type": "string"
+								},
+								"taskDescriptionChanged": {
+									"type": "string"
+								},
+								"taskCommentCreated": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"taskCreated",
+								"taskStatusChanged",
+								"taskPriorityChanged",
+								"taskTitleChanged",
+								"taskDescriptionChanged",
+								"taskCommentCreated"
+							]
+						},
+						"connect": {
+							"type": "string"
+						},
+						"saveChanges": {
+							"type": "string"
+						},
+						"update": {
+							"type": "string"
+						},
+						"disconnect": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"validation",
+						"toast",
+						"connectionTitle",
+						"connectionHint",
+						"connected",
+						"paused",
+						"webhookLabel",
+						"webhookPlaceholder",
+						"webhookHint",
+						"channelLabel",
+						"channelPlaceholder",
+						"channelHint",
+						"eventsTitle",
+						"eventsHint",
+						"events",
+						"connect",
+						"saveChanges",
+						"update",
+						"disconnect"
+					]
+				},
 				"genericWebhookIntegration": {
 					"type": "object",
 					"additionalProperties": false,
@@ -5141,6 +5302,7 @@
 				"giteaIntegration",
 				"slackIntegration",
 				"discordIntegration",
+				"mattermostIntegration",
 				"genericWebhookIntegration",
 				"telegramIntegration",
 				"repositoryBrowser",
@@ -6323,6 +6485,9 @@
 			"additionalProperties": false,
 			"properties": {
 				"checklistProgress": {
+					"type": "string"
+				},
+				"title": {
 					"type": "string"
 				},
 				"status": {
@@ -7605,10 +7770,10 @@
 						"title": {
 							"type": "string"
 						},
-						"searchPlaceholder": {
+						"jumpToToday": {
 							"type": "string"
 						},
-						"jumpToToday": {
+						"searchPlaceholder": {
 							"type": "string"
 						},
 						"hideTasks": {
@@ -7648,8 +7813,8 @@
 					"required": [
 						"pageTitle",
 						"title",
-						"searchPlaceholder",
 						"jumpToToday",
+						"searchPlaceholder",
 						"hideTasks",
 						"showTasks",
 						"noTasks",
@@ -8203,6 +8368,7 @@
 			},
 			"required": [
 				"checklistProgress",
+				"title",
 				"status",
 				"priority",
 				"boardSearchPlaceholder",

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -6322,6 +6322,9 @@
 			"type": "object",
 			"additionalProperties": false,
 			"properties": {
+				"checklistProgress": {
+					"type": "string"
+				},
 				"status": {
 					"type": "object",
 					"additionalProperties": false,
@@ -6929,6 +6932,9 @@
 					"type": "object",
 					"additionalProperties": false,
 					"properties": {
+						"progress": {
+							"type": "string"
+						},
 						"title": {
 							"type": "string"
 						},
@@ -6964,6 +6970,7 @@
 						}
 					},
 					"required": [
+						"progress",
 						"title",
 						"inputPlaceholder",
 						"addAction",
@@ -8195,6 +8202,7 @@
 				}
 			},
 			"required": [
+				"checklistProgress",
 				"status",
 				"priority",
 				"boardSearchPlaceholder",

--- a/i18n/tr-TR.json
+++ b/i18n/tr-TR.json
@@ -691,7 +691,9 @@
 			"slackSectionTitle": "Slack Entegrasyonu",
 			"slackSectionSubtitle": "Proje talep güncellemelerini gelen bir webhook ile Slack kanalına gönderin.",
 			"telegramSectionTitle": "Telegram Entegrasyonu",
-			"telegramSectionSubtitle": "Proje talep güncellemelerini bir bot ile Telegram sohbetine veya konusuna gönderin."
+			"telegramSectionSubtitle": "Proje talep güncellemelerini bir bot ile Telegram sohbetine veya konusuna gönderin.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "Proje Görünürlüğü",
@@ -1272,6 +1274,44 @@
 			"updateError": "Etiket güncellenemedi",
 			"deleteError": "Etiket silinemedi",
 			"nameRequired": "Etiket adı gereklidir"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/tr-TR.json
+++ b/i18n/tr-TR.json
@@ -1561,6 +1561,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "{{total}} kontrol listesi öğesinin {{completed}} tanesi tamamlandı",
 		"title": "Görevler",
 		"status": {
 			"label": "Durum",
@@ -1718,6 +1719,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "{{total}} alt görevin {{completed}} tanesi tamamlandı",
 			"title": "Alt talepler",
 			"inputPlaceholder": "Alt talep başlığı...",
 			"addAction": "Ekle",

--- a/i18n/uk-UA.json
+++ b/i18n/uk-UA.json
@@ -691,7 +691,9 @@
 			"slackSectionTitle": "Інтеґрація зі Slack",
 			"slackSectionSubtitle": "Надсилайте оновлення завдань проєкту до каналу Slack за допомогою вхідного вебхука.",
 			"telegramSectionTitle": "Інтеґрація з Telegram",
-			"telegramSectionSubtitle": "Надсилайте оновлення завдань проєкту до чату або теми Telegram за допомогою бота."
+			"telegramSectionSubtitle": "Надсилайте оновлення завдань проєкту до чату або теми Telegram за допомогою бота.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "Видимість проєкту",
@@ -1274,6 +1276,44 @@
 			"updateError": "Не вдалося оновити мітку",
 			"deleteError": "Не вдалося видалити мітку",
 			"nameRequired": "Назва мітки є обов'язковою"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/uk-UA.json
+++ b/i18n/uk-UA.json
@@ -1571,6 +1571,7 @@
 		"created": "створив це завдання"
 	},
 	"tasks": {
+		"checklistProgress": "Виконано пунктів списку: {{completed}} із {{total}}",
 		"title": "Завдання",
 		"status": {
 			"label": "Статус",
@@ -1728,6 +1729,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "Виконано підзавдань: {{completed}} із {{total}}",
 			"title": "Підзавдання",
 			"inputPlaceholder": "Назва підзавдання...",
 			"addAction": "Додати",

--- a/i18n/vi-VN.json
+++ b/i18n/vi-VN.json
@@ -852,7 +852,9 @@
 			"slackSectionTitle": "Tích hợp Slack",
 			"slackSectionSubtitle": "Gửi cập nhật công việc dự án vào kênh Slack bằng webhook đến.",
 			"telegramSectionTitle": "Tích hợp Telegram",
-			"telegramSectionSubtitle": "Gửi cập nhật công việc dự án vào cuộc trò chuyện hoặc chủ đề Telegram bằng bot."
+			"telegramSectionSubtitle": "Gửi cập nhật công việc dự án vào cuộc trò chuyện hoặc chủ đề Telegram bằng bot.",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "Chế độ hiển thị dự án",
@@ -1271,6 +1273,44 @@
 			"merged": "Đã gộp",
 			"draft": "Bản nháp",
 			"open": "Đang mở"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/vi-VN.json
+++ b/i18n/vi-VN.json
@@ -1556,6 +1556,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "Đã hoàn thành {{completed}} trên {{total}} mục trong danh sách kiểm tra",
 		"title": "Nhiệm vụ",
 		"status": {
 			"label": "Trạng thái",
@@ -1713,6 +1714,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "Đã hoàn thành {{completed}} trên {{total}} công việc con",
 			"title": "Công việc con",
 			"inputPlaceholder": "Tiêu đề công việc con...",
 			"addAction": "Thêm",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -852,7 +852,9 @@
 			"slackSectionTitle": "Slack 集成",
 			"slackSectionSubtitle": "通过 Incoming Webhook 将项目任务更新发送到 Slack 频道。",
 			"telegramSectionTitle": "Telegram 集成",
-			"telegramSectionSubtitle": "通过 Bot 将项目任务更新发送到 Telegram 聊天或话题。"
+			"telegramSectionSubtitle": "通过 Bot 将项目任务更新发送到 Telegram 聊天或话题。",
+			"mattermostSectionSubtitle": "Send project task updates into a Mattermost channel with an incoming webhook.",
+			"mattermostSectionTitle": "Mattermost Integration"
 		},
 		"projectVisibility": {
 			"pageTitle": "项目可见性",
@@ -1271,6 +1273,44 @@
 			"merged": "已合并",
 			"draft": "草稿",
 			"open": "打开"
+		},
+		"mattermostIntegration": {
+			"channelHint": "Optional label for your reference. Mattermost controls the actual destination channel from the webhook setup.",
+			"channelLabel": "Channel name",
+			"channelPlaceholder": "#team-updates",
+			"connect": "Connect Mattermost",
+			"connected": "Connected",
+			"connectionHint": "Paste a Mattermost incoming webhook URL and choose which task events should be posted.",
+			"connectionTitle": "Mattermost webhook connection",
+			"disconnect": "Disconnect",
+			"events": {
+				"taskCommentCreated": "New comments",
+				"taskCreated": "New tasks",
+				"taskDescriptionChanged": "Description changes",
+				"taskPriorityChanged": "Priority changes",
+				"taskStatusChanged": "Status changes",
+				"taskTitleChanged": "Title changes"
+			},
+			"eventsHint": "Choose which project changes should post to Mattermost.",
+			"eventsTitle": "Event notifications",
+			"paused": "Paused",
+			"saveChanges": "Save changes",
+			"toast": {
+				"disabled": "Mattermost notifications paused",
+				"enabled": "Mattermost notifications enabled",
+				"removed": "Mattermost integration removed successfully",
+				"removeError": "Failed to remove Mattermost integration",
+				"saved": "Mattermost integration saved successfully",
+				"saveError": "Failed to save Mattermost integration",
+				"updateError": "Failed to update Mattermost integration"
+			},
+			"update": "Update Mattermost",
+			"validation": {
+				"webhookInvalid": "Enter a valid Mattermost webhook URL"
+			},
+			"webhookHint": "Create an Incoming Webhook in Mattermost and paste the generated URL here.",
+			"webhookLabel": "Incoming webhook URL",
+			"webhookPlaceholder": "https://your-mattermost-server.com/hooks/..."
 		}
 	},
 	"navigation": {

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -1556,6 +1556,7 @@
 		}
 	},
 	"tasks": {
+		"checklistProgress": "已完成 {{completed}}/{{total}} 个清单项",
 		"title": "任务",
 		"status": {
 			"label": "状态",
@@ -1713,6 +1714,7 @@
 			}
 		},
 		"subtasks": {
+			"progress": "已完成 {{completed}}/{{total}} 个子任务",
 			"title": "子任务",
 			"inputPlaceholder": "子任务标题…",
 			"addAction": "添加",

--- a/tests/api-integration/subtask-counts.test.ts
+++ b/tests/api-integration/subtask-counts.test.ts
@@ -1,6 +1,8 @@
 import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import updateColumn from "../../apps/api/src/column/controllers/update-column";
 import db, { schema } from "../../apps/api/src/database";
+import { eventContext } from "../../apps/api/src/events";
 import { createApp } from "../../apps/api/src/index";
 import { getPublicProject } from "../../apps/api/src/project/controllers/get-public-project";
 import deleteTask from "../../apps/api/src/task/controllers/delete-task";
@@ -241,11 +243,13 @@ describe("API integration: subtask counters", () => {
       "other-window",
     );
     try {
-      await updateTaskStatus({
-        id: child.id,
-        status: "done",
-        currentUserId: member.user.id,
-      });
+      await eventContext.run({ initiatorId: "other-window" }, () =>
+        updateTaskStatus({
+          id: child.id,
+          status: "done",
+          currentUserId: member.user.id,
+        }),
+      );
       await vi.waitFor(() => expect(send).toHaveBeenCalled());
       expect(JSON.parse(send.mock.calls[0][0])).toEqual({
         type: "TASK_RELATION_UPDATED",
@@ -253,12 +257,104 @@ describe("API integration: subtask counters", () => {
         taskId: "",
       });
       send.mockClear();
-      await deleteTask(child.id, member.user.id);
+      await eventContext.run({ initiatorId: "other-window" }, () =>
+        deleteTask(child.id, member.user.id),
+      );
       await vi.waitFor(() => expect(send).toHaveBeenCalled());
       expect(JSON.parse(send.mock.calls[0][0])).toEqual({
         type: "TASK_RELATION_UPDATED",
         projectId: parentProject.project.id,
         taskId: "",
+      });
+    } finally {
+      removeConnection(parentProject.project.id, connection);
+      await shutdownWebSocketAdapter();
+    }
+  });
+  it("refreshes parent boards when a child's column is marked final or reopened", async () => {
+    const member = await createWorkspaceMember();
+    const parentProject = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    const childProject = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    const parent = await addTask(parentProject.project.id);
+    const child = await addTask(childProject.project.id, "done");
+    await relate(parent.id, child.id);
+    await initializeWebSocketAdapter();
+    const send = vi.fn();
+    const connection = addConnection(
+      parentProject.project.id,
+      { send } as never,
+      member.user.id,
+      "same-window",
+    );
+    try {
+      for (const isFinal of [false, true]) {
+        send.mockClear();
+        await eventContext.run({ initiatorId: "same-window" }, () =>
+          updateColumn(childProject.columns.done.id, { isFinal }),
+        );
+        await vi.waitFor(() => expect(send).toHaveBeenCalled());
+        expect(JSON.parse(send.mock.calls[0][0])).toEqual({
+          type: "TASK_RELATION_UPDATED",
+          projectId: parentProject.project.id,
+          taskId: "",
+        });
+        expect(await countsFor(parentProject.project.id, parent.id)).toEqual({
+          completed: isFinal ? 1 : 0,
+          total: 1,
+        });
+      }
+    } finally {
+      removeConnection(parentProject.project.id, connection);
+      await shutdownWebSocketAdapter();
+    }
+  });
+
+  it("refreshes parent boards after the bulk API deletes children", async () => {
+    const member = await createWorkspaceMember({ role: "owner" });
+    const parentProject = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    const childProject = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    const parent = await addTask(parentProject.project.id);
+    const child = await addTask(childProject.project.id);
+    const secondChild = await addTask(childProject.project.id);
+    await relate(parent.id, child.id);
+    await relate(parent.id, secondChild.id);
+    await initializeWebSocketAdapter();
+    const send = vi.fn();
+    const connection = addConnection(
+      parentProject.project.id,
+      { send } as never,
+      member.user.id,
+      "other-window",
+    );
+    try {
+      mockAuthenticatedSession(member.user);
+      const { app } = createApp();
+      const response = await app.request("/api/task/bulk", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          taskIds: [child.id, secondChild.id],
+          operation: "delete",
+        }),
+      });
+      expect(response.status).toBe(200);
+      await vi.waitFor(() => expect(send).toHaveBeenCalled());
+      expect(JSON.parse(send.mock.calls[0][0])).toEqual({
+        type: "TASK_RELATION_UPDATED",
+        projectId: parentProject.project.id,
+        taskId: "",
+      });
+      expect(await countsFor(parentProject.project.id, parent.id)).toEqual({
+        completed: 0,
+        total: 0,
       });
     } finally {
       removeConnection(parentProject.project.id, connection);

--- a/tests/api-integration/subtask-counts.test.ts
+++ b/tests/api-integration/subtask-counts.test.ts
@@ -4,6 +4,7 @@ import updateColumn from "../../apps/api/src/column/controllers/update-column";
 import db, { schema } from "../../apps/api/src/database";
 import { eventContext } from "../../apps/api/src/events";
 import { createApp } from "../../apps/api/src/index";
+import deleteProject from "../../apps/api/src/project/controllers/delete-project";
 import { getPublicProject } from "../../apps/api/src/project/controllers/get-public-project";
 import deleteTask from "../../apps/api/src/task/controllers/delete-task";
 import getTasks from "../../apps/api/src/task/controllers/get-tasks";
@@ -346,6 +347,48 @@ describe("API integration: subtask counters", () => {
         }),
       });
       expect(response.status).toBe(200);
+      await vi.waitFor(() => expect(send).toHaveBeenCalled());
+      expect(JSON.parse(send.mock.calls[0][0])).toEqual({
+        type: "TASK_RELATION_UPDATED",
+        projectId: parentProject.project.id,
+        taskId: "",
+      });
+      expect(await countsFor(parentProject.project.id, parent.id)).toEqual({
+        completed: 0,
+        total: 0,
+      });
+    } finally {
+      removeConnection(parentProject.project.id, connection);
+      await shutdownWebSocketAdapter();
+    }
+  });
+  it("refreshes surviving parent boards when a child project is deleted", async () => {
+    const member = await createWorkspaceMember();
+    const parentProject = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    const childProject = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    const parent = await addTask(parentProject.project.id);
+    const child = await addTask(childProject.project.id, "done");
+    await relate(parent.id, child.id);
+    expect(await countsFor(parentProject.project.id, parent.id)).toEqual({
+      completed: 1,
+      total: 1,
+    });
+    await initializeWebSocketAdapter();
+    const send = vi.fn();
+    const connection = addConnection(
+      parentProject.project.id,
+      { send } as never,
+      member.user.id,
+      "same-window",
+    );
+    try {
+      await eventContext.run({ initiatorId: "same-window" }, () =>
+        deleteProject(childProject.project.id, member.workspace.id),
+      );
       await vi.waitFor(() => expect(send).toHaveBeenCalled());
       expect(JSON.parse(send.mock.calls[0][0])).toEqual({
         type: "TASK_RELATION_UPDATED",

--- a/tests/api-integration/subtask-counts.test.ts
+++ b/tests/api-integration/subtask-counts.test.ts
@@ -1,0 +1,268 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import db, { schema } from "../../apps/api/src/database";
+import { createApp } from "../../apps/api/src/index";
+import { getPublicProject } from "../../apps/api/src/project/controllers/get-public-project";
+import deleteTask from "../../apps/api/src/task/controllers/delete-task";
+import getTasks from "../../apps/api/src/task/controllers/get-tasks";
+import updateTaskStatus from "../../apps/api/src/task/controllers/update-task-status";
+import {
+  addConnection,
+  initializeWebSocketAdapter,
+  removeConnection,
+  shutdownWebSocketAdapter,
+} from "../../apps/api/src/ws";
+import { mockAuthenticatedSession } from "./helpers/auth";
+import { resetTestDatabase } from "./helpers/database";
+import {
+  createProjectFixture,
+  createWorkspaceMember,
+} from "./helpers/fixtures";
+
+async function addTask(projectId: string, status = "to-do") {
+  const [task] = await db
+    .insert(schema.taskTable)
+    .values({
+      projectId,
+      title: "Task",
+      status,
+      number: null,
+    })
+    .returning();
+  return task;
+}
+
+async function relate(
+  sourceTaskId: string,
+  targetTaskId: string,
+  relationType = "subtask",
+) {
+  const [relation] = await db
+    .insert(schema.taskRelationTable)
+    .values({
+      sourceTaskId,
+      targetTaskId,
+      relationType,
+    })
+    .returning();
+  return relation;
+}
+
+async function countsFor(projectId: string, taskId: string) {
+  const { data } = await getTasks(projectId);
+  return [
+    ...data.columns.flatMap((c) => c.tasks),
+    ...data.plannedTasks,
+    ...data.archivedTasks,
+  ].find((task) => task.id === taskId)?.subtaskCounts;
+}
+
+describe("API integration: subtask counters", () => {
+  beforeEach(resetTestDatabase);
+
+  it("counts direct children across filters and pagination, excluding other relations and incoming parents", async () => {
+    const member = await createWorkspaceMember();
+    const { project } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    const parent = await addTask(project.id);
+    const child = await addTask(project.id, "done");
+    const grandchild = await addTask(project.id, "done");
+    const other = await addTask(project.id, "in-progress");
+    await relate(parent.id, child.id);
+    await relate(child.id, grandchild.id);
+    await relate(parent.id, other.id, "blocks");
+    await relate(other.id, parent.id);
+    await db
+      .update(schema.taskTable)
+      .set({ description: "- [x] Checklist\n- [ ] Checklist" })
+      .where(eq(schema.taskTable.id, parent.id));
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+    const response = await app.request(
+      `/api/task/tasks/${project.id}?status=to-do&limit=1&page=1`,
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const tasks = body.data.columns.flatMap(
+      (column: { tasks: unknown[] }) => column.tasks,
+    );
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      id: parent.id,
+      subtaskCounts: { completed: 1, total: 1 },
+    });
+  });
+
+  it("uses the child's final columns across projects and includes planned and archived children", async () => {
+    const member = await createWorkspaceMember();
+    const { project } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    const other = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    await db
+      .update(schema.columnTable)
+      .set({ isFinal: false })
+      .where(eq(schema.columnTable.id, other.columns.done.id));
+    await db.insert(schema.columnTable).values({
+      projectId: other.project.id,
+      name: "Shipped",
+      slug: "shipped",
+      isFinal: true,
+    });
+    const parent = await addTask(project.id, "planned");
+    for (const status of ["shipped", "done", "planned", "archived"]) {
+      const child = await addTask(other.project.id, status);
+      await relate(parent.id, child.id);
+    }
+    expect(await countsFor(project.id, parent.id)).toEqual({
+      completed: 1,
+      total: 4,
+    });
+    await db
+      .update(schema.taskTable)
+      .set({ status: "archived" })
+      .where(eq(schema.taskTable.id, parent.id));
+    expect(await countsFor(project.id, parent.id)).toEqual({
+      completed: 1,
+      total: 4,
+    });
+  });
+
+  it("returns zero for empty tasks and reflects completion, reopening, unlinking, and deletion", async () => {
+    const member = await createWorkspaceMember();
+    const { project } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    expect(
+      (await getTasks(project.id)).data.columns.every(
+        (c) => c.tasks.length === 0,
+      ),
+    ).toBe(true);
+    const parent = await addTask(project.id);
+    const child = await addTask(project.id);
+    expect(await countsFor(project.id, parent.id)).toEqual({
+      completed: 0,
+      total: 0,
+    });
+    const relation = await relate(parent.id, child.id);
+    expect(await countsFor(project.id, parent.id)).toEqual({
+      completed: 0,
+      total: 1,
+    });
+    await updateTaskStatus({
+      id: child.id,
+      status: "done",
+      currentUserId: member.user.id,
+    });
+    expect(await countsFor(project.id, parent.id)).toEqual({
+      completed: 1,
+      total: 1,
+    });
+    await updateTaskStatus({
+      id: child.id,
+      status: "to-do",
+      currentUserId: member.user.id,
+    });
+    expect(await countsFor(project.id, parent.id)).toEqual({
+      completed: 0,
+      total: 1,
+    });
+    await db
+      .delete(schema.taskRelationTable)
+      .where(eq(schema.taskRelationTable.id, relation.id));
+    expect(await countsFor(project.id, parent.id)).toEqual({
+      completed: 0,
+      total: 0,
+    });
+    await relate(parent.id, child.id);
+    await deleteTask(child.id, member.user.id);
+    expect(await countsFor(project.id, parent.id)).toEqual({
+      completed: 0,
+      total: 0,
+    });
+  });
+
+  it("excludes cross-workspace relations and private-project counts on public boards", async () => {
+    const member = await createWorkspaceMember();
+    const stranger = await createWorkspaceMember();
+    const { project } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    const privateProject = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    const foreignProject = await createProjectFixture({
+      workspaceId: stranger.workspace.id,
+    });
+    await db
+      .update(schema.projectTable)
+      .set({ isPublic: true })
+      .where(eq(schema.projectTable.id, project.id));
+    const parent = await addTask(project.id);
+    const publicChild = await addTask(project.id, "done");
+    const privateChild = await addTask(privateProject.project.id, "done");
+    const foreignChild = await addTask(foreignProject.project.id, "done");
+    await relate(parent.id, publicChild.id);
+    await relate(parent.id, privateChild.id);
+    // Simulate a legacy malformed relation; it must not cross the workspace boundary.
+    await relate(parent.id, foreignChild.id);
+    expect(await countsFor(project.id, parent.id)).toEqual({
+      completed: 2,
+      total: 2,
+    });
+    const publicBoard = await getPublicProject(project.id);
+    expect(
+      publicBoard.columns
+        .flatMap((c) => c.tasks)
+        .find((t) => t.id === parent.id)?.subtaskCounts,
+    ).toEqual({ completed: 1, total: 1 });
+  });
+  it("refreshes a parent board when a child in another project is completed or deleted", async () => {
+    const member = await createWorkspaceMember();
+    const parentProject = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    const childProject = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+    const parent = await addTask(parentProject.project.id);
+    const child = await addTask(childProject.project.id);
+    await relate(parent.id, child.id);
+    await initializeWebSocketAdapter();
+    const send = vi.fn();
+    const connection = addConnection(
+      parentProject.project.id,
+      { send } as never,
+      member.user.id,
+      "other-window",
+    );
+    try {
+      await updateTaskStatus({
+        id: child.id,
+        status: "done",
+        currentUserId: member.user.id,
+      });
+      await vi.waitFor(() => expect(send).toHaveBeenCalled());
+      expect(JSON.parse(send.mock.calls[0][0])).toEqual({
+        type: "TASK_RELATION_UPDATED",
+        projectId: parentProject.project.id,
+        taskId: "",
+      });
+      send.mockClear();
+      await deleteTask(child.id, member.user.id);
+      await vi.waitFor(() => expect(send).toHaveBeenCalled());
+      expect(JSON.parse(send.mock.calls[0][0])).toEqual({
+        type: "TASK_RELATION_UPDATED",
+        projectId: parentProject.project.id,
+        taskId: "",
+      });
+    } finally {
+      removeConnection(parentProject.project.id, connection);
+      await shutdownWebSocketAdapter();
+    }
+  });
+});

--- a/tests/api-integration/subtask-counts.test.ts
+++ b/tests/api-integration/subtask-counts.test.ts
@@ -9,6 +9,7 @@ import { getPublicProject } from "../../apps/api/src/project/controllers/get-pub
 import deleteTask from "../../apps/api/src/task/controllers/delete-task";
 import getTasks from "../../apps/api/src/task/controllers/get-tasks";
 import updateTaskStatus from "../../apps/api/src/task/controllers/update-task-status";
+import * as subtaskParents from "../../apps/api/src/task/get-subtask-parent-projects";
 import {
   addConnection,
   initializeWebSocketAdapter,
@@ -314,54 +315,64 @@ describe("API integration: subtask counters", () => {
     }
   });
 
-  it("refreshes parent boards after the bulk API deletes children", async () => {
-    const member = await createWorkspaceMember({ role: "owner" });
-    const parentProject = await createProjectFixture({
-      workspaceId: member.workspace.id,
-    });
-    const childProject = await createProjectFixture({
-      workspaceId: member.workspace.id,
-    });
-    const parent = await addTask(parentProject.project.id);
-    const child = await addTask(childProject.project.id);
-    const secondChild = await addTask(childProject.project.id);
-    await relate(parent.id, child.id);
-    await relate(parent.id, secondChild.id);
-    await initializeWebSocketAdapter();
-    const send = vi.fn();
-    const connection = addConnection(
-      parentProject.project.id,
-      { send } as never,
-      member.user.id,
-      "other-window",
-    );
-    try {
-      mockAuthenticatedSession(member.user);
-      const { app } = createApp();
-      const response = await app.request("/api/task/bulk", {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          taskIds: [child.id, secondChild.id],
-          operation: "delete",
-        }),
+  it.each(["delete", "updateStatus"])(
+    "batches parent refreshes when the bulk API performs %s",
+    async (operation) => {
+      const member = await createWorkspaceMember({ role: "owner" });
+      const parentProject = await createProjectFixture({
+        workspaceId: member.workspace.id,
       });
-      expect(response.status).toBe(200);
-      await vi.waitFor(() => expect(send).toHaveBeenCalled());
-      expect(JSON.parse(send.mock.calls[0][0])).toEqual({
-        type: "TASK_RELATION_UPDATED",
-        projectId: parentProject.project.id,
-        taskId: "",
+      const childProject = await createProjectFixture({
+        workspaceId: member.workspace.id,
       });
-      expect(await countsFor(parentProject.project.id, parent.id)).toEqual({
-        completed: 0,
-        total: 0,
-      });
-    } finally {
-      removeConnection(parentProject.project.id, connection);
-      await shutdownWebSocketAdapter();
-    }
-  });
+      const parent = await addTask(parentProject.project.id);
+      const child = await addTask(childProject.project.id);
+      const secondChild = await addTask(childProject.project.id);
+      await relate(parent.id, child.id);
+      await relate(parent.id, secondChild.id);
+      await initializeWebSocketAdapter();
+      const send = vi.fn();
+      const connection = addConnection(
+        parentProject.project.id,
+        { send } as never,
+        member.user.id,
+        "other-window",
+      );
+      const parentLookup = vi.spyOn(subtaskParents, "getSubtaskParentProjects");
+      try {
+        mockAuthenticatedSession(member.user);
+        const { app } = createApp();
+        const response = await app.request("/api/task/bulk", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            taskIds: [child.id, secondChild.id],
+            operation,
+            value: operation === "updateStatus" ? "done" : undefined,
+          }),
+        });
+        expect(response.status).toBe(200);
+        await vi.waitFor(() => expect(send).toHaveBeenCalled());
+        expect(JSON.parse(send.mock.calls[0][0])).toEqual({
+          type: "TASK_RELATION_UPDATED",
+          projectId: parentProject.project.id,
+          taskId: "",
+        });
+        expect(await countsFor(parentProject.project.id, parent.id)).toEqual({
+          completed: operation === "updateStatus" ? 2 : 0,
+          total: operation === "updateStatus" ? 2 : 0,
+        });
+        expect(parentLookup).toHaveBeenCalledTimes(1);
+        expect(parentLookup.mock.calls[0][0].toSorted()).toEqual(
+          [child.id, secondChild.id].toSorted(),
+        );
+      } finally {
+        parentLookup.mockRestore();
+        removeConnection(parentProject.project.id, connection);
+        await shutdownWebSocketAdapter();
+      }
+    },
+  );
   it("refreshes surviving parent boards when a child project is deleted", async () => {
     const member = await createWorkspaceMember();
     const parentProject = await createProjectFixture({


### PR DESCRIPTION
## Description
Task cards previously showed description checklist progress without indicating whether a task had subtasks. Show a separate completed/total subtask badge on board cards and list rows (including planned and archived backlog tasks), hide it when there are no children, and use success styling when every child is complete. Public cards and list rows also show privacy-filtered progress. Both counters have distinct icons and translated tooltips; the existing checklist preference still applies.

Load direct-child counts in one batched query with the board response, using each child's project final columns. Preserve workspace boundaries and exclude private-project children from public responses. Batch parent lookups for bulk status changes. Refresh parent boards after relation, status, deletion (including bulk and project cascades), move, and final-column changes, including parents in other projects. Reopening a cached board also refreshes counts after changes made while its project socket was inactive.

## Related Issue(s)
Follow-up to #1638.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [x] Test addition or update

## How Has This Been Tested?
- [x] Unit tests: repository-wide suite passed with `NODE_OPTIONS=--no-experimental-webstorage pnpm test` on local Node 26.
- [x] Integration tests: `pnpm test:integration` passed against an isolated PostgreSQL 16 database, with nine focused counter and realtime tests passing after review fixes.
- [x] Manual testing: rendered the actual card and list components with fixture data in a browser; verified badge appearance and keyboard tooltip access.
- [x] Other: `pnpm typecheck`, `pnpm build`, `pnpm exec biome ci .`, and `pnpm openapi:check` passed.

`pnpm i18n:check` passes. The pre-existing Mattermost locale-key mismatch is repaired using the repository script, which supplies English fallback text for missing entries while preserving existing translations; the schema is regenerated. Both new counter strings are supplied in every locale.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I understand and take responsibility for every change, and I wrote this pull request description in my own words
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task cards and list views now display completed and total subtask counts.
  * Subtask progress is supported across active, planned, archived, backlog, and public task views.
  * Public boards show counts only for subtasks from public projects.
* **Bug Fixes**
  * Task and public project views refresh more reliably when revisited.
  * Subtask progress updates after status changes, deletions, relationship changes, and project updates.
* **Localization**
  * Added checklist and subtask progress translations across supported languages.
  * Added localized text for Mattermost integration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->