### PR TITLE
feat(task): add epic task type, epics view, and backlog filtering

### DIFF
--- a/apps/api/drizzle/0045_narrow_norman_osborn.sql
+++ b/apps/api/drizzle/0045_narrow_norman_osborn.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "task" ADD COLUMN "type" text DEFAULT 'task' NOT NULL;

--- a/apps/api/drizzle/meta/0045_snapshot.json
+++ b/apps/api/drizzle/meta/0045_snapshot.json
@@ -1,0 +1,4213 @@
+{
+	"id": "a32b5a81-7214-4a0a-8fb7-a50eb7ebfe53",
+	"prevId": "9248c325-fef7-4c63-a54a-6800d29169ec",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.activity": {
+			"name": "activity",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_data": {
+					"name": "event_data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"external_user_name": {
+					"name": "external_user_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"external_user_avatar": {
+					"name": "external_user_avatar",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"external_source": {
+					"name": "external_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"external_url": {
+					"name": "external_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"activity_task_id_idx": {
+					"name": "activity_task_id_idx",
+					"columns": [
+						{
+							"expression": "task_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"activity_userId_idx": {
+					"name": "activity_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"activity_task_id_task_id_fk": {
+					"name": "activity_task_id_task_id_fk",
+					"tableFrom": "activity",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"activity_user_id_user_id_fk": {
+					"name": "activity_user_id_user_id_fk",
+					"tableFrom": "activity",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"activity_task_external_source_external_url_unique": {
+					"name": "activity_task_external_source_external_url_unique",
+					"nullsNotDistinct": false,
+					"columns": ["task_id", "external_source", "external_url"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.apikey": {
+			"name": "apikey",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"config_id": {
+					"name": "config_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'default'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start": {
+					"name": "start",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"prefix": {
+					"name": "prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refill_interval": {
+					"name": "refill_interval",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refill_amount": {
+					"name": "refill_amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_refill_at": {
+					"name": "last_refill_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": true
+				},
+				"rate_limit_enabled": {
+					"name": "rate_limit_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": true
+				},
+				"rate_limit_time_window": {
+					"name": "rate_limit_time_window",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 86400000
+				},
+				"rate_limit_max": {
+					"name": "rate_limit_max",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 10
+				},
+				"request_count": {
+					"name": "request_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"remaining": {
+					"name": "remaining",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_request": {
+					"name": "last_request",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"permissions": {
+					"name": "permissions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"apikey_configId_idx": {
+					"name": "apikey_configId_idx",
+					"columns": [
+						{
+							"expression": "config_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"apikey_key_idx": {
+					"name": "apikey_key_idx",
+					"columns": [
+						{
+							"expression": "key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"apikey_referenceId_idx": {
+					"name": "apikey_referenceId_idx",
+					"columns": [
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"apikey_userId_idx": {
+					"name": "apikey_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"apikey_reference_id_user_id_fk": {
+					"name": "apikey_reference_id_user_id_fk",
+					"tableFrom": "apikey",
+					"tableTo": "user",
+					"columnsFrom": ["reference_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"apikey_user_id_user_id_fk": {
+					"name": "apikey_user_id_user_id_fk",
+					"tableFrom": "apikey",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.asset": {
+			"name": "asset",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"activity_id": {
+					"name": "activity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"object_key": {
+					"name": "object_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"filename": {
+					"name": "filename",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"mime_type": {
+					"name": "mime_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"size": {
+					"name": "size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'image'"
+				},
+				"surface": {
+					"name": "surface",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'description'"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"asset_workspaceId_idx": {
+					"name": "asset_workspaceId_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"asset_projectId_idx": {
+					"name": "asset_projectId_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"asset_taskId_idx": {
+					"name": "asset_taskId_idx",
+					"columns": [
+						{
+							"expression": "task_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"asset_activityId_idx": {
+					"name": "asset_activityId_idx",
+					"columns": [
+						{
+							"expression": "activity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"asset_createdBy_idx": {
+					"name": "asset_createdBy_idx",
+					"columns": [
+						{
+							"expression": "created_by",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"asset_workspace_id_workspace_id_fk": {
+					"name": "asset_workspace_id_workspace_id_fk",
+					"tableFrom": "asset",
+					"tableTo": "workspace",
+					"columnsFrom": ["workspace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"asset_project_id_project_id_fk": {
+					"name": "asset_project_id_project_id_fk",
+					"tableFrom": "asset",
+					"tableTo": "project",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"asset_task_id_task_id_fk": {
+					"name": "asset_task_id_task_id_fk",
+					"tableFrom": "asset",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"asset_activity_id_activity_id_fk": {
+					"name": "asset_activity_id_activity_id_fk",
+					"tableFrom": "asset",
+					"tableTo": "activity",
+					"columnsFrom": ["activity_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"asset_created_by_user_id_fk": {
+					"name": "asset_created_by_user_id_fk",
+					"tableFrom": "asset",
+					"tableTo": "user",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"asset_object_key_unique": {
+					"name": "asset_object_key_unique",
+					"nullsNotDistinct": false,
+					"columns": ["object_key"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.billing_event": {
+			"name": "billing_event",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"processed_at": {
+					"name": "processed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.billing_reminder_sent": {
+			"name": "billing_reminder_sent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reminder_type": {
+					"name": "reminder_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"trial_ends_at": {
+					"name": "trial_ends_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"billing_reminder_sent_workspaceId_idx": {
+					"name": "billing_reminder_sent_workspaceId_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"billing_reminder_sent_userId_idx": {
+					"name": "billing_reminder_sent_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"billing_reminder_sent_user_id_user_id_fk": {
+					"name": "billing_reminder_sent_user_id_user_id_fk",
+					"tableFrom": "billing_reminder_sent",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"billing_reminder_sent_workspace_id_workspace_id_fk": {
+					"name": "billing_reminder_sent_workspace_id_workspace_id_fk",
+					"tableFrom": "billing_reminder_sent",
+					"tableTo": "workspace",
+					"columnsFrom": ["workspace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"billing_reminder_sent_user_type_unique": {
+					"name": "billing_reminder_sent_user_type_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_id", "reminder_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.column": {
+			"name": "column",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"icon": {
+					"name": "icon",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"color": {
+					"name": "color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_final": {
+					"name": "is_final",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"column_projectId_idx": {
+					"name": "column_projectId_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"column_project_id_project_id_fk": {
+					"name": "column_project_id_project_id_fk",
+					"tableFrom": "column",
+					"tableTo": "project",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.comment": {
+			"name": "comment",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"comment_task_idx": {
+					"name": "comment_task_idx",
+					"columns": [
+						{
+							"expression": "task_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"comment_user_idx": {
+					"name": "comment_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"comment_task_id_task_id_fk": {
+					"name": "comment_task_id_task_id_fk",
+					"tableFrom": "comment",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"comment_user_id_user_id_fk": {
+					"name": "comment_user_id_user_id_fk",
+					"tableFrom": "comment",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.device_code": {
+			"name": "device_code",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"device_code": {
+					"name": "device_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_code": {
+					"name": "user_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_polled_at": {
+					"name": "last_polled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"polling_interval": {
+					"name": "polling_interval",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"device_code_device_code_uidx": {
+					"name": "device_code_device_code_uidx",
+					"columns": [
+						{
+							"expression": "device_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"device_code_user_code_uidx": {
+					"name": "device_code_user_code_uidx",
+					"columns": [
+						{
+							"expression": "user_code",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"device_code_user_id_idx": {
+					"name": "device_code_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"device_code_user_id_user_id_fk": {
+					"name": "device_code_user_id_user_id_fk",
+					"tableFrom": "device_code",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.external_link": {
+			"name": "external_link",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"integration_id": {
+					"name": "integration_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"resource_type": {
+					"name": "resource_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"external_id": {
+					"name": "external_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"external_link_taskId_idx": {
+					"name": "external_link_taskId_idx",
+					"columns": [
+						{
+							"expression": "task_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"external_link_integrationId_idx": {
+					"name": "external_link_integrationId_idx",
+					"columns": [
+						{
+							"expression": "integration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"external_link_externalId_idx": {
+					"name": "external_link_externalId_idx",
+					"columns": [
+						{
+							"expression": "external_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"external_link_resourceType_idx": {
+					"name": "external_link_resourceType_idx",
+					"columns": [
+						{
+							"expression": "resource_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"external_link_task_id_task_id_fk": {
+					"name": "external_link_task_id_task_id_fk",
+					"tableFrom": "external_link",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"external_link_integration_id_integration_id_fk": {
+					"name": "external_link_integration_id_integration_id_fk",
+					"tableFrom": "external_link",
+					"tableTo": "integration",
+					"columnsFrom": ["integration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.github_integration": {
+			"name": "github_integration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"repository_owner": {
+					"name": "repository_owner",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"repository_name": {
+					"name": "repository_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"installation_id": {
+					"name": "installation_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"github_integration_project_id_project_id_fk": {
+					"name": "github_integration_project_id_project_id_fk",
+					"tableFrom": "github_integration",
+					"tableTo": "project",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"github_integration_project_id_unique": {
+					"name": "github_integration_project_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["project_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.integration": {
+			"name": "integration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"config": {
+					"name": "config",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"integration_projectId_idx": {
+					"name": "integration_projectId_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"integration_type_idx": {
+					"name": "integration_type_idx",
+					"columns": [
+						{
+							"expression": "type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"integration_project_id_project_id_fk": {
+					"name": "integration_project_id_project_id_fk",
+					"tableFrom": "integration",
+					"tableTo": "project",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"integration_project_type_unique": {
+					"name": "integration_project_type_unique",
+					"nullsNotDistinct": false,
+					"columns": ["project_id", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.invitation": {
+			"name": "invitation",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"team_id": {
+					"name": "team_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"inviter_id": {
+					"name": "inviter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"invitation_workspaceId_idx": {
+					"name": "invitation_workspaceId_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"invitation_email_idx": {
+					"name": "invitation_email_idx",
+					"columns": [
+						{
+							"expression": "email",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"invitation_inviterId_idx": {
+					"name": "invitation_inviterId_idx",
+					"columns": [
+						{
+							"expression": "inviter_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"invitation_workspace_id_workspace_id_fk": {
+					"name": "invitation_workspace_id_workspace_id_fk",
+					"tableFrom": "invitation",
+					"tableTo": "workspace",
+					"columnsFrom": ["workspace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"invitation_inviter_id_user_id_fk": {
+					"name": "invitation_inviter_id_user_id_fk",
+					"tableFrom": "invitation",
+					"tableTo": "user",
+					"columnsFrom": ["inviter_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.job_lease": {
+			"name": "job_lease",
+			"schema": "",
+			"columns": {
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"owner": {
+					"name": "owner",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.label": {
+			"name": "label",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"color": {
+					"name": "color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"label_task_id_idx": {
+					"name": "label_task_id_idx",
+					"columns": [
+						{
+							"expression": "task_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"label_workspace_id_idx": {
+					"name": "label_workspace_id_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"label_workspace_name_unique": {
+					"name": "label_workspace_name_unique",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"label\".\"task_id\" is null",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"label_task_id_task_id_fk": {
+					"name": "label_task_id_task_id_fk",
+					"tableFrom": "label",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"label_workspace_id_workspace_id_fk": {
+					"name": "label_workspace_id_workspace_id_fk",
+					"tableFrom": "label",
+					"tableTo": "workspace",
+					"columnsFrom": ["workspace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"label_task_name_unique": {
+					"name": "label_task_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["task_id", "name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.mcp_oauth_state": {
+			"name": "mcp_oauth_state",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload": {
+					"name": "payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"mcp_oauth_state_kind_key_uidx": {
+					"name": "mcp_oauth_state_kind_key_uidx",
+					"columns": [
+						{
+							"expression": "kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"mcp_oauth_state_expiresAt_idx": {
+					"name": "mcp_oauth_state_expiresAt_idx",
+					"columns": [
+						{
+							"expression": "expires_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.notification": {
+			"name": "notification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'info'"
+				},
+				"event_data": {
+					"name": "event_data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_read": {
+					"name": "is_read",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"resource_id": {
+					"name": "resource_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resource_type": {
+					"name": "resource_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"notification_userId_idx": {
+					"name": "notification_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"notification_user_id_user_id_fk": {
+					"name": "notification_user_id_user_id_fk",
+					"tableFrom": "notification",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workspace_role": {
+			"name": "workspace_role",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"permission": {
+					"name": "permission",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"workspace_role_workspaceId_idx": {
+					"name": "workspace_role_workspaceId_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"workspace_role_role_idx": {
+					"name": "workspace_role_role_idx",
+					"columns": [
+						{
+							"expression": "role",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"workspace_role_workspace_id_workspace_id_fk": {
+					"name": "workspace_role_workspace_id_workspace_id_fk",
+					"tableFrom": "workspace_role",
+					"tableTo": "workspace",
+					"columnsFrom": ["workspace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project": {
+			"name": "project",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"icon": {
+					"name": "icon",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'Layout'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"is_public": {
+					"name": "is_public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_task_number": {
+					"name": "last_task_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				}
+			},
+			"indexes": {
+				"project_workspaceId_position_idx": {
+					"name": "project_workspaceId_position_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "position",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_workspace_id_workspace_id_fk": {
+					"name": "project_workspace_id_workspace_id_fk",
+					"tableFrom": "project",
+					"tableTo": "workspace",
+					"columnsFrom": ["workspace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"project_workspace_id_id_unique": {
+					"name": "project_workspace_id_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["workspace_id", "id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"active_organization_id": {
+					"name": "active_organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"active_team_id": {
+					"name": "active_team_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.task_relation": {
+			"name": "task_relation",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"source_task_id": {
+					"name": "source_task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_task_id": {
+					"name": "target_task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"relation_type": {
+					"name": "relation_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"task_relation_source_idx": {
+					"name": "task_relation_source_idx",
+					"columns": [
+						{
+							"expression": "source_task_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"task_relation_target_idx": {
+					"name": "task_relation_target_idx",
+					"columns": [
+						{
+							"expression": "target_task_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"task_relation_source_task_id_task_id_fk": {
+					"name": "task_relation_source_task_id_task_id_fk",
+					"tableFrom": "task_relation",
+					"tableTo": "task",
+					"columnsFrom": ["source_task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"task_relation_target_task_id_task_id_fk": {
+					"name": "task_relation_target_task_id_task_id_fk",
+					"tableFrom": "task_relation",
+					"tableTo": "task",
+					"columnsFrom": ["target_task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.task_reminder_sent": {
+			"name": "task_reminder_sent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reminder_type": {
+					"name": "reminder_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"task_reminder_sent_taskId_idx": {
+					"name": "task_reminder_sent_taskId_idx",
+					"columns": [
+						{
+							"expression": "task_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"task_reminder_sent_task_id_task_id_fk": {
+					"name": "task_reminder_sent_task_id_task_id_fk",
+					"tableFrom": "task_reminder_sent",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"task_reminder_sent_task_type_unique": {
+					"name": "task_reminder_sent_task_type_unique",
+					"nullsNotDistinct": false,
+					"columns": ["task_id", "reminder_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"number": {
+					"name": "number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 1
+				},
+				"assignee_id": {
+					"name": "assignee_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'task'"
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'to-do'"
+				},
+				"column_id": {
+					"name": "column_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"priority": {
+					"name": "priority",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'low'"
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"due_date": {
+					"name": "due_date",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"task_projectId_idx": {
+					"name": "task_projectId_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"task_dueDate_idx": {
+					"name": "task_dueDate_idx",
+					"columns": [
+						{
+							"expression": "due_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"task_assigneeId_idx": {
+					"name": "task_assigneeId_idx",
+					"columns": [
+						{
+							"expression": "assignee_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"task_columnId_idx": {
+					"name": "task_columnId_idx",
+					"columns": [
+						{
+							"expression": "column_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"task_project_id_project_id_fk": {
+					"name": "task_project_id_project_id_fk",
+					"tableFrom": "task",
+					"tableTo": "project",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"task_assignee_id_user_id_fk": {
+					"name": "task_assignee_id_user_id_fk",
+					"tableFrom": "task",
+					"tableTo": "user",
+					"columnsFrom": ["assignee_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				},
+				"task_column_id_column_id_fk": {
+					"name": "task_column_id_column_id_fk",
+					"tableFrom": "task",
+					"tableTo": "column",
+					"columnsFrom": ["column_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"task_project_number_unique": {
+					"name": "task_project_number_unique",
+					"nullsNotDistinct": false,
+					"columns": ["project_id", "number"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.team": {
+			"name": "team",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"team_workspaceId_idx": {
+					"name": "team_workspaceId_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"team_workspace_id_workspace_id_fk": {
+					"name": "team_workspace_id_workspace_id_fk",
+					"tableFrom": "team",
+					"tableTo": "workspace",
+					"columnsFrom": ["workspace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.team_member": {
+			"name": "team_member",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"team_id": {
+					"name": "team_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"teamMember_teamId_idx": {
+					"name": "teamMember_teamId_idx",
+					"columns": [
+						{
+							"expression": "team_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"teamMember_userId_idx": {
+					"name": "teamMember_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"team_member_team_id_team_id_fk": {
+					"name": "team_member_team_id_team_id_fk",
+					"tableFrom": "team_member",
+					"tableTo": "team",
+					"columnsFrom": ["team_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"team_member_user_id_user_id_fk": {
+					"name": "team_member_user_id_user_id_fk",
+					"tableFrom": "team_member",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.time_entry": {
+			"name": "time_entry",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"start_time": {
+					"name": "start_time",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"end_time": {
+					"name": "end_time",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration": {
+					"name": "duration",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"time_entry_taskId_idx": {
+					"name": "time_entry_taskId_idx",
+					"columns": [
+						{
+							"expression": "task_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"time_entry_userId_idx": {
+					"name": "time_entry_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"time_entry_task_id_task_id_fk": {
+					"name": "time_entry_task_id_task_id_fk",
+					"tableFrom": "time_entry",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"time_entry_user_id_user_id_fk": {
+					"name": "time_entry_user_id_user_id_fk",
+					"tableFrom": "time_entry",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.trial_grant": {
+			"name": "trial_grant",
+			"schema": "",
+			"columns": {
+				"email_hash": {
+					"name": "email_hash",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"trial_ends_at": {
+					"name": "trial_ends_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"locale": {
+					"name": "locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"is_anonymous": {
+					"name": "is_anonymous",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"banned": {
+					"name": "banned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_avatar": {
+			"name": "user_avatar",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"mime_type": {
+					"name": "mime_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"size": {
+					"name": "size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"data": {
+					"name": "data",
+					"type": "bytea",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"user_avatar_userId_idx": {
+					"name": "user_avatar_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_avatar_user_id_user_id_fk": {
+					"name": "user_avatar_user_id_user_id_fk",
+					"tableFrom": "user_avatar",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_avatar_user_id_unique": {
+					"name": "user_avatar_user_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_notification_preference": {
+			"name": "user_notification_preference",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_enabled": {
+					"name": "email_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"ntfy_enabled": {
+					"name": "ntfy_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"ntfy_server_url": {
+					"name": "ntfy_server_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ntfy_topic": {
+					"name": "ntfy_topic",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ntfy_token": {
+					"name": "ntfy_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"gotify_enabled": {
+					"name": "gotify_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"gotify_server_url": {
+					"name": "gotify_server_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"gotify_token": {
+					"name": "gotify_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"webhook_enabled": {
+					"name": "webhook_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"webhook_url": {
+					"name": "webhook_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"webhook_secret": {
+					"name": "webhook_secret",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"task_assignment_enabled": {
+					"name": "task_assignment_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"task_comment_enabled": {
+					"name": "task_comment_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"task_status_change_enabled": {
+					"name": "task_status_change_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"due_date_reminder_enabled": {
+					"name": "due_date_reminder_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"due_date_reminder_lead_time_minutes": {
+					"name": "due_date_reminder_lead_time_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1440
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_notification_preference_user_id_user_id_fk": {
+					"name": "user_notification_preference_user_id_user_id_fk",
+					"tableFrom": "user_notification_preference",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_notification_preference_user_id_unique": {
+					"name": "user_notification_preference_user_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_notification_workspace_project": {
+			"name": "user_notification_workspace_project",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workspace_rule_id": {
+					"name": "workspace_rule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"user_notification_workspace_project_ruleId_idx": {
+					"name": "user_notification_workspace_project_ruleId_idx",
+					"columns": [
+						{
+							"expression": "workspace_rule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"user_notification_workspace_project_projectId_idx": {
+					"name": "user_notification_workspace_project_projectId_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"user_notification_workspace_project_workspaceId_projectId_idx": {
+					"name": "user_notification_workspace_project_workspaceId_projectId_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"unwp_workspaceId_workspaceRuleId_idx": {
+					"name": "unwp_workspaceId_workspaceRuleId_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workspace_rule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_notification_workspace_project_workspace_id_workspace_id_fk": {
+					"name": "user_notification_workspace_project_workspace_id_workspace_id_fk",
+					"tableFrom": "user_notification_workspace_project",
+					"tableTo": "workspace",
+					"columnsFrom": ["workspace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"user_notification_workspace_project_workspace_id_workspace_rule_id_user_notification_workspace_rule_workspace_id_id_fk": {
+					"name": "user_notification_workspace_project_workspace_id_workspace_rule_id_user_notification_workspace_rule_workspace_id_id_fk",
+					"tableFrom": "user_notification_workspace_project",
+					"tableTo": "user_notification_workspace_rule",
+					"columnsFrom": ["workspace_id", "workspace_rule_id"],
+					"columnsTo": ["workspace_id", "id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"user_notification_workspace_project_workspace_id_project_id_project_workspace_id_id_fk": {
+					"name": "user_notification_workspace_project_workspace_id_project_id_project_workspace_id_id_fk",
+					"tableFrom": "user_notification_workspace_project",
+					"tableTo": "project",
+					"columnsFrom": ["workspace_id", "project_id"],
+					"columnsTo": ["workspace_id", "id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_notification_workspace_project_rule_project_unique": {
+					"name": "user_notification_workspace_project_rule_project_unique",
+					"nullsNotDistinct": false,
+					"columns": ["workspace_rule_id", "project_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_notification_workspace_rule": {
+			"name": "user_notification_workspace_rule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"email_enabled": {
+					"name": "email_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"ntfy_enabled": {
+					"name": "ntfy_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"gotify_enabled": {
+					"name": "gotify_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"webhook_enabled": {
+					"name": "webhook_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"project_mode": {
+					"name": "project_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'all'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"user_notification_workspace_rule_userId_idx": {
+					"name": "user_notification_workspace_rule_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"user_notification_workspace_rule_workspaceId_idx": {
+					"name": "user_notification_workspace_rule_workspaceId_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_notification_workspace_rule_user_id_user_id_fk": {
+					"name": "user_notification_workspace_rule_user_id_user_id_fk",
+					"tableFrom": "user_notification_workspace_rule",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"user_notification_workspace_rule_workspace_id_workspace_id_fk": {
+					"name": "user_notification_workspace_rule_workspace_id_workspace_id_fk",
+					"tableFrom": "user_notification_workspace_rule",
+					"tableTo": "workspace",
+					"columnsFrom": ["workspace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_notification_workspace_rule_user_workspace_unique": {
+					"name": "user_notification_workspace_rule_user_workspace_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_id", "workspace_id"]
+				},
+				"user_notification_workspace_rule_workspace_id_id_unique": {
+					"name": "user_notification_workspace_rule_workspace_id_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["workspace_id", "id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_rule": {
+			"name": "workflow_rule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"integration_type": {
+					"name": "integration_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"column_id": {
+					"name": "column_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"workflow_rule_projectId_idx": {
+					"name": "workflow_rule_projectId_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"workflow_rule_columnId_idx": {
+					"name": "workflow_rule_columnId_idx",
+					"columns": [
+						{
+							"expression": "column_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"workflow_rule_project_id_project_id_fk": {
+					"name": "workflow_rule_project_id_project_id_fk",
+					"tableFrom": "workflow_rule",
+					"tableTo": "project",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"workflow_rule_column_id_column_id_fk": {
+					"name": "workflow_rule_column_id_column_id_fk",
+					"tableFrom": "workflow_rule",
+					"tableTo": "column",
+					"columnsFrom": ["column_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workspace": {
+			"name": "workspace",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"logo": {
+					"name": "logo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"workspace_slug_unique": {
+					"name": "workspace_slug_unique",
+					"nullsNotDistinct": false,
+					"columns": ["slug"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workspace_billing": {
+			"name": "workspace_billing",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"founding_free": {
+					"name": "founding_free",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"trial_ends_at": {
+					"name": "trial_ends_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"creem_customer_id": {
+					"name": "creem_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"creem_subscription_id": {
+					"name": "creem_subscription_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"creem_product_id": {
+					"name": "creem_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"plan": {
+					"name": "plan",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"billing_interval": {
+					"name": "billing_interval",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"seats": {
+					"name": "seats",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"current_period_end": {
+					"name": "current_period_end",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"canceled_at": {
+					"name": "canceled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"workspace_billing_workspaceId_idx": {
+					"name": "workspace_billing_workspaceId_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"workspace_billing_workspace_id_workspace_id_fk": {
+					"name": "workspace_billing_workspace_id_workspace_id_fk",
+					"tableFrom": "workspace_billing",
+					"tableTo": "workspace",
+					"columnsFrom": ["workspace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"workspace_billing_workspace_id_unique": {
+					"name": "workspace_billing_workspace_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["workspace_id"]
+				},
+				"workspace_billing_creem_subscription_id_unique": {
+					"name": "workspace_billing_creem_subscription_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["creem_subscription_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workspace_member": {
+			"name": "workspace_member",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'member'"
+				},
+				"joined_at": {
+					"name": "joined_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"workspace_member_workspaceId_idx": {
+					"name": "workspace_member_workspaceId_idx",
+					"columns": [
+						{
+							"expression": "workspace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"workspace_member_userId_idx": {
+					"name": "workspace_member_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"workspace_member_workspace_id_workspace_id_fk": {
+					"name": "workspace_member_workspace_id_workspace_id_fk",
+					"tableFrom": "workspace_member",
+					"tableTo": "workspace",
+					"columnsFrom": ["workspace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"workspace_member_user_id_user_id_fk": {
+					"name": "workspace_member_user_id_user_id_fk",
+					"tableFrom": "workspace_member",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
 			"when": 1787492852776,
 			"tag": "0044_needy_triathlon",
 			"breakpoints": true
+		},
+		{
+			"idx": 45,
+			"version": "7",
+			"when": 1788272699677,
+			"tag": "0045_narrow_norman_osborn",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/api/src/database/schema.ts
+++ b/apps/api/src/database/schema.ts
@@ -418,6 +418,10 @@ export const taskTable = pgTable(
     }),
     title: text("title").notNull(),
     description: text("description"),
+    // "task" (default) or "epic". An epic is an ordinary task that groups
+    // children through a `task_relation` row of type "epic" (see
+    // taskRelationTable) rather than a separate table.
+    type: text("type").notNull().default("task"),
     status: text("status").notNull().default("to-do"),
     columnId: text("column_id").references(() => columnTable.id, {
       onDelete: "set null",

--- a/apps/api/src/mcp/tools.ts
+++ b/apps/api/src/mcp/tools.ts
@@ -195,6 +195,7 @@ const prioritySchema = z.enum([
   "high",
   "urgent",
 ]);
+const taskTypeSchema = z.enum(["task", "epic"]);
 const nonEmptyString = z.string().trim().min(1);
 const optionalNonEmptyString = nonEmptyString.optional();
 const nullableOptionalNonEmptyString = nonEmptyString.nullable().optional();
@@ -364,12 +365,14 @@ export function registerMcpTools(
   registerTool(
     "list_tasks",
     {
-      description: "List tasks for a project (optionally filtered/sorted).",
+      description:
+        "List tasks for a project (optionally filtered/sorted). Pass type: 'epic' to list only the project's epics.",
       inputSchema: z.object({
         projectId: nonEmptyString,
         status: optionalNonEmptyString,
         priority: prioritySchema.optional(),
         assigneeId: optionalNonEmptyString,
+        type: taskTypeSchema.optional(),
         page: z.number().int().positive().optional(),
         limit: z.number().int().positive().optional(),
         sortBy: z
@@ -420,7 +423,8 @@ export function registerMcpTools(
   registerTool(
     "create_task",
     {
-      description: "Create a task in a project.",
+      description:
+        "Create a task in a project. Pass type: 'epic' to create an epic that other tasks can be grouped under via create_task_relation.",
       inputSchema: z.object({
         projectId: nonEmptyString,
         title: nonEmptyString,
@@ -430,6 +434,7 @@ export function registerMcpTools(
         startDate: optionalIsoDateTimeSchema,
         dueDate: optionalIsoDateTimeSchema,
         userId: optionalNonEmptyString,
+        type: taskTypeSchema.optional(),
       }),
     },
     async (args) => {
@@ -442,6 +447,7 @@ export function registerMcpTools(
       if (args.startDate !== undefined) body.startDate = args.startDate;
       if (args.dueDate !== undefined) body.dueDate = args.dueDate;
       if (args.userId !== undefined) body.userId = args.userId;
+      if (args.type !== undefined) body.type = args.type;
       return run(() =>
         client.json(`/api/task/${encodeURIComponent(args.projectId)}`, {
           method: "POST",
@@ -666,11 +672,11 @@ export function registerMcpTools(
     "create_task_relation",
     {
       description:
-        "Create a relation between two tasks. relationType: 'subtask' (sourceTaskId is the parent, targetTaskId the child), 'blocks' (sourceTaskId blocks targetTaskId), or 'related' (bidirectional).",
+        "Create a relation between two tasks. relationType: 'subtask' (sourceTaskId is the parent, targetTaskId the child), 'blocks' (sourceTaskId blocks targetTaskId), 'related' (bidirectional), or 'epic' (sourceTaskId must be a task of type 'epic'; targetTaskId becomes one of its children).",
       inputSchema: z.object({
         sourceTaskId: nonEmptyString,
         targetTaskId: nonEmptyString,
-        relationType: z.enum(["subtask", "blocks", "related"]),
+        relationType: z.enum(["subtask", "blocks", "related", "epic"]),
       }),
     },
     async (args) =>
@@ -690,7 +696,7 @@ export function registerMcpTools(
     "get_task_relations",
     {
       description:
-        "List all relations (subtask/blocks/related) involving a task.",
+        "List all relations (subtask/blocks/related/epic) involving a task.",
       inputSchema: z.object({ taskId: nonEmptyString }),
     },
     async (args) =>

--- a/apps/api/src/task-relation/controllers/create-task-relation.ts
+++ b/apps/api/src/task-relation/controllers/create-task-relation.ts
@@ -30,6 +30,7 @@ async function createTaskRelation({
   const [sourceTask] = await db
     .select({
       id: taskTable.id,
+      type: taskTable.type,
       projectId: taskTable.projectId,
       workspaceId: projectTable.workspaceId,
     })
@@ -45,6 +46,14 @@ async function createTaskRelation({
 
   if (!sourceTask) {
     throw new HTTPException(404, { message: "Source task not found" });
+  }
+
+  // The epic UI only renders children under a task whose type is "epic", so an
+  // epic relation hanging off a plain task would create children nothing shows.
+  if (relationType === "epic" && sourceTask.type !== "epic") {
+    throw new HTTPException(400, {
+      message: "An epic relation requires the source task to be an epic",
+    });
   }
 
   const [targetTask] = await db

--- a/apps/api/src/task-relation/response.ts
+++ b/apps/api/src/task-relation/response.ts
@@ -1,7 +1,7 @@
 import { responseTimestamp, z } from "../openapi";
 
 const relationTypeDescription =
-  "How the two tasks relate: `subtask`, `blocks`, or `related`.";
+  "How the two tasks relate: `subtask`, `blocks`, `related`, or `epic` (source is the epic, target is a child task).";
 
 const relatedTaskSchema = z
   .object({

--- a/apps/api/src/task-relation/schema.ts
+++ b/apps/api/src/task-relation/schema.ts
@@ -7,5 +7,5 @@ export const taskRelationParam = z.object({ id: z.string() });
 export const createTaskRelationBody = z.object({
   sourceTaskId: z.string(),
   targetTaskId: z.string(),
-  relationType: z.enum(["subtask", "blocks", "related"]),
+  relationType: z.enum(["subtask", "blocks", "related", "epic"]),
 });

--- a/apps/api/src/task/controllers/create-task.ts
+++ b/apps/api/src/task/controllers/create-task.ts
@@ -7,7 +7,10 @@ import {
   assertAssignableUser,
   getProjectWorkspaceId,
 } from "../../utils/assert-assignable-user";
-import { assertValidTaskStatus } from "../validate-task-fields";
+import {
+  assertValidTaskStatus,
+  assertValidTaskType,
+} from "../validate-task-fields";
 import { claimTaskNumber } from "./claim-task-numbers";
 
 async function createTask({
@@ -20,6 +23,7 @@ async function createTask({
   dueDate,
   description,
   priority,
+  type,
 }: {
   projectId: string;
   currentUserId: string;
@@ -30,13 +34,16 @@ async function createTask({
   dueDate?: Date;
   description?: string;
   priority?: string;
+  type?: string;
 }) {
   const resolvedStatus = status || "to-do";
   const resolvedPriority = priority || "no-priority";
+  const resolvedType = type || "task";
 
   const normalizedUserId = userId?.trim() || undefined;
 
   await assertValidTaskStatus(resolvedStatus, projectId);
+  assertValidTaskType(resolvedType);
 
   let assignee: { name: string } | undefined;
 
@@ -82,6 +89,7 @@ async function createTask({
         projectId,
         userId: normalizedUserId ?? null,
         title: title || "",
+        type: resolvedType,
         status: resolvedStatus,
         columnId: column?.id ?? null,
         startDate: startDate || null,

--- a/apps/api/src/task/controllers/export-tasks.ts
+++ b/apps/api/src/task/controllers/export-tasks.ts
@@ -25,6 +25,7 @@ async function exportTasks(projectId: string) {
       title: taskTable.title,
       number: taskTable.number,
       description: taskTable.description,
+      type: taskTable.type,
       status: taskTable.status,
       priority: taskTable.priority,
       startDate: taskTable.startDate,

--- a/apps/api/src/task/controllers/get-task.ts
+++ b/apps/api/src/task/controllers/get-task.ts
@@ -10,6 +10,7 @@ async function getTask(taskId: string) {
       title: taskTable.title,
       number: taskTable.number,
       description: taskTable.description,
+      type: taskTable.type,
       status: taskTable.status,
       priority: taskTable.priority,
       startDate: taskTable.startDate,

--- a/apps/api/src/task/controllers/get-tasks.ts
+++ b/apps/api/src/task/controllers/get-tasks.ts
@@ -36,6 +36,7 @@ type GetTasksOptions = {
     | "number";
   sortOrder?: "asc" | "desc";
   status?: string;
+  type?: string;
 };
 
 const priorityCaseExpr = sql<number>`CASE
@@ -93,6 +94,10 @@ async function getTasks(projectId: string, options: GetTasksOptions = {}) {
     conditions.push(eq(taskTable.userId, options.assigneeId));
   }
 
+  if (options.type) {
+    conditions.push(eq(taskTable.type, options.type));
+  }
+
   if (options.dueBefore) {
     conditions.push(lte(taskTable.dueDate, new Date(options.dueBefore)));
   }
@@ -125,6 +130,7 @@ async function getTasks(projectId: string, options: GetTasksOptions = {}) {
     title: taskTable.title,
     number: taskTable.number,
     description: taskTable.description,
+    type: taskTable.type,
     status: taskTable.status,
     priority: taskTable.priority,
     startDate: taskTable.startDate,

--- a/apps/api/src/task/controllers/import-tasks.ts
+++ b/apps/api/src/task/controllers/import-tasks.ts
@@ -14,6 +14,7 @@ import { claimTaskNumber } from "./claim-task-numbers";
 export type ImportTask = {
   title: string;
   description?: string;
+  type?: string;
   status: string;
   priority?: string;
   startDate?: string | null;
@@ -91,6 +92,7 @@ async function importTasks(
             projectId,
             userId: assigneeId,
             title: taskData.title,
+            type: taskData.type ?? "task",
             status,
             columnId: column?.id ?? null,
             startDate: taskData.startDate ? new Date(taskData.startDate) : null,

--- a/apps/api/src/task/controllers/update-task.ts
+++ b/apps/api/src/task/controllers/update-task.ts
@@ -8,7 +8,10 @@ import {
   assertAssignableUser,
   getProjectWorkspaceId,
 } from "../../utils/assert-assignable-user";
-import { assertValidTaskStatus } from "../validate-task-fields";
+import {
+  assertValidTaskStatus,
+  assertValidTaskType,
+} from "../validate-task-fields";
 
 async function updateTask(
   id: string,
@@ -22,6 +25,10 @@ async function updateTask(
   position: number,
   userId?: string,
   currentUserId?: string,
+  // Omitted (rather than defaulted) so routine edits through this "replace
+  // every field" endpoint never touch a task's type unless a caller
+  // explicitly asks to change it.
+  type?: string,
 ) {
   const [existingTask] = await db
     .select({
@@ -47,6 +54,10 @@ async function updateTask(
   }
 
   await assertValidTaskStatus(status, projectId);
+
+  if (type !== undefined) {
+    assertValidTaskType(type);
+  }
 
   const normalizedUserId = userId?.trim() || undefined;
 
@@ -77,6 +88,7 @@ async function updateTask(
       priority,
       position,
       userId: normalizedUserId ?? null,
+      ...(type !== undefined ? { type } : {}),
     })
     .where(eq(taskTable.id, id))
     .returning();

--- a/apps/api/src/task/index.ts
+++ b/apps/api/src/task/index.ts
@@ -581,8 +581,16 @@ const task = apiRouter<BaseVariables & { workspaceId: string }>()
   })
   .openapi(createTaskRoute, async (c) => {
     const { projectId } = c.req.param();
-    const { title, description, startDate, dueDate, priority, status, userId } =
-      c.req.valid("json");
+    const {
+      title,
+      description,
+      startDate,
+      dueDate,
+      priority,
+      status,
+      userId,
+      type,
+    } = c.req.valid("json");
 
     const parsedStartDate =
       startDate !== undefined
@@ -605,6 +613,7 @@ const task = apiRouter<BaseVariables & { workspaceId: string }>()
       dueDate: parsedDueDate,
       priority,
       status,
+      type,
     });
 
     return c.json(task, 200);
@@ -642,6 +651,7 @@ const task = apiRouter<BaseVariables & { workspaceId: string }>()
       projectId,
       position,
       userId,
+      type,
     } = c.req.valid("json");
 
     const currentUserId = c.get("userId");
@@ -669,6 +679,7 @@ const task = apiRouter<BaseVariables & { workspaceId: string }>()
       position,
       userId,
       currentUserId,
+      type,
     );
 
     return c.json(task, 200);

--- a/apps/api/src/task/response.ts
+++ b/apps/api/src/task/response.ts
@@ -18,6 +18,9 @@ export const taskSchema = z
       .openapi({ description: "The assignee, if any." }),
     title: z.string(),
     description: z.string().nullable(),
+    type: z.string().openapi({
+      description: "`task` (default) or `epic`.",
+    }),
     status: z.string().openapi({
       description: "The slug of the column the task sits in.",
     }),
@@ -63,6 +66,9 @@ export const boardTaskSchema = z
     title: z.string(),
     number: z.number().nullable(),
     description: z.string().nullable(),
+    type: z.string().openapi({
+      description: "`task` (default) or `epic`.",
+    }),
     status: z.string(),
     priority: z.string().openapi({ description: priorityDescription }),
     startDate: nullableResponseTimestamp,

--- a/apps/api/src/task/schema.ts
+++ b/apps/api/src/task/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "../openapi";
-import { VALID_PRIORITIES } from "./validate-task-fields";
+import { VALID_PRIORITIES, VALID_TASK_TYPES } from "./validate-task-fields";
 
 const pagingNumber = (min: number, max: number) =>
   z
@@ -13,12 +13,16 @@ export const taskParam = z.object({ id: z.string() });
 export const projectIdParam = z.object({ projectId: z.string() });
 
 const priority = z.enum(VALID_PRIORITIES);
+const taskType = z.enum(VALID_TASK_TYPES);
 
 // Required object of optional filters: a RouteParameter cannot itself be optional.
 export const listTasksQuery = z.object({
   status: z.string().optional(),
   priority: z.string().optional(),
   assigneeId: z.string().optional(),
+  type: taskType.optional().openapi({
+    description: "Filter to only tasks of this type, e.g. `epic`.",
+  }),
   // Number("abc") is NaN, which used to reach the limit/offset clause unchecked.
   page: pagingNumber(1, 1_000_000).optional(),
   limit: pagingNumber(1, 200).optional(),
@@ -55,6 +59,9 @@ export const createTaskBody = z.object({
   priority,
   status: z.string().openapi({ description: "The target column's slug." }),
   userId: z.string().optional().openapi({ description: "Assignee, if any." }),
+  type: taskType.optional().openapi({
+    description: "Defaults to `task`. Set to `epic` to create an epic.",
+  }),
 });
 
 export const updateTaskBody = z.object({
@@ -67,6 +74,9 @@ export const updateTaskBody = z.object({
   projectId: z.string(),
   position: z.number(),
   userId: z.string().optional(),
+  type: taskType.optional().openapi({
+    description: "Omit to leave the task's type unchanged.",
+  }),
 });
 
 export const moveTaskBody = z.object({

--- a/apps/api/src/task/schema.ts
+++ b/apps/api/src/task/schema.ts
@@ -91,6 +91,7 @@ export const importTasksBody = z.object({
     z.object({
       title: z.string(),
       description: z.string().optional(),
+      type: taskType.optional(),
       status: z.string(),
       priority: z.string().optional(),
       startDate: z.string().nullable().optional(),

--- a/apps/api/src/task/validate-task-fields.ts
+++ b/apps/api/src/task/validate-task-fields.ts
@@ -13,10 +13,20 @@ export const VALID_PRIORITIES = [
 
 export const VIRTUAL_STATUSES = ["planned", "archived"] as const;
 
+export const VALID_TASK_TYPES = ["task", "epic"] as const;
+
 export function assertValidPriority(priority: string): void {
   if (!(VALID_PRIORITIES as readonly string[]).includes(priority)) {
     throw new HTTPException(400, {
       message: `Invalid priority "${priority}". Valid values: ${VALID_PRIORITIES.join(", ")}`,
+    });
+  }
+}
+
+export function assertValidTaskType(type: string): void {
+  if (!(VALID_TASK_TYPES as readonly string[]).includes(type)) {
+    throw new HTTPException(400, {
+      message: `Invalid type "${type}". Valid values: ${VALID_TASK_TYPES.join(", ")}`,
     });
   }
 }

--- a/apps/docs/core/functional/backlog-planning.mdx
+++ b/apps/docs/core/functional/backlog-planning.mdx
@@ -21,7 +21,7 @@ Use backlog when you need to:
 1. Open your project **Backlog** view.
 2. Add or edit planned tasks.
 3. Apply priority, due date, labels, and assignee.
-4. Filter by priority/assignee/due date/labels to review specific slices.
+4. Filter by priority/assignee/due date/labels/epic to review specific slices.
 5. Move ready tasks from planning into active execution.
 
 ## Recommended planning cadence
@@ -43,4 +43,5 @@ A task is ready to move when it has:
 ## Next
 
 - [Plan and execute tasks in Board/List](/core/functional/plan-and-execute-tasks)
+- [Group work with epics](/core/functional/group-work-with-epics)
 - [Collaborate with your team](/core/functional/collaborate-with-team)

--- a/apps/docs/core/functional/group-work-with-epics.mdx
+++ b/apps/docs/core/functional/group-work-with-epics.mdx
@@ -1,0 +1,61 @@
+---
+title: Group Work with Epics
+description: Use epics to group related tasks under a single parent and track their progress
+---
+
+An epic is a task that groups other tasks. Use it when a piece of work is too
+large for one task but does not deserve its own project.
+
+Epics live alongside regular tasks: they sit in project columns, carry a status,
+priority, assignee, and due date, and open in the same task view. The only
+difference is that an epic can have child tasks and shows their progress.
+
+## Create an epic
+
+1. Open your project **Epics** view (or press <kbd>g</kbd> then <kbd>e</kbd>).
+2. Click **New Epic**.
+3. Give it a title and press <kbd>Enter</kbd>.
+
+The Epics view lists every epic in the project with its status, priority,
+assignee, and a completion ring showing how many of its child tasks are done.
+
+## Add tasks to an epic
+
+1. Open the epic.
+2. In **Tasks in this epic**, click the **+** button.
+3. Enter a title and click **Add**.
+
+New child tasks are created in the project's first non-final column, so they
+appear on the board straight away. An epic created in the backlog adds its
+children as planned tasks instead.
+
+Each child task shows a **Part of** link back to its epic, so you can navigate up
+from any task in the group.
+
+## Track progress
+
+An epic's completion ring counts child tasks that sit in a final column. Because
+"done" is resolved from your project's own columns, renaming or reordering
+columns keeps the count accurate.
+
+## Filter the backlog by epic
+
+Backlog view can narrow to a single epic:
+
+1. Open **Backlog**.
+2. Open the **Filter** menu.
+3. Pick an epic under **Epic**.
+
+The backlog then shows only that epic's child tasks, which is useful when
+grooming one workstream at a time.
+
+## When to use epics instead of subtasks
+
+- **Epic**: a workstream that spans many independent tasks, each worth
+  scheduling, assigning, and prioritising on its own.
+- **Subtask**: a checklist step that only makes sense inside its parent task.
+
+## Next
+
+- [Plan work in backlog](/core/functional/backlog-planning)
+- [Plan and execute tasks in Board/List](/core/functional/plan-and-execute-tasks)

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -53,6 +53,7 @@
 							"core/functional/create-workspace-and-project",
 							"core/functional/plan-and-execute-tasks",
 							"core/functional/backlog-planning",
+							"core/functional/group-work-with-epics",
 							"core/functional/collaborate-with-team",
 							"core/functional/configure-workflows",
 							"core/functional/account-notifications",

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -302,6 +302,10 @@
               "null"
             ]
           },
+          "type": {
+            "type": "string",
+            "description": "`task` (default) or `epic`."
+          },
           "status": {
             "type": "string"
           },
@@ -378,6 +382,7 @@
           "title",
           "number",
           "description",
+          "type",
           "status",
           "priority",
           "startDate",
@@ -735,6 +740,10 @@
               "null"
             ]
           },
+          "type": {
+            "type": "string",
+            "description": "`task` (default) or `epic`."
+          },
           "status": {
             "type": "string",
             "description": "The slug of the column the task sits in."
@@ -770,6 +779,7 @@
           "userId",
           "title",
           "description",
+          "type",
           "status",
           "priority",
           "startDate",
@@ -2752,7 +2762,7 @@
           },
           "relationType": {
             "type": "string",
-            "description": "How the two tasks relate: `subtask`, `blocks`, or `related`."
+            "description": "How the two tasks relate: `subtask`, `blocks`, `related`, or `epic` (source is the epic, target is a child task)."
           },
           "createdAt": {
             "type": "string",
@@ -6101,6 +6111,20 @@
           {
             "schema": {
               "type": "string",
+              "enum": [
+                "task",
+                "epic"
+              ],
+              "description": "Filter to only tasks of this type, e.g. `epic`."
+            },
+            "required": false,
+            "description": "Filter to only tasks of this type, e.g. `epic`.",
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "pattern": "^\\d+$"
             },
             "required": false,
@@ -6349,6 +6373,14 @@
                   "userId": {
                     "type": "string",
                     "description": "Assignee, if any."
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "task",
+                      "epic"
+                    ],
+                    "description": "Defaults to `task`. Set to `epic` to create an epic."
                   }
                 },
                 "required": [
@@ -6509,6 +6541,14 @@
                   },
                   "userId": {
                     "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "task",
+                      "epic"
+                    ],
+                    "description": "Omit to leave the task's type unchanged."
                   }
                 },
                 "required": [
@@ -6790,6 +6830,13 @@
                         },
                         "description": {
                           "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "task",
+                            "epic"
+                          ]
                         },
                         "status": {
                           "type": "string"
@@ -12509,7 +12556,8 @@
                     "enum": [
                       "subtask",
                       "blocks",
-                      "related"
+                      "related",
+                      "epic"
                     ]
                   }
                 },

--- a/apps/web/src/components/common/header/mobile-project-nav.tsx
+++ b/apps/web/src/components/common/header/mobile-project-nav.tsx
@@ -2,6 +2,7 @@ import {
   CalendarDays,
   CalendarRange,
   Check,
+  Layers,
   Menu,
   Plus,
   SquareKanban,
@@ -20,11 +21,12 @@ import { cn } from "@/lib/cn";
 type MobileProjectNavProps = {
   workspaceId: string;
   projectId: string;
-  activeView: "backlog" | "board" | "calendar" | "gantt";
+  activeView: "backlog" | "board" | "calendar" | "gantt" | "epics";
   onSelectBoard: () => void;
   onSelectBacklog: () => void;
   onSelectCalendar: () => void;
   onSelectGantt: () => void;
+  onSelectEpics: () => void;
   onSelectProject: (projectId: string) => void;
   onAddProject: () => void;
 };
@@ -37,6 +39,7 @@ export default function MobileProjectNav({
   onSelectBacklog,
   onSelectCalendar,
   onSelectGantt,
+  onSelectEpics,
   onSelectProject,
   onAddProject,
 }: MobileProjectNavProps) {
@@ -62,7 +65,7 @@ export default function MobileProjectNav({
             <p className="px-1 text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
               View
             </p>
-            <div className="grid grid-cols-4 gap-1">
+            <div className="grid grid-cols-5 gap-1">
               <button
                 type="button"
                 onClick={onSelectBacklog}
@@ -113,6 +116,19 @@ export default function MobileProjectNav({
               >
                 <CalendarDays className="size-3.5" />
                 Gantt
+              </button>
+              <button
+                type="button"
+                onClick={onSelectEpics}
+                className={cn(
+                  "flex w-full items-center justify-center gap-1 whitespace-nowrap rounded-md border px-2 py-1.5 text-xs font-medium transition-colors",
+                  activeView === "epics"
+                    ? "border-border bg-secondary text-foreground"
+                    : "border-transparent text-muted-foreground hover:bg-accent",
+                )}
+              >
+                <Layers className="size-3.5" />
+                {t("tasks:epics.tabTitle")}
               </button>
             </div>
           </div>

--- a/apps/web/src/components/common/project-layout.tsx
+++ b/apps/web/src/components/common/project-layout.tsx
@@ -2,6 +2,7 @@ import { useLocation, useNavigate } from "@tanstack/react-router";
 import {
   CalendarDays,
   CalendarRange,
+  Layers,
   SquareKanban,
   SquircleDashed,
 } from "lucide-react";
@@ -32,7 +33,7 @@ type ProjectLayoutProps = {
   headerActions?: ReactNode;
   children: ReactNode;
   showViewSwitcher?: boolean;
-  activeView?: "backlog" | "board" | "calendar" | "gantt";
+  activeView?: "backlog" | "board" | "calendar" | "gantt" | "epics";
 };
 
 export default function ProjectLayout({
@@ -60,7 +61,9 @@ export default function ProjectLayout({
         ? "calendar"
         : location.pathname.includes("/gantt")
           ? "gantt"
-          : "board");
+          : location.pathname.includes("/epics")
+            ? "epics"
+            : "board");
 
   const handleNavigateToBacklog = () => {
     navigate({
@@ -90,6 +93,13 @@ export default function ProjectLayout({
     });
   };
 
+  const handleNavigateToEpics = () => {
+    navigate({
+      to: "/dashboard/workspace/$workspaceId/project/$projectId/epics",
+      params: { workspaceId, projectId },
+    });
+  };
+
   const handleProjectSwitch = (nextProjectId: string) => {
     navigate({
       to:
@@ -99,7 +109,9 @@ export default function ProjectLayout({
             ? "/dashboard/workspace/$workspaceId/project/$projectId/calendar"
             : resolvedView === "gantt"
               ? "/dashboard/workspace/$workspaceId/project/$projectId/gantt"
-              : "/dashboard/workspace/$workspaceId/project/$projectId/board",
+              : resolvedView === "epics"
+                ? "/dashboard/workspace/$workspaceId/project/$projectId/epics"
+                : "/dashboard/workspace/$workspaceId/project/$projectId/board",
       params: {
         workspaceId,
         projectId: nextProjectId,
@@ -154,6 +166,7 @@ export default function ProjectLayout({
                 onSelectBoard={handleNavigateToBoard}
                 onSelectCalendar={handleNavigateToCalendar}
                 onSelectGantt={handleNavigateToGantt}
+                onSelectEpics={handleNavigateToEpics}
                 onSelectProject={handleProjectSwitch}
                 onAddProject={() => setIsCreateProjectModalOpen(true)}
               />
@@ -208,6 +221,18 @@ export default function ProjectLayout({
                 >
                   <CalendarDays className="size-3.5" />
                   Gantt
+                </Button>
+                <Button
+                  variant={resolvedView === "epics" ? "secondary" : "ghost"}
+                  size="xs"
+                  onClick={handleNavigateToEpics}
+                  className={cn(
+                    "h-6 gap-1.5 rounded-md px-2 text-xs",
+                    resolvedView !== "epics" && "text-muted-foreground",
+                  )}
+                >
+                  <Layers className="size-3.5" />
+                  {t("tasks:epics.tabTitle")}
                 </Button>
               </div>
             )}

--- a/apps/web/src/components/keyboard-shortcuts-help.tsx
+++ b/apps/web/src/components/keyboard-shortcuts-help.tsx
@@ -92,6 +92,10 @@ function useShortcutCategories(): ShortcutCategory[] {
             keys: [shortcuts.view.prefix, shortcuts.view.calendar],
             description: t("navigation:keyboardShortcuts.items.calendarView"),
           },
+          {
+            keys: [shortcuts.view.prefix, shortcuts.view.epics],
+            description: t("navigation:keyboardShortcuts.items.epicsView"),
+          },
         ],
       },
       {

--- a/apps/web/src/components/task/task-details-content.tsx
+++ b/apps/web/src/components/task/task-details-content.tsx
@@ -14,6 +14,7 @@ import useGetTask from "@/hooks/queries/task/use-get-task";
 import useGetTaskRelations from "@/hooks/queries/task-relation/use-get-task-relations";
 import type { ExternalLink } from "@/types/external-link";
 import TaskDescription from "./task-description";
+import TaskEpicChildren from "./task-epic-children";
 import TaskRelations from "./task-relations";
 import TaskSubtasks from "./task-subtasks";
 import TaskTitle from "./task-title";
@@ -46,6 +47,11 @@ export default function TaskDetailsContent({
   );
   const parentTask = parentRelation?.sourceTask;
 
+  const parentEpicRelation = relations.find(
+    (rel) => rel.relationType === "epic" && rel.targetTaskId === taskId,
+  );
+  const parentEpic = parentEpicRelation?.sourceTask;
+
   if (!taskId) return null;
 
   return (
@@ -73,6 +79,28 @@ export default function TaskDetailsContent({
             </span>
           </button>
         )}
+        {parentEpic && (
+          <button
+            type="button"
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors w-fit"
+            onClick={() =>
+              navigate({
+                to: "/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId",
+                params: {
+                  workspaceId,
+                  projectId,
+                  taskId: parentEpic.id,
+                },
+              })
+            }
+          >
+            <ArrowUpRight className="size-3" />
+            <span>
+              {t("tasks:detail.epicOf")}{" "}
+              <span className="font-medium">{parentEpic.title}</span>
+            </span>
+          </button>
+        )}
         <p className="text-xs font-semibold text-foreground/70">
           {project?.slug}-{task?.number}
         </p>
@@ -84,6 +112,16 @@ export default function TaskDetailsContent({
           <ExternalLinksAccordion
             externalLinks={externalLinks as ExternalLink[]}
             isLoading={isLoadingExternalLinks}
+          />
+        </div>
+      )}
+      {task?.type === "epic" && (
+        <div className="mt-4">
+          <TaskEpicChildren
+            taskId={taskId}
+            projectId={projectId}
+            workspaceId={workspaceId}
+            parentStatus={task.status}
           />
         </div>
       )}

--- a/apps/web/src/components/task/task-epic-children.test.tsx
+++ b/apps/web/src/components/task/task-epic-children.test.tsx
@@ -1,0 +1,224 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TaskEpicChildren from "./task-epic-children";
+
+const mocks = vi.hoisted(() => ({
+  canCreateTasks: vi.fn(),
+  canUpdateTasks: vi.fn(),
+  createTask: vi.fn(),
+  createRelation: vi.fn(),
+  getColumns: vi.fn(),
+  getRelations: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
+// Only AnimatePresence is stubbed; SubtaskRow renders real motion elements, so
+// the rest of framer-motion has to stay intact.
+vi.mock("framer-motion", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("framer-motion")>()),
+  AnimatePresence: ({ children }: { children: unknown }) => children,
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@/hooks/mutations/task/use-create-task", () => ({
+  default: () => ({ mutateAsync: mocks.createTask, isPending: false }),
+}));
+vi.mock("@/hooks/mutations/task-relation/use-create-task-relation", () => ({
+  default: () => ({ mutateAsync: mocks.createRelation }),
+}));
+vi.mock("@/hooks/mutations/task/use-delete-task", () => ({
+  useDeleteTask: () => ({ mutateAsync: vi.fn() }),
+}));
+vi.mock("@/hooks/mutations/task/use-update-task-status", () => ({
+  useUpdateTaskStatus: () => ({ mutateAsync: vi.fn() }),
+}));
+vi.mock("@/hooks/queries/column/use-get-columns", () => ({
+  useGetColumns: () => mocks.getColumns(),
+}));
+vi.mock("@/hooks/queries/task-relation/use-get-task-relations", () => ({
+  default: () => mocks.getRelations(),
+}));
+vi.mock("@/hooks/queries/workspace/use-active-workspace", () => ({
+  default: () => ({ data: { id: "workspace-1" } }),
+}));
+vi.mock(
+  "@/hooks/queries/workspace-users/use-get-active-workspace-users",
+  () => ({
+    useGetActiveWorkspaceUsers: () => ({ data: { members: [] } }),
+  }),
+);
+// The rendered child rows pull in assignee/status popovers and the task context
+// menu, which each check a different permission; everything this test does not
+// drive is simply granted.
+vi.mock("@/hooks/use-workspace-permission", () => ({
+  useWorkspacePermission: () =>
+    new Proxy(
+      {
+        canCreateTasks: mocks.canCreateTasks,
+        canUpdateTasks: mocks.canUpdateTasks,
+      } as Record<string, () => boolean>,
+      {
+        get: (target, property: string) => target[property] ?? (() => true),
+      },
+    ),
+}));
+vi.mock("@/lib/toast", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+const addButtonName =
+  "tasks:epics.children.addAction tasks:epics.children.title";
+
+function childRelation(
+  id: string,
+  overrides: Partial<{ status: string; title: string }> = {},
+) {
+  return {
+    id: `relation-${id}`,
+    relationType: "epic",
+    sourceTaskId: "epic-1",
+    targetTaskId: id,
+    targetTask: {
+      id,
+      title: overrides.title ?? `Child ${id}`,
+      number: 1,
+      status: overrides.status ?? "to-do",
+      priority: "no-priority",
+      userId: null,
+      assigneeName: null,
+      projectId: "project-1",
+    },
+  };
+}
+
+// SubtaskRow reaches for the query client through its assignee/status popovers.
+function renderEpicChildren(parentStatus: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TaskEpicChildren
+        taskId="epic-1"
+        projectId="project-1"
+        workspaceId="workspace-1"
+        parentStatus={parentStatus}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mocks.canCreateTasks.mockReturnValue(true);
+  mocks.canUpdateTasks.mockReturnValue(true);
+  mocks.getRelations.mockReturnValue({ data: [] });
+  mocks.getColumns.mockReturnValue({
+    data: [
+      { id: "todo", slug: "to-do", name: "To Do", isFinal: false },
+      { id: "done", slug: "done", name: "Done", isFinal: true },
+    ],
+    isLoading: false,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("TaskEpicChildren", () => {
+  it("links a new child to the epic with an epic-type relation", async () => {
+    mocks.createTask.mockResolvedValue({ id: "child-1" });
+    mocks.createRelation.mockResolvedValue({});
+
+    renderEpicChildren("to-do");
+
+    fireEvent.click(screen.getByRole("button", { name: addButtonName }));
+    fireEvent.change(
+      screen.getByPlaceholderText("tasks:epics.children.inputPlaceholder"),
+      { target: { value: "Ship the new nav" } },
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "tasks:epics.children.addAction" }),
+    );
+
+    await waitFor(() => expect(mocks.createRelation).toHaveBeenCalledTimes(1));
+    expect(mocks.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "to-do" }),
+    );
+    expect(mocks.createRelation).toHaveBeenCalledWith({
+      sourceTaskId: "epic-1",
+      targetTaskId: "child-1",
+      relationType: "epic",
+    });
+  });
+
+  it("creates children as planned when the epic itself is planned", async () => {
+    mocks.createTask.mockResolvedValue({ id: "child-2" });
+    mocks.createRelation.mockResolvedValue({});
+
+    renderEpicChildren("planned");
+
+    fireEvent.click(screen.getByRole("button", { name: addButtonName }));
+    fireEvent.change(
+      screen.getByPlaceholderText("tasks:epics.children.inputPlaceholder"),
+      { target: { value: "Groom the nav work" } },
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "tasks:epics.children.addAction" }),
+    );
+
+    await waitFor(() => expect(mocks.createTask).toHaveBeenCalledTimes(1));
+    expect(mocks.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "planned" }),
+    );
+  });
+
+  it("counts children in a final column as complete", () => {
+    mocks.getRelations.mockReturnValue({
+      data: [
+        childRelation("child-1", { status: "done" }),
+        childRelation("child-2", { status: "to-do" }),
+        childRelation("child-3", { status: "to-do" }),
+      ],
+    });
+
+    renderEpicChildren("to-do");
+
+    expect(screen.getByText("1/3")).toBeInTheDocument();
+  });
+
+  it("ignores relations that are not this epic's children", () => {
+    mocks.getRelations.mockReturnValue({
+      data: [
+        childRelation("child-1"),
+        { ...childRelation("child-2"), relationType: "blocks" },
+        { ...childRelation("child-3"), sourceTaskId: "another-epic" },
+      ],
+    });
+
+    renderEpicChildren("to-do");
+
+    expect(screen.getByText("0/1")).toBeInTheDocument();
+  });
+
+  it("hides child creation without task-create permission", () => {
+    mocks.canCreateTasks.mockReturnValue(false);
+
+    renderEpicChildren("to-do");
+
+    expect(
+      screen.queryByRole("button", { name: addButtonName }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/task/task-epic-children.tsx
+++ b/apps/web/src/components/task/task-epic-children.tsx
@@ -1,0 +1,346 @@
+import { useNavigate } from "@tanstack/react-router";
+import { AnimatePresence } from "framer-motion";
+import { ChevronDown, ChevronRight, Plus } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import CircularProgress from "@/components/ui/circular-progress";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Input } from "@/components/ui/input";
+import useCreateTask from "@/hooks/mutations/task/use-create-task";
+import { useDeleteTask } from "@/hooks/mutations/task/use-delete-task";
+import { useUpdateTaskStatus } from "@/hooks/mutations/task/use-update-task-status";
+import useCreateTaskRelation from "@/hooks/mutations/task-relation/use-create-task-relation";
+import { useGetColumns } from "@/hooks/queries/column/use-get-columns";
+import useGetTaskRelations from "@/hooks/queries/task-relation/use-get-task-relations";
+import useActiveWorkspace from "@/hooks/queries/workspace/use-active-workspace";
+import { useGetActiveWorkspaceUsers } from "@/hooks/queries/workspace-users/use-get-active-workspace-users";
+import { useWorkspacePermission } from "@/hooks/use-workspace-permission";
+import { toast } from "@/lib/toast";
+import queryClient from "@/query-client";
+import type Task from "@/types/task";
+import SubtaskRow from "./subtask-row";
+
+type TaskEpicChildrenProps = {
+  taskId: string;
+  projectId: string;
+  workspaceId: string;
+  parentStatus: string;
+};
+
+// Parallel to TaskSubtasks, but children are linked through "epic"-type
+// relations rather than "subtask" ones. Keyboard navigation and multi-select
+// are intentionally not replicated here to keep this smaller; add them if an
+// epic's child list grows large enough to need them.
+export default function TaskEpicChildren({
+  taskId,
+  projectId,
+  workspaceId,
+  parentStatus,
+}: TaskEpicChildrenProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [isOpen, setIsOpen] = useState(true);
+  const [isAdding, setIsAdding] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+  const [deleteTaskId, setDeleteTaskId] = useState<string | null>(null);
+
+  const { data: relations = [] } = useGetTaskRelations(taskId);
+  const { data: workspace } = useActiveWorkspace();
+  const { data: workspaceUsers } = useGetActiveWorkspaceUsers(
+    workspace?.id ?? "",
+  );
+  const createTask = useCreateTask();
+  const createRelation = useCreateTaskRelation();
+  const { mutateAsync: deleteTask } = useDeleteTask();
+  const { mutateAsync: updateTaskStatus } = useUpdateTaskStatus();
+  const { data: columns = [], isLoading: isLoadingColumns } =
+    useGetColumns(projectId);
+  const { canCreateTasks, canUpdateTasks } = useWorkspacePermission();
+  const canEdit = canUpdateTasks();
+  const canCreate = canCreateTasks();
+
+  // Same column-slug mapping TaskSubtasks uses: the API validates status
+  // against the project's real columns, so "done" here means "a final column".
+  const doneSlug = columns.find((c) => c.isFinal)?.slug ?? "done";
+  const todoSlug = columns.find((c) => !c.isFinal)?.slug;
+  const canCreateChild =
+    parentStatus === "planned" || (!isLoadingColumns && Boolean(todoSlug));
+  const isCompleted = (status: string) =>
+    columns.length > 0
+      ? (columns.find((c) => c.slug === status)?.isFinal ?? false)
+      : status === "done";
+
+  const children = relations
+    .filter((rel) => rel.relationType === "epic" && rel.sourceTaskId === taskId)
+    .map((rel) => ({ relation: rel, task: rel.targetTask }))
+    .filter(
+      (item): item is typeof item & { task: NonNullable<typeof item.task> } =>
+        item.task !== null,
+    );
+
+  const completedCount = children.filter((c) =>
+    isCompleted(c.task.status),
+  ).length;
+  const totalCount = children.length;
+
+  const buildTaskObject = (child: (typeof children)[number]): Task => ({
+    id: child.task.id,
+    title: child.task.title,
+    number: child.task.number,
+    description: null,
+    status: child.task.status,
+    priority: child.task.priority,
+    startDate: null,
+    dueDate: null,
+    position: null,
+    createdAt: "",
+    userId: child.task.userId,
+    assigneeId: child.task.userId,
+    assigneeName: child.task.assigneeName,
+    projectId: child.task.projectId,
+  });
+
+  const handleToggleComplete = async (taskObj: Task) => {
+    try {
+      await updateTaskStatus({
+        ...taskObj,
+        status: isCompleted(taskObj.status) ? (todoSlug ?? "to-do") : doneSlug,
+      });
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t("tasks:popover.status.updateError"),
+      );
+    }
+  };
+
+  const getAssignee = (userId: string | null) => {
+    if (!userId || !workspaceUsers?.members) return null;
+    return (
+      workspaceUsers.members.find((member) => member.userId === userId) ?? null
+    );
+  };
+
+  const handleAddChild = async () => {
+    if (!canCreate || !canEdit || !newTitle.trim()) return;
+    const initialStatus = parentStatus === "planned" ? "planned" : todoSlug;
+    if (!initialStatus) return;
+
+    try {
+      const newTask = await createTask.mutateAsync({
+        title: newTitle.trim(),
+        description: "",
+        projectId,
+        status: initialStatus,
+        priority: "no-priority",
+      });
+
+      await createRelation.mutateAsync({
+        sourceTaskId: taskId,
+        targetTaskId: newTask.id,
+        relationType: "epic",
+      });
+
+      setNewTitle("");
+      setIsAdding(false);
+    } catch {
+      toast.error(t("tasks:epics.children.createError"));
+    }
+  };
+
+  const handleDeleteTask = async () => {
+    if (!deleteTaskId) return;
+    try {
+      await deleteTask(deleteTaskId);
+      queryClient.invalidateQueries({ queryKey: ["tasks", projectId] });
+      queryClient.invalidateQueries({ queryKey: ["task-relations", taskId] });
+      toast.success(t("tasks:epics.children.deleteSuccess"));
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t("tasks:epics.children.deleteError"),
+      );
+    } finally {
+      setDeleteTaskId(null);
+    }
+  };
+
+  return (
+    <>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5">
+            <CollapsibleTrigger asChild>
+              <button
+                type="button"
+                className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {isOpen ? (
+                  <ChevronDown className="size-4" />
+                ) : (
+                  <ChevronRight className="size-4" />
+                )}
+                <span>{t("tasks:epics.children.title")}</span>
+              </button>
+            </CollapsibleTrigger>
+            {totalCount > 0 && (
+              <span className="flex items-center gap-1.5 ml-0.5">
+                <CircularProgress
+                  completed={completedCount}
+                  total={totalCount}
+                />
+                <span className="text-xs text-muted-foreground">
+                  {completedCount}/{totalCount}
+                </span>
+              </span>
+            )}
+          </div>
+          {canEdit && canCreate && (
+            <Button
+              variant="ghost"
+              size="xs"
+              className="text-muted-foreground"
+              aria-label={`${t("tasks:epics.children.addAction")} ${t("tasks:epics.children.title")}`}
+              onClick={() => setIsAdding(true)}
+              disabled={!canCreateChild}
+            >
+              <Plus className="size-3.5" />
+            </Button>
+          )}
+        </div>
+
+        <CollapsibleContent>
+          <div className="flex flex-col mt-1">
+            <AnimatePresence initial={false}>
+              {children.map((child) => {
+                const taskObj = buildTaskObject(child);
+
+                return (
+                  <SubtaskRow
+                    key={child.task.id}
+                    task={taskObj}
+                    tasks={[taskObj]}
+                    projectId={projectId}
+                    workspaceId={workspace?.id ?? workspaceId}
+                    isSelected={false}
+                    isFocused={false}
+                    isCompleted={isCompleted(child.task.status)}
+                    canEdit={canEdit}
+                    selectionRadius="rounded-md"
+                    assignee={getAssignee(child.task.userId)}
+                    onToggleComplete={() => handleToggleComplete(taskObj)}
+                    onNavigate={() =>
+                      navigate({
+                        to: "/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId",
+                        params: {
+                          workspaceId,
+                          projectId,
+                          taskId: child.task.id,
+                        },
+                      })
+                    }
+                    onDeleteClick={() => setDeleteTaskId(child.task.id)}
+                  />
+                );
+              })}
+            </AnimatePresence>
+          </div>
+
+          {isAdding && canEdit && canCreate && (
+            <div className="flex items-center gap-2 mt-2">
+              <Input
+                size="sm"
+                placeholder={t("tasks:epics.children.inputPlaceholder")}
+                value={newTitle}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setNewTitle(e.target.value)
+                }
+                onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                  if (e.key === "Enter") handleAddChild();
+                  if (e.key === "Escape") {
+                    setIsAdding(false);
+                    setNewTitle("");
+                  }
+                }}
+                autoFocus
+              />
+              <Button
+                size="xs"
+                onClick={handleAddChild}
+                disabled={
+                  !newTitle.trim() || createTask.isPending || !canCreateChild
+                }
+              >
+                {t("tasks:epics.children.addAction")}
+              </Button>
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={() => {
+                  setIsAdding(false);
+                  setNewTitle("");
+                }}
+              >
+                {t("common:actions.cancel")}
+              </Button>
+            </div>
+          )}
+
+          {!isAdding && totalCount === 0 && (
+            <p className="text-xs text-muted-foreground px-2 py-1">
+              {t("tasks:epics.children.empty")}
+            </p>
+          )}
+        </CollapsibleContent>
+      </Collapsible>
+
+      <AlertDialog
+        open={!!deleteTaskId}
+        onOpenChange={(open) => !open && setDeleteTaskId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("tasks:epics.children.deleteDialogTitle")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("tasks:epics.children.deleteDialogDescription")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose render={<Button variant="outline" size="sm" />}>
+              {t("common:actions.cancel")}
+            </AlertDialogClose>
+            <AlertDialogClose
+              render={
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={handleDeleteTask}
+                />
+              }
+            >
+              {t("tasks:epics.children.deleteAction")}
+            </AlertDialogClose>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/web/src/components/task/task-relations.tsx
+++ b/apps/web/src/components/task/task-relations.tsx
@@ -104,8 +104,11 @@ export default function TaskRelations({
     }
   }, [commandOpen]);
 
+  // "subtask" and "epic" relations each have their own dedicated section
+  // (TaskSubtasks / TaskEpicChildren), so they're excluded here to avoid
+  // showing the same link twice under two different UIs.
   const nonSubtaskRelations = relations.filter(
-    (rel) => rel.relationType !== "subtask",
+    (rel) => rel.relationType !== "subtask" && rel.relationType !== "epic",
   );
 
   const groupedRelations = useMemo(() => {

--- a/apps/web/src/constants/shortcuts.ts
+++ b/apps/web/src/constants/shortcuts.ts
@@ -37,6 +37,7 @@ export const shortcuts = {
     gantt: "g",
     list: "l",
     backlog: "k",
+    epics: "e",
   },
   taskDetails: {
     status: "s",

--- a/apps/web/src/fetchers/task-relation/create-task-relation.ts
+++ b/apps/web/src/fetchers/task-relation/create-task-relation.ts
@@ -7,7 +7,7 @@ async function createTaskRelation({
 }: {
   sourceTaskId: string;
   targetTaskId: string;
-  relationType: "subtask" | "blocks" | "related";
+  relationType: "subtask" | "blocks" | "related" | "epic";
 }) {
   const response = await client["task-relation"].$post({
     json: {

--- a/apps/web/src/fetchers/task/create-task.ts
+++ b/apps/web/src/fetchers/task/create-task.ts
@@ -15,6 +15,7 @@ async function createTask(
   startDate: Date | undefined,
   dueDate: Date | undefined,
   priority: CreateTaskRequest["priority"],
+  type?: CreateTaskRequest["type"],
 ) {
   if (!projectId) {
     throw new Error("No project selected for task creation");
@@ -29,6 +30,7 @@ async function createTask(
       startDate: startDate?.toISOString() || undefined,
       dueDate: dueDate?.toISOString() || undefined,
       priority,
+      ...(type ? { type } : {}),
     },
     param: { projectId },
   });

--- a/apps/web/src/fetchers/task/get-tasks.ts
+++ b/apps/web/src/fetchers/task/get-tasks.ts
@@ -1,11 +1,16 @@
 import { client } from "@kaneo/libs";
 import { HttpError } from "@/lib/http-error";
 
-async function getTasks(projectId: string) {
+type GetTasksFilters = {
+  type?: "task" | "epic";
+};
+
+async function getTasks(projectId: string, filters: GetTasksFilters = {}) {
   const response = await client.task.tasks[":projectId"].$get({
     param: { projectId },
-    // No filters: the route returns the whole board on a single page.
-    query: {},
+    // Everything else is unpaginated: the route returns the whole board (or,
+    // with `type`, every task of that type across it) on a single page.
+    query: filters.type ? { type: filters.type } : {},
   });
 
   if (!response.ok) {

--- a/apps/web/src/fetchers/task/import-tasks.ts
+++ b/apps/web/src/fetchers/task/import-tasks.ts
@@ -3,6 +3,7 @@ import { client } from "@kaneo/libs";
 export type TaskToImport = {
   title: string;
   description?: string;
+  type?: "task" | "epic";
   status: string;
   priority?: string;
   startDate?: string;

--- a/apps/web/src/hooks/mutations/task/use-create-task.ts
+++ b/apps/web/src/hooks/mutations/task/use-create-task.ts
@@ -16,6 +16,7 @@ function useCreateTask() {
       startDate,
       dueDate,
       priority,
+      type,
     }: CreateTaskRequest) =>
       createTask(
         title,
@@ -26,6 +27,7 @@ function useCreateTask() {
         startDate ? new Date(startDate) : undefined,
         dueDate ? new Date(dueDate) : undefined,
         priority,
+        type,
       ),
     onSuccess: (_data, variables) => {
       void queryClient.invalidateQueries({

--- a/apps/web/src/hooks/queries/task/use-get-project-epics.ts
+++ b/apps/web/src/hooks/queries/task/use-get-project-epics.ts
@@ -1,0 +1,25 @@
+import type getTasks from "@/fetchers/task/get-tasks";
+import { useGetTasks } from "@/hooks/queries/task/use-get-tasks";
+
+export type ProjectEpic = Awaited<
+  ReturnType<typeof getTasks>
+>["columns"][number]["tasks"][number];
+
+// Epics have no dedicated table, so "list a project's epics" reuses the board
+// endpoint's `type` filter and flattens its columns/archived/planned buckets,
+// mirroring how gantt.tsx and task-relations.tsx already flatten the same
+// shape into a plain task list.
+export function useGetProjectEpics(projectId: string) {
+  const query = useGetTasks(projectId, { type: "epic" });
+
+  const epics =
+    query.data == null
+      ? []
+      : [
+          ...query.data.columns.flatMap((column) => column.tasks),
+          ...(query.data.archivedTasks ?? []),
+          ...(query.data.plannedTasks ?? []),
+        ];
+
+  return { ...query, data: epics };
+}

--- a/apps/web/src/hooks/queries/task/use-get-tasks.ts
+++ b/apps/web/src/hooks/queries/task/use-get-tasks.ts
@@ -2,10 +2,18 @@ import { useQuery } from "@tanstack/react-query";
 import getTasks from "@/fetchers/task/get-tasks";
 import { isUnauthorizedError } from "@/lib/http-error";
 
-export function useGetTasks(projectId: string) {
+export function useGetTasks(
+  projectId: string,
+  filters?: { type?: "task" | "epic" },
+) {
   return useQuery({
-    queryKey: ["tasks", projectId],
-    queryFn: () => getTasks(projectId),
+    // Unfiltered callers keep the plain ["tasks", projectId] key that every
+    // mutation already invalidates; a type filter gets its own cache entry
+    // (invalidating ["tasks", projectId] still matches it as a key prefix).
+    queryKey: filters?.type
+      ? (["tasks", projectId, filters.type] as const)
+      : (["tasks", projectId] as const),
+    queryFn: () => getTasks(projectId, filters),
     refetchInterval: (query) =>
       isUnauthorizedError(query.state.error) ? false : 30000,
     enabled: !!projectId,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -55,6 +55,7 @@ import { Route as LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProject
 import { Route as LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBacklogRouteImport } from './routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog'
 import { Route as LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRouteImport } from './routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board'
 import { Route as LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRouteImport } from './routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar'
+import { Route as LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdEpicsRouteImport } from './routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/epics'
 import { Route as LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRouteImport } from './routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/gantt'
 import { Route as LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdTaskTaskIdRouteImport } from './routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId_'
 
@@ -338,6 +339,15 @@ const LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRo
         LayoutAuthenticatedDashboardWorkspaceWorkspaceIdRoute,
     } as any,
   )
+const LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdEpicsRoute =
+  LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdEpicsRouteImport.update(
+    {
+      id: '/project/$projectId/epics',
+      path: '/project/$projectId/epics',
+      getParentRoute: () =>
+        LayoutAuthenticatedDashboardWorkspaceWorkspaceIdRoute,
+    } as any,
+  )
 const LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute =
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRouteImport.update(
     {
@@ -401,6 +411,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/workspace/$workspaceId/project/$projectId/backlog': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBacklogRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/board': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/calendar': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute
+  '/dashboard/workspace/$workspaceId/project/$projectId/epics': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdEpicsRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/gantt': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdIndexRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdTaskTaskIdRoute
@@ -446,6 +457,7 @@ export interface FileRoutesByTo {
   '/dashboard/workspace/$workspaceId/project/$projectId/backlog': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBacklogRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/board': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/calendar': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute
+  '/dashboard/workspace/$workspaceId/project/$projectId/epics': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdEpicsRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/gantt': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute
   '/dashboard/workspace/$workspaceId/project/$projectId': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdIndexRoute
   '/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdTaskTaskIdRoute
@@ -497,6 +509,7 @@ export interface FileRoutesById {
   '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBacklogRoute
   '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute
   '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute
+  '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/epics': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdEpicsRoute
   '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/gantt': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute
   '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdIndexRoute
   '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId_': typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdTaskTaskIdRoute
@@ -547,6 +560,7 @@ export interface FileRouteTypes {
     | '/dashboard/workspace/$workspaceId/project/$projectId/backlog'
     | '/dashboard/workspace/$workspaceId/project/$projectId/board'
     | '/dashboard/workspace/$workspaceId/project/$projectId/calendar'
+    | '/dashboard/workspace/$workspaceId/project/$projectId/epics'
     | '/dashboard/workspace/$workspaceId/project/$projectId/gantt'
     | '/dashboard/workspace/$workspaceId/project/$projectId/'
     | '/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId'
@@ -592,6 +606,7 @@ export interface FileRouteTypes {
     | '/dashboard/workspace/$workspaceId/project/$projectId/backlog'
     | '/dashboard/workspace/$workspaceId/project/$projectId/board'
     | '/dashboard/workspace/$workspaceId/project/$projectId/calendar'
+    | '/dashboard/workspace/$workspaceId/project/$projectId/epics'
     | '/dashboard/workspace/$workspaceId/project/$projectId/gantt'
     | '/dashboard/workspace/$workspaceId/project/$projectId'
     | '/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId'
@@ -642,6 +657,7 @@ export interface FileRouteTypes {
     | '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog'
     | '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board'
     | '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar'
+    | '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/epics'
     | '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/gantt'
     | '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/'
     | '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/task/$taskId_'
@@ -982,6 +998,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRouteImport
       parentRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdRoute
     }
+    '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/epics': {
+      id: '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/epics'
+      path: '/project/$projectId/epics'
+      fullPath: '/dashboard/workspace/$workspaceId/project/$projectId/epics'
+      preLoaderRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdEpicsRouteImport
+      parentRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdRoute
+    }
     '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/gantt': {
       id: '/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/gantt'
       path: '/project/$projectId/gantt'
@@ -1099,6 +1122,7 @@ interface LayoutAuthenticatedDashboardWorkspaceWorkspaceIdRouteChildren {
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBacklogRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBacklogRoute
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute
+  LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdEpicsRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdEpicsRoute
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdIndexRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdIndexRoute
   LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdTaskTaskIdRoute: typeof LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdTaskTaskIdRoute
@@ -1118,6 +1142,8 @@ const LayoutAuthenticatedDashboardWorkspaceWorkspaceIdRouteChildren: LayoutAuthe
       LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdBoardRoute,
     LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute:
       LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdCalendarRoute,
+    LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdEpicsRoute:
+      LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdEpicsRoute,
     LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute:
       LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdGanttRoute,
     LayoutAuthenticatedDashboardWorkspaceWorkspaceIdProjectProjectIdIndexRoute:

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/backlog.tsx
@@ -1,7 +1,15 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { produce } from "immer";
-import { ArrowRight, Calendar, Filter, Plus, User, X } from "lucide-react";
+import {
+  ArrowRight,
+  Calendar,
+  Filter,
+  Layers,
+  Plus,
+  User,
+  X,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import BacklogListView from "@/components/backlog-list-view";
@@ -26,7 +34,9 @@ import labelColors from "@/constants/label-colors";
 import { shortcuts } from "@/constants/shortcuts";
 import { useUpdateTask } from "@/hooks/mutations/task/use-update-task";
 import useGetLabelsByWorkspace from "@/hooks/queries/label/use-get-labels-by-workspace";
+import { useGetProjectEpics } from "@/hooks/queries/task/use-get-project-epics";
 import { useGetTasks } from "@/hooks/queries/task/use-get-tasks";
+import useGetTaskRelations from "@/hooks/queries/task-relation/use-get-task-relations";
 import { useGetActiveWorkspaceUsers } from "@/hooks/queries/workspace-users/use-get-active-workspace-users";
 import { useRegisterShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { DUE_DATE_FILTER_VALUES } from "@/hooks/use-task-filters";
@@ -110,6 +120,12 @@ function RouteComponent() {
             params: { workspaceId, projectId },
           });
         },
+        [shortcuts.view.epics]: () => {
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/epics",
+            params: { workspaceId, projectId },
+          });
+        },
         [shortcuts.view.backlog]: () => {},
       },
     },
@@ -120,7 +136,29 @@ function RouteComponent() {
     assignee: null as string | null,
     dueDate: null as string | null,
     labels: [] as string[],
+    epicId: null as string | null,
   });
+
+  const { data: epics = [] } = useGetProjectEpics(projectId);
+  // Only the selected epic's children matter, so this fetches one task's
+  // relations (like TaskSubtasks/TaskEpicChildren do) rather than every
+  // relation in the project.
+  const { data: epicRelations = [] } = useGetTaskRelations(
+    filters.epicId ?? "",
+  );
+  const epicChildIds = useMemo(
+    () =>
+      new Set(
+        epicRelations
+          .filter(
+            (rel) =>
+              rel.relationType === "epic" &&
+              rel.sourceTaskId === filters.epicId,
+          )
+          .map((rel) => rel.targetTaskId),
+      ),
+    [epicRelations, filters.epicId],
+  );
 
   const updateFilter = (key: string, value: string | null) => {
     setFilters((prev) => ({ ...prev, [key]: value }));
@@ -141,6 +179,7 @@ function RouteComponent() {
       assignee: null,
       dueDate: null,
       labels: [],
+      epicId: null,
     });
   };
 
@@ -240,6 +279,10 @@ function RouteComponent() {
           }
         }
 
+        if (filters.epicId && !epicChildIds.has(task.id)) {
+          return false;
+        }
+
         return true;
       });
     };
@@ -249,7 +292,7 @@ function RouteComponent() {
       plannedTasks: filterTasks(project.plannedTasks || []),
       archivedTasks: filterTasks(project.archivedTasks || []),
     };
-  }, [project, filters, getTaskLabels]);
+  }, [project, filters, getTaskLabels, epicChildIds]);
 
   const uniqueLabels = workspaceLabels.reduce(
     (
@@ -525,6 +568,34 @@ function RouteComponent() {
                       </Button>
                     ))}
 
+                {filters.epicId && (
+                  <Button
+                    variant="secondary"
+                    size="xs"
+                    className="h-7 rounded-md px-2 text-xs font-medium gap-1.5"
+                  >
+                    <Layers className="h-3 w-3" />
+                    <span>
+                      {t("tasks:backlog.filters.epic", {
+                        name:
+                          epics.find((epic) => epic.id === filters.epicId)
+                            ?.title ?? "",
+                      })}
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-4 w-4 p-0 ml-1 hover:bg-destructive hover:text-destructive-foreground"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        updateFilter("epicId", null);
+                      }}
+                    >
+                      <X className="h-2.5 w-2.5" />
+                    </Button>
+                  </Button>
+                )}
+
                 <SortControl sort={sort} onSortChange={setSort} />
 
                 <DropdownMenu>
@@ -685,6 +756,37 @@ function RouteComponent() {
                         className="h-8 rounded-md text-sm text-muted-foreground"
                       >
                         <span>{t("tasks:labels.empty")}</span>
+                      </DropdownMenuItem>
+                    )}
+
+                    <DropdownMenuSeparator />
+                    <DropdownMenuGroup>
+                      <DropdownMenuLabel className="text-[11px] uppercase tracking-wide">
+                        {t("tasks:epics.label")}
+                      </DropdownMenuLabel>
+                    </DropdownMenuGroup>
+                    {epics.length > 0 ? (
+                      epics.map((epic) => (
+                        <DropdownMenuCheckboxItem
+                          key={epic.id}
+                          checked={filters.epicId === epic.id}
+                          onCheckedChange={(checked) =>
+                            updateFilter("epicId", checked ? epic.id : null)
+                          }
+                          className="h-8 rounded-md text-sm"
+                        >
+                          <div className="flex items-center gap-2 min-w-0">
+                            <Layers className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                            <span className="truncate">{epic.title}</span>
+                          </div>
+                        </DropdownMenuCheckboxItem>
+                      ))
+                    ) : (
+                      <DropdownMenuItem
+                        disabled
+                        className="h-8 rounded-md text-sm text-muted-foreground"
+                      >
+                        <span>{t("tasks:epics.noneAvailable")}</span>
                       </DropdownMenuItem>
                     )}
                   </DropdownMenuContent>

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/board.tsx
@@ -116,6 +116,11 @@ function RouteComponent() {
             to: "/dashboard/workspace/$workspaceId/project/$projectId/gantt",
             params: { workspaceId, projectId },
           }),
+        [shortcuts.view.epics]: () =>
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/epics",
+            params: { workspaceId, projectId },
+          }),
         [shortcuts.view.backlog]: () =>
           navigate({
             to: "/dashboard/workspace/$workspaceId/project/$projectId/backlog",

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/calendar.tsx
@@ -105,6 +105,12 @@ function RouteComponent() {
             params: { workspaceId, projectId },
           });
         },
+        [shortcuts.view.epics]: () => {
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/epics",
+            params: { workspaceId, projectId },
+          });
+        },
         [shortcuts.view.calendar]: () => {},
       },
     },

--- a/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/epics.tsx
+++ b/apps/web/src/routes/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/epics.tsx
@@ -1,0 +1,294 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Layers, Plus } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import ProjectLayout from "@/components/common/project-layout";
+import PageTitle from "@/components/page-title";
+import TaskDetailsSheet from "@/components/task/task-details-sheet";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import CircularProgress from "@/components/ui/circular-progress";
+import { Input } from "@/components/ui/input";
+import { shortcuts } from "@/constants/shortcuts";
+import useCreateTask from "@/hooks/mutations/task/use-create-task";
+import { useGetColumns } from "@/hooks/queries/column/use-get-columns";
+import useGetProject from "@/hooks/queries/project/use-get-project";
+import {
+  type ProjectEpic,
+  useGetProjectEpics,
+} from "@/hooks/queries/task/use-get-project-epics";
+import useGetTaskRelations from "@/hooks/queries/task-relation/use-get-task-relations";
+import { useGetActiveWorkspaceUsers } from "@/hooks/queries/workspace-users/use-get-active-workspace-users";
+import { useRegisterShortcuts } from "@/hooks/use-keyboard-shortcuts";
+import { useWorkspacePermission } from "@/hooks/use-workspace-permission";
+import { getInitials } from "@/lib/get-initials";
+import { getStatusLabel } from "@/lib/i18n/domain";
+import { getPriorityIcon } from "@/lib/priority";
+import { toast } from "@/lib/toast";
+
+type EpicsSearchParams = {
+  taskId?: string;
+};
+
+export const Route = createFileRoute(
+  "/_layout/_authenticated/dashboard/workspace/$workspaceId/project/$projectId/epics",
+)({
+  component: RouteComponent,
+  validateSearch: (search: Record<string, unknown>): EpicsSearchParams => ({
+    taskId: typeof search.taskId === "string" ? search.taskId : undefined,
+  }),
+});
+
+type WorkspaceMembers = NonNullable<
+  ReturnType<typeof useGetActiveWorkspaceUsers>["data"]
+>["members"];
+
+function EpicRow({
+  epic,
+  columns,
+  members,
+  onOpen,
+}: {
+  epic: ProjectEpic;
+  columns: ReturnType<typeof useGetColumns>["data"];
+  members: WorkspaceMembers | undefined;
+  onOpen: (taskId: string) => void;
+}) {
+  const { data: relations = [] } = useGetTaskRelations(epic.id);
+
+  const children = relations.filter(
+    (rel) => rel.relationType === "epic" && rel.sourceTaskId === epic.id,
+  );
+
+  const isFinal = (status: string) =>
+    columns && columns.length > 0
+      ? (columns.find((c) => c.slug === status)?.isFinal ?? false)
+      : status === "done";
+
+  const completedCount = children.filter(
+    (rel) => rel.targetTask && isFinal(rel.targetTask.status),
+  ).length;
+  const totalCount = children.length;
+
+  const assignee = members?.find((member) => member.userId === epic.userId);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(epic.id)}
+      className="flex w-full items-center gap-3 border-b border-border/50 px-4 py-2.5 text-left transition-colors hover:bg-accent/40"
+    >
+      <Layers className="size-4 shrink-0 text-muted-foreground" />
+      <span className="w-16 shrink-0 truncate text-xs font-mono text-muted-foreground">
+        {epic.number}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+        {epic.title}
+      </span>
+      <span className="shrink-0 rounded-full bg-secondary px-2 py-0.5 text-[11px] font-medium text-secondary-foreground">
+        {getStatusLabel(epic.status)}
+      </span>
+      <span className="shrink-0">
+        {getPriorityIcon(epic.priority ?? "no-priority")}
+      </span>
+      {totalCount > 0 && (
+        <span className="flex shrink-0 items-center gap-1.5">
+          <CircularProgress completed={completedCount} total={totalCount} />
+          <span className="text-xs text-muted-foreground">
+            {completedCount}/{totalCount}
+          </span>
+        </span>
+      )}
+      <Avatar className="size-6 shrink-0">
+        <AvatarImage
+          src={assignee?.user?.image ?? ""}
+          alt={assignee?.user?.name || ""}
+        />
+        <AvatarFallback className="text-[10px] font-medium border border-border/30">
+          {epic.userId ? getInitials(assignee?.user?.name) : "?"}
+        </AvatarFallback>
+      </Avatar>
+    </button>
+  );
+}
+
+function RouteComponent() {
+  const { t } = useTranslation();
+  const { projectId, workspaceId } = Route.useParams();
+  const { taskId } = Route.useSearch();
+  const navigate = useNavigate();
+  const { data: project } = useGetProject({ id: projectId, workspaceId });
+  const { data: epics = [], isLoading } = useGetProjectEpics(projectId);
+  const { data: columns = [] } = useGetColumns(projectId);
+  const { data: workspaceUsers } = useGetActiveWorkspaceUsers(workspaceId);
+  const createTask = useCreateTask();
+  const { canCreateTasks } = useWorkspacePermission();
+  const canCreate = canCreateTasks();
+
+  const [isAdding, setIsAdding] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+
+  const todoSlug = columns.find((c) => !c.isFinal)?.slug ?? "to-do";
+
+  useRegisterShortcuts({
+    sequentialShortcuts: {
+      [shortcuts.view.prefix]: {
+        [shortcuts.view.board]: () => {
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/board",
+            params: { workspaceId, projectId },
+          });
+        },
+        [shortcuts.view.list]: () => {
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/board",
+            params: { workspaceId, projectId },
+          });
+        },
+        [shortcuts.view.calendar]: () => {
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/calendar",
+            params: { workspaceId, projectId },
+          });
+        },
+        [shortcuts.view.gantt]: () => {
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/gantt",
+            params: { workspaceId, projectId },
+          });
+        },
+        [shortcuts.view.backlog]: () => {
+          navigate({
+            to: "/dashboard/workspace/$workspaceId/project/$projectId/backlog",
+            params: { workspaceId, projectId },
+          });
+        },
+        [shortcuts.view.epics]: () => {},
+      },
+    },
+  });
+
+  const handleOpenEpic = (openTaskId: string) => {
+    navigate({ to: ".", search: { taskId: openTaskId }, replace: true });
+  };
+
+  const handleCloseTaskSheet = () => {
+    navigate({ to: ".", search: {}, replace: true });
+  };
+
+  const handleAddEpic = async () => {
+    if (!canCreate || !newTitle.trim()) return;
+
+    try {
+      await createTask.mutateAsync({
+        title: newTitle.trim(),
+        description: "",
+        projectId,
+        status: todoSlug,
+        priority: "no-priority",
+        type: "epic",
+      });
+
+      setNewTitle("");
+      setIsAdding(false);
+    } catch {
+      toast.error(t("tasks:epics.createError"));
+    }
+  };
+
+  return (
+    <ProjectLayout
+      projectId={projectId}
+      workspaceId={workspaceId}
+      activeView="epics"
+    >
+      <PageTitle title={t("tasks:epics.pageTitle", { name: project?.name })} />
+      <div className="flex h-full min-h-0 flex-col bg-background">
+        <div className="flex items-center justify-between border-b border-border/80 px-4 py-2.5">
+          <h1 className="text-sm font-semibold text-foreground">
+            {t("tasks:epics.title")}
+          </h1>
+          {canCreate && (
+            <Button
+              variant="outline"
+              size="xs"
+              className="gap-1.5"
+              onClick={() => setIsAdding(true)}
+            >
+              <Plus className="size-3.5" />
+              {t("tasks:epics.newEpic")}
+            </Button>
+          )}
+        </div>
+
+        {isAdding && (
+          <div className="flex items-center gap-2 border-b border-border/50 px-4 py-2.5">
+            <Input
+              size="sm"
+              autoFocus
+              placeholder={t("tasks:epics.inputPlaceholder")}
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleAddEpic();
+                if (e.key === "Escape") {
+                  setIsAdding(false);
+                  setNewTitle("");
+                }
+              }}
+            />
+            <Button
+              size="xs"
+              onClick={handleAddEpic}
+              disabled={!newTitle.trim() || createTask.isPending}
+            >
+              {t("tasks:epics.children.addAction")}
+            </Button>
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={() => {
+                setIsAdding(false);
+                setNewTitle("");
+              }}
+            >
+              {t("common:actions.cancel")}
+            </Button>
+          </div>
+        )}
+
+        <div className="flex-1 overflow-auto">
+          {!isLoading && epics.length === 0 && (
+            <div className="flex h-full items-center justify-center px-6">
+              <div className="max-w-sm text-center">
+                <h2 className="text-sm font-semibold text-foreground">
+                  {t("tasks:epics.empty")}
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {t("tasks:epics.emptySubtitle")}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {epics.map((epic) => (
+            <EpicRow
+              key={epic.id}
+              epic={epic}
+              columns={columns}
+              members={workspaceUsers?.members}
+              onOpen={handleOpenEpic}
+            />
+          ))}
+        </div>
+
+        <TaskDetailsSheet
+          taskId={taskId}
+          projectId={projectId}
+          workspaceId={workspaceId}
+          onClose={handleCloseTaskSheet}
+        />
+      </div>
+    </ProjectLayout>
+  );
+}

--- a/apps/web/src/types/task/index.ts
+++ b/apps/web/src/types/task/index.ts
@@ -20,6 +20,7 @@ type Task = {
   title: string;
   number: number | null;
   description: string | null;
+  type?: string;
   status: string;
   priority: string | null;
   startDate: string | null;

--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -1380,7 +1380,8 @@
 				"prevTask": "Vorherige Aufgabe",
 				"openTask": "Ausgewählte Aufgabe öffnen",
 				"quickSelectNumber": "Option per Nummer auswählen",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1690,7 +1691,8 @@
 				"mermaid": {
 					"renderFailed": "Mermaid-Diagramm konnte nicht gerendert werden"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "Aufgabe"
@@ -1813,7 +1815,8 @@
 				"label": "Label: {{name}}",
 				"dueThisWeek": "Diese Woche fällig",
 				"dueNextWeek": "Nächste Woche fällig",
-				"noDueDate": "Kein Fälligkeitsdatum"
+				"noDueDate": "Kein Fälligkeitsdatum",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1977,6 +1980,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/el-GR.json
+++ b/i18n/el-GR.json
@@ -1380,7 +1380,8 @@
 				"prevTask": "Προηγούμενη εργασία",
 				"openTask": "Άνοιγμα επιλεγμένης εργασίας",
 				"quickSelectNumber": "Επιλογή επιλογής με αριθμό",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1690,7 +1691,8 @@
 				"mermaid": {
 					"renderFailed": "Δεν ήταν δυνατή η απόδοση του διαγράμματος Mermaid"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "Εργασία"
@@ -1813,7 +1815,8 @@
 				"label": "Ετικέτα: {{name}}",
 				"dueThisWeek": "Λήγει αυτή την εβδομάδα",
 				"dueNextWeek": "Λήγει την επόμενη εβδομάδα",
-				"noDueDate": "Χωρίς ημερομηνία λήξης"
+				"noDueDate": "Χωρίς ημερομηνία λήξης",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1977,6 +1980,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1377,6 +1377,7 @@
 				"listView": "Switch to list view",
 				"backlogView": "Switch to backlog view",
 				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view",
 				"nextTask": "Next task",
 				"prevTask": "Previous task",
 				"openTask": "Open selected task",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1588,6 +1588,7 @@
 		},
 		"detail": {
 			"subtaskOf": "Subtask of",
+			"epicOf": "Part of",
 			"activity": "Activity",
 			"noActivity": "No activity found",
 			"openInFullPage": "Open in full page",
@@ -1726,6 +1727,30 @@
 			"deleteAction": "Delete Task",
 			"completeAria": "Mark subtask complete"
 		},
+		"epics": {
+			"tabTitle": "Epics",
+			"label": "Epic",
+			"title": "Epics",
+			"pageTitle": "{{name}} – Epics",
+			"newEpic": "New Epic",
+			"inputPlaceholder": "Epic title...",
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"noneAvailable": "No epics available",
+			"children": {
+				"title": "Tasks in this epic",
+				"inputPlaceholder": "Task title...",
+				"addAction": "Add",
+				"empty": "No tasks in this epic yet",
+				"createError": "Failed to create task",
+				"deleteSuccess": "Task deleted successfully",
+				"deleteError": "Failed to delete task",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteAction": "Delete Task"
+			}
+		},
 		"properties": {
 			"title": "Properties",
 			"labels": "Labels",
@@ -1813,7 +1838,8 @@
 				"label": "Label: {{name}}",
 				"dueThisWeek": "Due this week",
 				"dueNextWeek": "Due next week",
-				"noDueDate": "No due date"
+				"noDueDate": "No due date",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -1381,7 +1381,8 @@
 				"prevTask": "Tarea anterior",
 				"openTask": "Abrir tarea seleccionada",
 				"quickSelectNumber": "Seleccionar opción por número",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1695,7 +1696,8 @@
 				"mermaid": {
 					"renderFailed": "No se pudo renderizar el diagrama de Mermaid"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "Tarea"
@@ -1807,7 +1809,8 @@
 				"label": "Etiqueta: {{name}}",
 				"dueThisWeek": "Para esta semana",
 				"dueNextWeek": "Para la semana que viene",
-				"noDueDate": "Sin fecha de vencimiento"
+				"noDueDate": "Sin fecha de vencimiento",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1983,6 +1986,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -1381,7 +1381,8 @@
 				"prevTask": "Tâche précédente",
 				"openTask": "Ouvrir la tâche sélectionnée",
 				"quickSelectNumber": "Sélectionner une option par numéro",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1695,7 +1696,8 @@
 				"mermaid": {
 					"renderFailed": "Impossible d'afficher le diagramme Mermaid"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "Tâche"
@@ -1818,7 +1820,8 @@
 				"label": "Label : {{name}}",
 				"dueThisWeek": "Échéance cette semaine",
 				"dueNextWeek": "Échéance la semaine prochaine",
-				"noDueDate": "Pas de date d'échéance"
+				"noDueDate": "Pas de date d'échéance",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1983,6 +1986,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/hi-IN.json
+++ b/i18n/hi-IN.json
@@ -1380,7 +1380,8 @@
 				"prevTask": "पिछला कार्य",
 				"openTask": "चयनित कार्य खोलें",
 				"quickSelectNumber": "संख्या द्वारा विकल्प चुनें",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1690,7 +1691,8 @@
 				"mermaid": {
 					"renderFailed": "Mermaid डायग्राम प्रस्तुत नहीं किया जा सका"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "कार्य"
@@ -1813,7 +1815,8 @@
 				"label": "लेबल: {{name}}",
 				"dueThisWeek": "इस सप्ताह देय",
 				"dueNextWeek": "अगले सप्ताह देय",
-				"noDueDate": "कोई नियत तारीख नहीं"
+				"noDueDate": "कोई नियत तारीख नहीं",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1977,6 +1980,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/id-ID.json
+++ b/i18n/id-ID.json
@@ -1379,7 +1379,8 @@
 				"prevTask": "Tugas sebelumnya",
 				"openTask": "Buka tugas terpilih",
 				"quickSelectNumber": "Pilih opsi berdasarkan nomor",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1685,7 +1686,8 @@
 				"mermaid": {
 					"renderFailed": "Diagram Mermaid tidak dapat dirender"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "Tugas"
@@ -1808,7 +1810,8 @@
 				"label": "Label: {{name}}",
 				"dueThisWeek": "Tenggat minggu ini",
 				"dueNextWeek": "Tenggat minggu depan",
-				"noDueDate": "Tanpa tenggat"
+				"noDueDate": "Tanpa tenggat",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1971,6 +1974,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/it-IT.json
+++ b/i18n/it-IT.json
@@ -1381,7 +1381,8 @@
 				"prevTask": "Attività precedente",
 				"openTask": "Apri attività selezionata",
 				"quickSelectNumber": "Seleziona opzione per numero",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1695,7 +1696,8 @@
 				"mermaid": {
 					"renderFailed": "Impossibile eseguire il rendering del diagramma Mermaid"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "Attività"
@@ -1818,7 +1820,8 @@
 				"label": "Etichetta: {{name}}",
 				"dueThisWeek": "Scade questa settimana",
 				"dueNextWeek": "Scade la prossima settimana",
-				"noDueDate": "Nessuna scadenza"
+				"noDueDate": "Nessuna scadenza",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1983,6 +1986,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/ja-JP.json
+++ b/i18n/ja-JP.json
@@ -1379,7 +1379,8 @@
 				"nextTask": "次のタスク",
 				"prevTask": "前のタスク",
 				"openTask": "選択したタスクを開く",
-				"quickSelectNumber": "番号で項目を選択"
+				"quickSelectNumber": "番号で項目を選択",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1685,7 +1686,8 @@
 				"mermaid": {
 					"renderFailed": "Mermaid ダイアグラムを描画できませんでした"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "タスク"
@@ -1808,7 +1810,8 @@
 				"label": "ラベル: {{name}}",
 				"dueThisWeek": "今週が期限",
 				"dueNextWeek": "来週が期限",
-				"noDueDate": "期限なし"
+				"noDueDate": "期限なし",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1971,6 +1974,30 @@
 				"deleteRow": "行を削除",
 				"deleteTable": "表を削除"
 			}
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/ko-KR.json
+++ b/i18n/ko-KR.json
@@ -1379,7 +1379,8 @@
 				"nextTask": "다음 작업",
 				"prevTask": "이전 작업",
 				"openTask": "선택한 작업 열기",
-				"quickSelectNumber": "번호로 옵션 선택"
+				"quickSelectNumber": "번호로 옵션 선택",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1685,7 +1686,8 @@
 				"mermaid": {
 					"renderFailed": "Mermaid 다이어그램을 렌더링할 수 없습니다"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "작업"
@@ -1808,7 +1810,8 @@
 				"label": "라벨: {{name}}",
 				"dueThisWeek": "이번 주 마감",
 				"dueNextWeek": "다음 주 마감",
-				"noDueDate": "마감일 없음"
+				"noDueDate": "마감일 없음",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1971,6 +1974,30 @@
 				"deleteRow": "행 삭제",
 				"deleteTable": "표 삭제"
 			}
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/mk-MK.json
+++ b/i18n/mk-MK.json
@@ -1380,7 +1380,8 @@
 				"prevTask": "Претходна задача",
 				"openTask": "Отвори избрана задача",
 				"quickSelectNumber": "Избери опција по број",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1690,7 +1691,8 @@
 				"mermaid": {
 					"renderFailed": "Mermaid дијаграмот не можеше да се прикаже"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "Задача"
@@ -1813,7 +1815,8 @@
 				"label": "Етикета: {{name}}",
 				"dueThisWeek": "Рок оваа недела",
 				"dueNextWeek": "Рок следна недела",
-				"noDueDate": "Без краен рок"
+				"noDueDate": "Без краен рок",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1977,6 +1980,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/nl-NL.json
+++ b/i18n/nl-NL.json
@@ -1380,7 +1380,8 @@
 				"prevTask": "Vorige taak",
 				"openTask": "Geselecteerde taak openen",
 				"quickSelectNumber": "Selecteer optie via nummer",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1690,7 +1691,8 @@
 				"mermaid": {
 					"renderFailed": "Mermaid-diagram kon niet worden weergegeven"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "Taak"
@@ -1802,7 +1804,8 @@
 				"label": "Label: {{name}}",
 				"dueThisWeek": "Deze week vervallen",
 				"dueNextWeek": "Volgende week vervallen",
-				"noDueDate": "Geen einddatum"
+				"noDueDate": "Geen einddatum",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1977,6 +1980,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -1381,7 +1381,8 @@
 				"prevTask": "Tarefa anterior",
 				"openTask": "Abrir tarefa selecionada",
 				"quickSelectNumber": "Selecionar opção por número",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1695,7 +1696,8 @@
 				"mermaid": {
 					"renderFailed": "Mermaid diagram couldn't be rendered"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "Tarefa"
@@ -1818,7 +1820,8 @@
 				"label": "Etiqueta: {{name}}",
 				"dueThisWeek": "Vence esta semana",
 				"dueNextWeek": "Vence na próxima semana",
-				"noDueDate": "Sem data de vencimento"
+				"noDueDate": "Sem data de vencimento",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1983,6 +1986,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/ru-RU.json
+++ b/i18n/ru-RU.json
@@ -1390,7 +1390,8 @@
 				"prevTask": "Предыдущая задача",
 				"openTask": "Открыть выбранную задачу",
 				"quickSelectNumber": "Выбрать вариант по номеру",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1708,7 +1709,8 @@
 				"mermaid": {
 					"renderFailed": "Не удалось отобразить диаграмму Mermaid"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "Задача"
@@ -1834,7 +1836,8 @@
 				"label": "Метка: {{name}}",
 				"dueThisWeek": "Срок на этой неделе",
 				"dueNextWeek": "Срок на следующей неделе",
-				"noDueDate": "Без срока"
+				"noDueDate": "Без срока",
+				"epic": "Epic: {{name}}"
 			},
 			"moveAllSuccess": "{{count}} задач перемещено в «К выполнению»"
 		},
@@ -2045,6 +2048,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/schema.json
+++ b/i18n/schema.json
@@ -5533,6 +5533,9 @@
 								"calendarView": {
 									"type": "string"
 								},
+								"epicsView": {
+									"type": "string"
+								},
 								"nextTask": {
 									"type": "string"
 								},
@@ -5559,6 +5562,7 @@
 								"listView",
 								"backlogView",
 								"calendarView",
+								"epicsView",
 								"nextTask",
 								"prevTask",
 								"openTask",
@@ -6425,6 +6429,9 @@
 						"subtaskOf": {
 							"type": "string"
 						},
+						"epicOf": {
+							"type": "string"
+						},
 						"activity": {
 							"type": "string"
 						},
@@ -6826,6 +6833,7 @@
 					},
 					"required": [
 						"subtaskOf",
+						"epicOf",
 						"activity",
 						"noActivity",
 						"openInFullPage",
@@ -6963,6 +6971,103 @@
 						"deleteDialogDescription",
 						"deleteAction",
 						"completeAria"
+					]
+				},
+				"epics": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"tabTitle": {
+							"type": "string"
+						},
+						"label": {
+							"type": "string"
+						},
+						"title": {
+							"type": "string"
+						},
+						"pageTitle": {
+							"type": "string"
+						},
+						"newEpic": {
+							"type": "string"
+						},
+						"inputPlaceholder": {
+							"type": "string"
+						},
+						"createError": {
+							"type": "string"
+						},
+						"empty": {
+							"type": "string"
+						},
+						"emptySubtitle": {
+							"type": "string"
+						},
+						"noneAvailable": {
+							"type": "string"
+						},
+						"children": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"inputPlaceholder": {
+									"type": "string"
+								},
+								"addAction": {
+									"type": "string"
+								},
+								"empty": {
+									"type": "string"
+								},
+								"createError": {
+									"type": "string"
+								},
+								"deleteSuccess": {
+									"type": "string"
+								},
+								"deleteError": {
+									"type": "string"
+								},
+								"deleteDialogTitle": {
+									"type": "string"
+								},
+								"deleteDialogDescription": {
+									"type": "string"
+								},
+								"deleteAction": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"title",
+								"inputPlaceholder",
+								"addAction",
+								"empty",
+								"createError",
+								"deleteSuccess",
+								"deleteError",
+								"deleteDialogTitle",
+								"deleteDialogDescription",
+								"deleteAction"
+							]
+						}
+					},
+					"required": [
+						"tabTitle",
+						"label",
+						"title",
+						"pageTitle",
+						"newEpic",
+						"inputPlaceholder",
+						"createError",
+						"empty",
+						"emptySubtitle",
+						"noneAvailable",
+						"children"
 					]
 				},
 				"properties": {
@@ -7323,6 +7428,9 @@
 								},
 								"noDueDate": {
 									"type": "string"
+								},
+								"epic": {
+									"type": "string"
 								}
 							},
 							"required": [
@@ -7332,7 +7440,8 @@
 								"label",
 								"dueThisWeek",
 								"dueNextWeek",
-								"noDueDate"
+								"noDueDate",
+								"epic"
 							]
 						}
 					},
@@ -8188,6 +8297,7 @@
 				"entity",
 				"relations",
 				"subtasks",
+				"epics",
 				"properties",
 				"move",
 				"popover",

--- a/i18n/tr-TR.json
+++ b/i18n/tr-TR.json
@@ -1380,7 +1380,8 @@
 				"prevTask": "Önceki talep",
 				"openTask": "Seçili talebi aç",
 				"quickSelectNumber": "Numarayla seçenek seç",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1690,7 +1691,8 @@
 				"mermaid": {
 					"renderFailed": "Mermaid diyagramı oluşturulamadı"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "Talep"
@@ -1813,7 +1815,8 @@
 				"label": "Etiket: {{name}}",
 				"dueThisWeek": "Bu hafta bitiyor",
 				"dueNextWeek": "Önümüzdeki hafta bitiyor",
-				"noDueDate": "Bitiş tarihi yok"
+				"noDueDate": "Bitiş tarihi yok",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1977,6 +1980,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/uk-UA.json
+++ b/i18n/uk-UA.json
@@ -1382,7 +1382,8 @@
 				"prevTask": "Попереднє завдання",
 				"openTask": "Відкрити обране завдання",
 				"quickSelectNumber": "Обрати варіант за номером",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1700,7 +1701,8 @@
 				"mermaid": {
 					"renderFailed": "Не вдалося відобразити діаграму Mermaid"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "Завдання"
@@ -1823,7 +1825,8 @@
 				"label": "Мітка: {{name}}",
 				"dueThisWeek": "Термін цього тижня",
 				"dueNextWeek": "Термін наступного тижня",
-				"noDueDate": "Без дати завершення"
+				"noDueDate": "Без дати завершення",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1989,6 +1992,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/vi-VN.json
+++ b/i18n/vi-VN.json
@@ -1379,7 +1379,8 @@
 				"prevTask": "Công việc trước đó",
 				"openTask": "Mở công việc đã chọn",
 				"quickSelectNumber": "Chọn tùy chọn theo số",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1685,7 +1686,8 @@
 				"mermaid": {
 					"renderFailed": "Mermaid diagram couldn't be rendered"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "Công việc"
@@ -1808,7 +1810,8 @@
 				"label": "Nhãn: {{name}}",
 				"dueThisWeek": "Đến hạn tuần này",
 				"dueNextWeek": "Đến hạn tuần sau",
-				"noDueDate": "Không có ngày đến hạn"
+				"noDueDate": "Không có ngày đến hạn",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1971,6 +1974,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -1379,7 +1379,8 @@
 				"prevTask": "上一任务",
 				"openTask": "打开所选任务",
 				"quickSelectNumber": "按数字选择选项",
-				"calendarView": "Switch to calendar view"
+				"calendarView": "Switch to calendar view",
+				"epicsView": "Switch to epics view"
 			}
 		}
 	},
@@ -1685,7 +1686,8 @@
 				"mermaid": {
 					"renderFailed": "Mermaid diagram couldn't be rendered"
 				}
-			}
+			},
+			"epicOf": "Part of"
 		},
 		"entity": {
 			"task": "任务"
@@ -1808,7 +1810,8 @@
 				"label": "标签：{{name}}",
 				"dueThisWeek": "本周到期",
 				"dueNextWeek": "下周到期",
-				"noDueDate": "无截止日期"
+				"noDueDate": "无截止日期",
+				"epic": "Epic: {{name}}"
 			}
 		},
 		"sort": {
@@ -1971,6 +1974,30 @@
 			"title": "Calendar",
 			"today": "Today",
 			"loadError": "Failed to load tasks."
+		},
+		"epics": {
+			"children": {
+				"addAction": "Add",
+				"createError": "Failed to create task",
+				"deleteAction": "Delete Task",
+				"deleteDialogDescription": "This will permanently remove the task and all its data. You can't undo this action.",
+				"deleteDialogTitle": "Delete Task?",
+				"deleteError": "Failed to delete task",
+				"deleteSuccess": "Task deleted successfully",
+				"empty": "No tasks in this epic yet",
+				"inputPlaceholder": "Task title...",
+				"title": "Tasks in this epic"
+			},
+			"createError": "Failed to create epic",
+			"empty": "No epics yet",
+			"emptySubtitle": "Create an epic to group related tasks together.",
+			"inputPlaceholder": "Epic title...",
+			"label": "Epic",
+			"newEpic": "New Epic",
+			"noneAvailable": "No epics available",
+			"pageTitle": "{{name}} – Epics",
+			"tabTitle": "Epics",
+			"title": "Epics"
 		}
 	},
 	"invitations": {

--- a/packages/mcp/src/tools/register.ts
+++ b/packages/mcp/src/tools/register.ts
@@ -13,6 +13,7 @@ const prioritySchema = z.enum([
   "urgent",
 ]);
 
+const taskTypeSchema = z.enum(["task", "epic"]);
 const nonEmptyString = z.string().trim().min(1);
 const optionalNonEmptyString = nonEmptyString.optional();
 const nullableOptionalNonEmptyString = nonEmptyString.nullable().optional();
@@ -190,6 +191,7 @@ export function registerTools(
     status: optionalNonEmptyString,
     priority: prioritySchema.optional(),
     assigneeId: optionalNonEmptyString,
+    type: taskTypeSchema.optional(),
     page: z.number().int().positive().optional(),
     limit: z.number().int().positive().optional(),
     sortBy: z
@@ -203,7 +205,8 @@ export function registerTools(
   server.registerTool(
     "list_tasks",
     {
-      description: "List tasks for a project (optionally filtered/sorted).",
+      description:
+        "List tasks for a project (optionally filtered/sorted). Pass type: 'epic' to list only the project's epics.",
       inputSchema: listTasksSchema,
     },
     async (args) => {
@@ -248,6 +251,7 @@ export function registerTools(
         startDate: optionalIsoDateTimeSchema,
         dueDate: optionalIsoDateTimeSchema,
         userId: optionalNonEmptyString,
+        type: taskTypeSchema.optional(),
       }),
     },
     async (args) => {
@@ -265,6 +269,9 @@ export function registerTools(
       }
       if (args.userId !== undefined) {
         body.userId = args.userId;
+      }
+      if (args.type !== undefined) {
+        body.type = args.type;
       }
       return run(() =>
         client.json(`/api/task/${encodeURIComponent(args.projectId)}`, {
@@ -495,11 +502,11 @@ export function registerTools(
     "create_task_relation",
     {
       description:
-        "Create a relation between two tasks. relationType: 'subtask' (sourceTaskId is the parent, targetTaskId the child), 'blocks' (sourceTaskId blocks targetTaskId), or 'related' (bidirectional).",
+        "Create a relation between two tasks. relationType: 'subtask' (sourceTaskId is the parent, targetTaskId the child), 'blocks' (sourceTaskId blocks targetTaskId), 'related' (bidirectional), or 'epic' (sourceTaskId must be a task of type 'epic'; targetTaskId becomes one of its children).",
       inputSchema: z.object({
         sourceTaskId: nonEmptyString,
         targetTaskId: nonEmptyString,
-        relationType: z.enum(["subtask", "blocks", "related"]),
+        relationType: z.enum(["subtask", "blocks", "related", "epic"]),
       }),
     },
     async (args) =>
@@ -519,7 +526,7 @@ export function registerTools(
     "get_task_relations",
     {
       description:
-        "List all relations (subtask/blocks/related) involving a task.",
+        "List all relations (subtask/blocks/related/epic) involving a task.",
       inputSchema: z.object({ taskId: nonEmptyString }),
     },
     async (args) =>

--- a/tests/api-integration/task-epic.test.ts
+++ b/tests/api-integration/task-epic.test.ts
@@ -169,6 +169,59 @@ describe("API integration: epics", () => {
     });
   });
 
+  it("rejects an epic relation whose source task is not an epic", async () => {
+    const member = await createWorkspaceMember();
+    const { project, columns } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    const [notAnEpic] = await db
+      .insert(schema.taskTable)
+      .values({
+        projectId: project.id,
+        title: "Ordinary task",
+        type: "task",
+        status: "to-do",
+        columnId: columns.todo.id,
+        number: 1,
+        position: 1,
+      })
+      .returning();
+    const [child] = await db
+      .insert(schema.taskTable)
+      .values({
+        projectId: project.id,
+        title: "Child task",
+        type: "task",
+        status: "to-do",
+        columnId: columns.todo.id,
+        number: 2,
+        position: 2,
+      })
+      .returning();
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request("/api/task-relation", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sourceTaskId: notAnEpic.id,
+        targetTaskId: child.id,
+        relationType: "epic",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+
+    const persistedRelations = await db
+      .select()
+      .from(schema.taskRelationTable)
+      .where(eq(schema.taskRelationTable.sourceTaskId, notAnEpic.id));
+    expect(persistedRelations).toHaveLength(0);
+  });
+
   it("lists only epic-type tasks when filtering the project's tasks by type", async () => {
     const member = await createWorkspaceMember();
     const { project, columns } = await createProjectFixture({

--- a/tests/api-integration/task-epic.test.ts
+++ b/tests/api-integration/task-epic.test.ts
@@ -1,0 +1,236 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import db, { schema } from "../../apps/api/src/database";
+import { createApp } from "../../apps/api/src/index";
+import { mockAuthenticatedSession } from "./helpers/auth";
+import { resetTestDatabase } from "./helpers/database";
+import {
+  createProjectFixture,
+  createWorkspaceMember,
+} from "./helpers/fixtures";
+
+describe("API integration: epics", () => {
+  beforeEach(async () => {
+    await resetTestDatabase();
+  });
+
+  it("defaults a newly created task's type to task", async () => {
+    const member = await createWorkspaceMember();
+    const { project } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request(`/api/task/${project.id}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Regular task",
+        description: "",
+        priority: "low",
+        status: "to-do",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { id: string; type: string };
+    expect(payload.type).toBe("task");
+
+    const persistedTask = await db.query.taskTable.findFirst({
+      where: eq(schema.taskTable.id, payload.id),
+    });
+    expect(persistedTask?.type).toBe("task");
+  });
+
+  it("creates a task with type epic", async () => {
+    const member = await createWorkspaceMember();
+    const { project } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request(`/api/task/${project.id}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Website redesign",
+        description: "Everything the redesign touches",
+        priority: "medium",
+        status: "to-do",
+        type: "epic",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { id: string; type: string };
+    expect(payload).toMatchObject({
+      title: "Website redesign",
+      type: "epic",
+    });
+
+    const persistedTask = await db.query.taskTable.findFirst({
+      where: eq(schema.taskTable.id, payload.id),
+    });
+    expect(persistedTask?.type).toBe("epic");
+  });
+
+  it("rejects an unknown task type", async () => {
+    const member = await createWorkspaceMember();
+    const { project } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request(`/api/task/${project.id}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Not a real type",
+        description: "",
+        priority: "low",
+        status: "to-do",
+        type: "story",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("creates an epic-type task relation linking an epic to a child task", async () => {
+    const member = await createWorkspaceMember();
+    const { project, columns } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    const [epic] = await db
+      .insert(schema.taskTable)
+      .values({
+        projectId: project.id,
+        title: "Epic",
+        type: "epic",
+        status: "to-do",
+        columnId: columns.todo.id,
+        number: 1,
+        position: 1,
+      })
+      .returning();
+    const [child] = await db
+      .insert(schema.taskTable)
+      .values({
+        projectId: project.id,
+        title: "Child task",
+        type: "task",
+        status: "to-do",
+        columnId: columns.todo.id,
+        number: 2,
+        position: 2,
+      })
+      .returning();
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request("/api/task-relation", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sourceTaskId: epic.id,
+        targetTaskId: child.id,
+        relationType: "epic",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      id: string;
+      sourceTaskId: string;
+      targetTaskId: string;
+      relationType: string;
+    };
+    expect(payload).toMatchObject({
+      sourceTaskId: epic.id,
+      targetTaskId: child.id,
+      relationType: "epic",
+    });
+
+    const persistedRelation = await db.query.taskRelationTable.findFirst({
+      where: eq(schema.taskRelationTable.id, payload.id),
+    });
+    expect(persistedRelation).toMatchObject({
+      sourceTaskId: epic.id,
+      targetTaskId: child.id,
+      relationType: "epic",
+    });
+  });
+
+  it("lists only epic-type tasks when filtering the project's tasks by type", async () => {
+    const member = await createWorkspaceMember();
+    const { project, columns } = await createProjectFixture({
+      workspaceId: member.workspace.id,
+    });
+
+    await db.insert(schema.taskTable).values([
+      {
+        projectId: project.id,
+        title: "Epic A",
+        type: "epic",
+        status: "to-do",
+        columnId: columns.todo.id,
+        number: 1,
+        position: 1,
+      },
+      {
+        projectId: project.id,
+        title: "Regular task",
+        type: "task",
+        status: "to-do",
+        columnId: columns.todo.id,
+        number: 2,
+        position: 2,
+      },
+      {
+        projectId: project.id,
+        title: "Planned epic",
+        type: "epic",
+        status: "planned",
+        number: 3,
+        position: 1,
+      },
+    ]);
+
+    mockAuthenticatedSession(member.user);
+    const { app } = createApp();
+
+    const response = await app.request(
+      `/api/task/tasks/${project.id}?type=epic`,
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      data: {
+        columns: { tasks: { title: string; type: string }[] }[];
+        plannedTasks: { title: string; type: string }[];
+        archivedTasks: { title: string; type: string }[];
+      };
+    };
+
+    const allReturnedTasks = [
+      ...payload.data.columns.flatMap((column) => column.tasks),
+      ...payload.data.plannedTasks,
+      ...payload.data.archivedTasks,
+    ];
+
+    expect(allReturnedTasks).toHaveLength(2);
+    expect(allReturnedTasks.map((task) => task.title).sort()).toEqual([
+      "Epic A",
+      "Planned epic",
+    ]);
+    expect(allReturnedTasks.every((task) => task.type === "epic")).toBe(true);
+  });
+});

--- a/tests/api/task/validate-task-fields.test.ts
+++ b/tests/api/task/validate-task-fields.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertValidTaskType,
+  VALID_TASK_TYPES,
+} from "../../../apps/api/src/task/validate-task-fields";
+
+describe("assertValidTaskType", () => {
+  it("accepts every valid task type", () => {
+    for (const type of VALID_TASK_TYPES) {
+      expect(() => assertValidTaskType(type)).not.toThrow();
+    }
+  });
+
+  it("rejects an unknown task type", () => {
+    expect(() => assertValidTaskType("story")).toThrowError(
+      /Invalid type "story"/,
+    );
+  });
+});


### PR DESCRIPTION
## Description

Adds an **epic** task type: a task that groups other tasks, tracks their completion, and gives a project a workstream-level view without inventing a second entity.

An epic is an ordinary row in `task` with `type = 'epic'`. Children are linked through a `task_relation` row of type `epic` rather than a separate table, so epics inherit status, priority, assignee, due dates, activity, and permissions for free.

**What this adds**

- **Schema**: `task.type` (`text`, defaults to `'task'`), with migration `0045_narrow_norman_osborn.sql`. Existing rows default to `task`, so installations upgrade without a backfill.
- **API**: `type` on create/update, a `type` filter on the project task list, `epic` in the task-relation enum, and validation via `assertValidTaskType`. `updateTask` deliberately *omits* `type` rather than defaulting it, so routine edits through that replace-every-field endpoint never silently reclassify a task.
- **Web**: a new project **Epics** view (`g e`), a "Tasks in this epic" section on epic task details, a "Part of" breadcrumb on children, and an epic filter in Backlog view.
- **MCP**: `type` on `create_task`, a `type` filter on `list_tasks`, and `epic` in `create_task_relation` — on both the HTTP MCP routes and the published stdio package.
- **Export/import**: `type` round-trips, so exporting and re-importing a project no longer flattens epics into ordinary tasks.
- **Docs**: a user-facing [Group Work with Epics](apps/docs/core/functional/group-work-with-epics.mdx) page, and a regenerated `apps/docs/openapi.json`.

**Reviewer notes**

- The second commit tightens one rule the first left open: the API now rejects an `epic` relation whose source task isn't an epic. The epic UI only renders children under `type === "epic"`, so without this the API would happily create children that nothing displays.
- `useGetTasks` gives a type-filtered query its own cache key (`["tasks", projectId, "epic"]`). Existing mutations invalidate `["tasks", projectId]`, which still matches it as a key prefix, so no mutation needed updating.
- `TaskEpicChildren` intentionally does *not* replicate `TaskSubtasks`' keyboard navigation and multi-select. Worth adding if epic child lists grow large, but it kept this component small.
- Epics and subtasks are excluded from the generic relations list, since each has its own dedicated section — otherwise the same link renders twice under two different UIs.
- The 17 non-English locales are seeded with the en-US strings, matching how previous feature PRs here have handled new keys (e.g. `0f556f3a`). `pnpm i18n:check` is green.

## Related Issue(s)

No linked issue.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Test addition or update

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

Full sweep on this branch: `pnpm typecheck`, `pnpm build`, and `pnpm test` all pass (388 API + 154 web + 103 package unit tests), plus **230 API integration tests against real PostgreSQL** — which also exercises the new migration applying to a fresh database. `pnpm i18n:check` reports all locales in sync.

New coverage added here: five `TaskEpicChildren` component tests (relation wiring, planned-parent behaviour, progress counting, relation filtering, permission gating) and six integration tests (type defaulting, epic creation, invalid-type rejection, epic relation creation, the type filter, and the new non-epic-source rejection).

**Not tested manually in a browser.** The Epics route itself has typecheck-and-build proof plus component coverage of its child-list path, but no one has clicked through it. Worth a manual pass before merge.

## Screenshots (if applicable)

None — no browser pass was done, see above.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I understand and take responsibility for every change, and I wrote this pull request description in my own words
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The "in my own words" box above is left unchecked deliberately: this description was drafted by Claude Code, so that attestation is the human author's to make.

One commit was made with `--no-verify`. The pre-commit hook runs `biome ci .`, and `biome.json` excludes `**/.claude`; this work happened in a git worktree under `.claude/worktrees/`, so the hook resolved to an ignored path, processed zero files, and exited non-zero. It fails identically on a clean tree, so it wasn't reacting to these changes. `biome check` was run explicitly against all 30 changed files instead and is clean. No change was made to `biome.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Epics as a project view, including creation, navigation, filtering, and keyboard shortcut support.
  * Tasks can now be classified as tasks or epics.
  * Epics can group child tasks, display completion progress, and link from task details.
  * Added support for epic relations through task APIs and integrations.

* **Documentation**
  * Added an Epics workflow guide and updated backlog planning documentation.

* **Tests**
  * Added coverage for epic creation, validation, filtering, relations, and child-task management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->