### PR TITLE
ci(docker): build GHCR images from suffixed version tags

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -61,7 +61,10 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PACKAGE_TOKEN }}
+          # GITHUB_TOKEN (with the packages:write granted above) is enough to
+          # push to this repository's own packages; GH_PACKAGE_TOKEN exists for
+          # pushing elsewhere and is not set up on forks.
+          password: ${{ secrets.GH_PACKAGE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,21 @@
 name: Build & publish images to GHCR
 
+# Two ways in:
+#   * push a suffixed tag (v2.23.2-patched) -- for builds that are not cut by
+#     the release workflow, e.g. a fork carrying local patches;
+#   * run it by hand with any version.
+#
+# Plain vX.Y.Z tags are deliberately NOT a trigger: those are created by
+# semantic-release in release.yml, which has already built and pushed the
+# images for that version by the time the tag exists.
 on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to tag the images (e.g., 1.0.0)"
+        description: "Version to tag the images (e.g. 2.23.2, v2.23.2-patched)"
         required: true
         type: string
       latest:
@@ -13,15 +24,80 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: docker-${{ inputs.version || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
+  resolve:
+    name: Resolve version
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      tags: ${{ steps.resolve.outputs.tags }}
+    steps:
+      - name: Resolve version and image tags
+        id: resolve
+        env:
+          # On a tag push this is the tag name; on a dispatch it is whatever
+          # was typed in. Read through the environment so neither can be
+          # interpolated into the script itself.
+          RAW_VERSION: ${{ inputs.version || github.ref_name }}
+          TAG_LATEST: ${{ inputs.latest || false }}
+        run: |
+          set -euo pipefail
+
+          raw="${RAW_VERSION#refs/tags/}"
+          # Git tags are conventionally v-prefixed; the version stamped into
+          # package.json and Chart.yaml must be bare semver.
+          version="${raw#v}"
+
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::'$raw' is not a version this workflow can build. Expected semver, optionally v-prefixed and with a suffix: 2.23.2, v2.23.2, v2.23.2-patched."
+            exit 1
+          fi
+
+          # Only `latest` is a choice; the rest follow from the version.
+          # release.yml owns `latest` for real releases, so a patched build
+          # never quietly takes it over.
+          tags=("$version")
+          # Also publish under the tag as written, so `v2.23.2-patched` in git
+          # and in a compose file are the same string.
+          if [ "$raw" != "$version" ]; then
+            tags+=("$raw")
+          fi
+          if [ "$TAG_LATEST" = "true" ]; then
+            tags+=("latest")
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "tags<<TAGS_EOF"
+            for tag in "${tags[@]}"; do
+              echo "type=raw,value=$tag"
+            done
+            echo "TAGS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Building \`$version\`"
+            echo
+            echo "Image tags:"
+            for tag in "${tags[@]}"; do
+              echo "- \`$tag\`"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
   build:
+    needs: resolve
     permissions:
       contents: read
       packages: write
     uses: ./.github/workflows/build-images.yml
     secrets: inherit
     with:
-      version: ${{ inputs.version }}
-      tags: |
-        type=raw,value=${{ inputs.version }}
-        type=raw,value=latest,enable=${{ inputs.latest }}
+      version: ${{ needs.resolve.outputs.version }}
+      tags: ${{ needs.resolve.outputs.tags }}


### PR DESCRIPTION
The image workflow could only be started by hand, with a version typed in as bare semver ("1.0.0"). Anything carrying the usual git tag shape (v2.23.2-patched) was rejected further down by apply-version.mjs, after the run had already started.

Accept both forms and normalise: strip the leading v for the version stamped into package.json and Chart.yaml, and publish the image under both "2.23.2-patched" and the tag as written, so the string in git and the string in a compose file can be the same.

Also trigger on pushing a suffixed tag, so a fork carrying local patches can cut an image without opening the Actions tab. Plain vX.Y.Z tags stay out of the trigger on purpose: semantic-release creates those in release.yml, which has already built and pushed the images for that version by the time the tag exists.

"latest" remains an explicit choice on manual runs only -- release.yml owns it for real releases and a patched build must not quietly take it over.

Bad input now fails in the first job with a message naming the accepted forms, instead of failing inside the build matrix.

Fall back to GITHUB_TOKEN for the GHCR login: pushing to the repository's own packages needs nothing more (packages:write is already granted), and GH_PACKAGE_TOKEN is not set up on forks.

## Description
<!-- Provide a brief summary of the changes in this PR -->

## Related Issue(s)
<!-- Link to the related issue(s) this PR addresses -->
Fixes #

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist
<!-- Mark the appropriate options with an "x" -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I understand and take responsibility for every change, and I wrote this pull request description in my own words
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Automation**
  - Container images can now be built and published automatically when versioned tags are pushed.
  - Version tags are validated and normalized before image builds, with consistent image tags generated automatically.
  - Release builds can optionally publish a `latest` image tag.

- **Reliability**
  - Concurrent image builds are coordinated to prevent conflicting runs.
  - Image publishing remains functional when the preferred package publishing credential is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->